### PR TITLE
bridge: authenticate the HTTP ingress and /register with a shared token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,21 @@ For HTTPS, generate a self-signed cert first:
 openssl req -x509 -newkey rsa:4096 -nodes -keyout key.pem -out cert.pem -days 365 -subj "/CN=localhost"
 ```
 
+### Ingress auth token
+
+The bridge gates its HTTP ingress and the endpoint `/register` handshake with a
+**shared bearer token**. On first start it generates one and writes it to
+`~/.radical/orbit/bridge.token` (0600), printing it on stdout. Resolution
+(client/endpoint side): `--token` > `$RADICAL_ORBIT_BRIDGE_TOKEN` >
+`~/.radical/orbit/bridge.token` — so same-host clients/endpoints pick it up with
+no config; for a remote bridge, copy the token or set the env var. The Explorer
+prompts for it and then rides an HttpOnly cookie minted by `POST /auth`. Disable
+the gate for local dev with `--no-auth` (or `RADICAL_ORBIT_BRIDGE_NO_AUTH=1`).
+Helpers live in `utils.py` (`resolve_bridge_token`, `ensure_bridge_token`,
+`auth_disabled`, `tokens_match`); the gate is the `Bridge._auth_dispatch`
+middleware. This is the interim credential that the planned broker rework
+generalizes into a per-participant identity (mTLS).
+
 ## Testing
 
 ```sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,9 @@ openssl req -x509 -newkey rsa:4096 -nodes -keyout key.pem -out cert.pem -days 36
 
 The bridge gates its HTTP ingress and the endpoint `/register` handshake with a
 **shared bearer token**. On first start it generates one and writes it to
-`~/.radical/orbit/bridge.token` (0600), printing it on stdout. Resolution
+`~/.radical/orbit/bridge.token` (0600); the token value is **never** printed to
+stdout (only its source/path), so it can't leak into captured logs (CWE-532) —
+read it from the file. Resolution
 (client/endpoint side): `--token` > `$RADICAL_ORBIT_BRIDGE_TOKEN` >
 `~/.radical/orbit/bridge.token` — so same-host clients/endpoints pick it up with
 no config; for a remote bridge, copy the token or set the env var. The Explorer

--- a/README.md
+++ b/README.md
@@ -54,16 +54,41 @@ set any of:
 ```sh
 export RADICAL_ORBIT_BRIDGE_URL='https://my-bridge:8000/'
 export RADICAL_ORBIT_BRIDGE_CERT="/path/to/bridge_cert.pem"
-export RADICAL_ORBIT_BRIDGE_KEY="/path/to/bridge_key.pem"  # only needed for the bridge
+export RADICAL_ORBIT_BRIDGE_KEY="/path/to/bridge_key.pem"    # only needed for the bridge
+export RADICAL_ORBIT_BRIDGE_TOKEN="<shared ingress token>"  # see "Ingress authentication" below
 ```
 
 See the **Bridge configuration** section below for the full
 precedence rules (CLI > env > file).
 
+### 1b. Ingress authentication (token)
+
+The bridge requires a **shared bearer token** on its HTTP ingress and on the
+endpoint `/register` handshake — without it, anyone who can reach the bridge
+could drive plugins (submit jobs, stage files). On first start the bridge
+**generates a token** and writes it to `~/.radical/orbit/bridge.token` (mode
+`0600`), printing it on stdout. Same-host endpoints and clients pick that file
+up automatically; for a remote bridge, copy the token (like the cert) and set:
+
+```sh
+export RADICAL_ORBIT_BRIDGE_TOKEN='<the token>'
+```
+
+Precedence is CLI (`--token`) > `$RADICAL_ORBIT_BRIDGE_TOKEN` >
+`~/.radical/orbit/bridge.token`. The Python client/SDK and the endpoint resolve
+it automatically; the **Explorer** prompts for it once and rides an HttpOnly
+cookie thereafter.
+
+For pure local development you can disable the gate (loud warning):
+
+```sh
+./bin/radical-orbit-bridge.py --no-auth   # or RADICAL_ORBIT_BRIDGE_NO_AUTH=1
+```
+
 ### 2. Starting the Bridge
 The Bridge server exposes a REST API and a WebSocket endpoint (`/register`):
 ```sh
-./bin/radical-orbit-bridge.py
+./bin/radical-orbit-bridge.py        # prints the auth token + URL on startup
 ```
 
 ### 3. Starting the Endpoint Service
@@ -89,8 +114,13 @@ The wrapper script automatically detects and exports the correct `PYTHONPATH` fo
 
 The Bridge serves as an HTTP proxy with the following management endpoints:
 
+All routes except the UI shell (`GET /`) and the static plugin assets
+(`/plugins/*`) require the bridge token — sent as `Authorization: Bearer <token>`
+or, for the browser, the cookie minted by `POST /auth`.
+
 ### Management Endpoints
-- `GET /` - Fetches the interactive ORBIT Explorer UI.
+- `GET /` - Fetches the interactive ORBIT Explorer UI. (ungated)
+- `POST /auth` - Validates the bearer token and sets the HttpOnly auth cookie (used by the Explorer / SSE).
 - `POST /endpoint/list` - Returns a JSON structure describing all currently connected Endpoints and their loaded Plugins namespaces.
 - `POST /endpoint/disconnect/{endpoint_name}` - Disconnect a specific endpoint service from the bridge.
 - `POST /bridge/terminate` - Terminate the bridge process (endpoints remain running).

--- a/bin/radical-orbit-bridge.py
+++ b/bin/radical-orbit-bridge.py
@@ -60,7 +60,9 @@ def main():
            key=args.key,
            host=args.host,
            port=args.port,
-           plugins=args.plugins).run()
+           plugins=args.plugins,
+           token=args.token,
+           no_auth=args.no_auth).run()
 
 
 if __name__ == "__main__":

--- a/bin/radical-orbit-bridge.py
+++ b/bin/radical-orbit-bridge.py
@@ -36,6 +36,15 @@ def main():
                              'registered plugin), "" (none).  Wildcards '
                              'allowed: "iri*". Prefix matching '
                              'supported. Combine, e.g.: "-p default,rose".')
+    parser.add_argument('--token', default=None,
+                        help='Shared ingress auth token.  CLI > '
+                             '$RADICAL_ORBIT_BRIDGE_TOKEN > '
+                             '~/.radical/orbit/bridge.token.  If none is set, '
+                             'one is generated and written to that file '
+                             '(mode 0600) at startup.')
+    parser.add_argument('--no-auth', action='store_true',
+                        help='Disable ingress authentication (local dev only). '
+                             'Also via $RADICAL_ORBIT_BRIDGE_NO_AUTH=1.')
     args = parser.parse_args()
 
     log_level_name = (os.environ.get('RADICAL_ORBIT_LOG_LVL')

--- a/bin/radical-orbit-endpoint.py
+++ b/bin/radical-orbit-endpoint.py
@@ -30,6 +30,10 @@ async def main():
                         help="Bridge TLS cert path.  CLI > "
                              "$RADICAL_ORBIT_BRIDGE_CERT > "
                              "~/.radical/orbit/bridge_cert.pem.")
+    parser.add_argument("--token",     "-t", nargs="?",
+                        help="Shared bridge auth token.  CLI > "
+                             "$RADICAL_ORBIT_BRIDGE_TOKEN > "
+                             "~/.radical/orbit/bridge.token.")
     parser.add_argument("--plugins",   "-p", default="default",
                         help="Comma-separated plugins to load (default: "
                              "the role-specific default set).  Special "
@@ -76,7 +80,8 @@ async def main():
                           name       =args.name,
                           plugins    =plugins,
                           tunnel     =args.tunnel,
-                          tunnel_via =args.tunnel_via)
+                          tunnel_via =args.tunnel_via,
+                          token      =args.token)
 
     loop = asyncio.get_running_loop()
 

--- a/bin/radical-orbit-endpoint.py
+++ b/bin/radical-orbit-endpoint.py
@@ -30,7 +30,7 @@ async def main():
                         help="Bridge TLS cert path.  CLI > "
                              "$RADICAL_ORBIT_BRIDGE_CERT > "
                              "~/.radical/orbit/bridge_cert.pem.")
-    parser.add_argument("--token",     "-t", nargs="?",
+    parser.add_argument("--token",     "-t",
                         help="Shared bridge auth token.  CLI > "
                              "$RADICAL_ORBIT_BRIDGE_TOKEN > "
                              "~/.radical/orbit/bridge.token.")

--- a/plans/security_token_mitigation.md
+++ b/plans/security_token_mitigation.md
@@ -1,0 +1,92 @@
+# ORBIT: bridge ingress token authentication — pre-broker security step
+
+## Context
+
+The bridge HTTP ingress has **no client authentication**: any party that can reach
+the bridge port can drive every plugin. The severe case is `psij.submit_job`, which
+takes an arbitrary `executable` (`plugin_psij.py:161`) → **arbitrary command
+execution** on any connected endpoint; `staging` can create files under `$HOME`/`/tmp`
+(`plugin_staging.py:51-58`, never overwriting, but new files such as a missing
+`~/.ssh/authorized_keys` are reachable). CORS is not authentication, and the TLS cert
+authenticates the *bridge to clients*, not clients to the bridge — `_strip_headers`
+even removes `proxy-authorization` on the way through (`bridge.py:310`).
+
+This is a **minimal interim mitigation on the current architecture, shipped as its own
+PR before the broker rewrite.** It is forward-compatible: the shared token becomes the
+`credential` half of the broker plan's `(name, credential)` identity tuple, and mTLS is
+the later per-participant upgrade. See `broker_architecture_plan.md` /
+`broker_architecture_rationale.md`.
+
+Root cause is one thing — a missing client credential on the ingress — so the fix gates
+the ingress, not individual plugins (disabling `staging` would leave `psij` open).
+
+## Decisions
+
+- A **shared bearer token** gates the whole capability-bearing ingress, **including the
+  endpoint WS `/register`** (which also closes today's endpoint-name-hijack: any
+  cert-trusting process can currently register as any endpoint).
+- The browser / SSE path uses a **post-handshake cookie** (HttpOnly, Secure,
+  SameSite=Strict), not a query-param token (no token in logs).
+- The token is **auto-generated and written 0600** if unset; an explicit **escape
+  hatch** disables auth for pure-local dev. Default is auth-on.
+
+## Scope / changes (current modules — pre-rename, pre-rewrite)
+
+- **`utils.py`** — `resolve_bridge_token` (CLI `--token` > `RADICAL_ORBIT_BRIDGE_TOKEN`
+  > `~/.radical/orbit/bridge.token`), mirroring `resolve_bridge_url`/`_cert`. If absent
+  and auth is enabled, generate, write the 0600 file, and print it at startup (next to
+  the URL).
+- **`bridge.py`**
+  - **Auth dependency** on the capability routes (proxy catch-all, `/endpoint/*`,
+    `/bridge/terminate`, `/events`): accept `Authorization: Bearer <token>` **or** the
+    auth cookie; 401 otherwise; **constant-time compare**. Left **ungated**: `/` (UI
+    shell) and `/plugins/*.js` (static, no capability) so the Explorer can load and
+    prompt.
+  - **`POST /auth`**: validate the bearer header, then `Set-Cookie` (HttpOnly, Secure,
+    SameSite=Strict) carrying the credential; the browser then rides the cookie for both
+    `fetch` and `EventSource`.
+  - **`/register` WS**: validate a `token` field in the register frame; on mismatch send
+    the existing error message + close (reuses the path at `bridge.py:448-451`).
+  - **Escape hatch**: `--no-auth` / `RADICAL_ORBIT_BRIDGE_NO_AUTH=1` disables the gate
+    with a loud startup warning. Default auth-on.
+- **`client.py` `BridgeClient`** — resolve the token; attach `Authorization: Bearer`
+  via the existing httpx request hook on all calls **including the SSE stream** (httpx
+  sets headers on streams, so Python clients use the header path, not the cookie).
+- **`service.py` `EndpointService`** — resolve the token; include it in
+  `RegisterMessage`. It already aborts on an `ErrorMessage` from the bridge, so a
+  bad/missing token surfaces as a clean fatal.
+- **`models.py`** — `RegisterMessage` gains `token: Optional[str]`.
+- **Explorer** (`data/orbit_explorer.html` + `data/plugins/*.js`) — prompt for the
+  token, store in `localStorage` (to re-auth), `POST /auth` to obtain the cookie, then
+  `fetch` + `EventSource` ride the **HttpOnly** cookie (the live in-browser credential
+  is the cookie, not JS-readable).
+- **`bin/` wrapper + examples** — token pass-through (`--token` / env).
+- **Tests + a short security note** in the docs.
+
+## Security properties / non-goals
+
+- A **shared secret** (deployment-scoped, like the cert), not per-user identity — same
+  trust model as "you have the cert/URL".
+- **HttpOnly** keeps the browser credential out of reach of XSS; **Secure** pins it to
+  TLS; **SameSite=Strict** + the existing CORS allowlist mitigate CSRF.
+- No token in query strings or logs (the cookie decision avoids that).
+- **Out of scope** (broker plan): per-participant identity, mTLS, tenant authz.
+
+## Verification
+
+- Unauthenticated HTTP request → 401; with header or cookie → 200.
+- `psij.submit_job` / `staging.put` unreachable without the token.
+- Browser: enter token → `/auth` sets the cookie → Explorer + live SSE work; no token in
+  logs.
+- Endpoint with wrong/missing token → register rejected (fatal at the endpoint).
+- `--no-auth` → gate disabled with a loud warning; same-host dev reads the written token
+  file automatically and works.
+
+## Handoff to the broker plan
+
+The shared token is the **`credential`** in the broker's `(name, credential)` identity
+tuple; the broker generalizes this gate and carries the cookie path into the `gateway`
+plugin; mTLS is the later per-participant upgrade. Because this step already requires a
+credential on the ingress (and on `/register`), the broker plan starts from an
+authenticated bridge — it no longer needs to "remove the unauthenticated
+`POST /bridge/terminate`" (closed here); admin-via-gateway simply inherits the gate.

--- a/src/radical/orbit/bridge.py
+++ b/src/radical/orbit/bridge.py
@@ -17,6 +17,7 @@ import itertools
 import json
 import logging
 import os
+import posixpath
 import re
 import signal
 from contextlib import asynccontextmanager
@@ -353,7 +354,8 @@ class Bridge:
                 # Strip only the bridge auth cookie; preserve any others that
                 # endpoint plugins may rely on.
                 kept = [c.strip() for c in v.split(";")
-                        if not c.strip().startswith(f"{utils.AUTH_COOKIE}=")]
+                        if c.strip()
+                        and not c.strip().startswith(f"{utils.AUTH_COOKIE}=")]
                 if kept:
                     headers[k] = "; ".join(kept)
             else:
@@ -406,7 +408,11 @@ class Bridge:
         is *not* exempt: it is reached only with a valid bearer header and
         then mints the cookie.
         """
-        path = request.url.path
+        # Normalize before matching exemptions so a traversal-style path
+        # (e.g. ``/plugins/../endpoint/list``) can't slip a gated route past
+        # the gate.  Routing still uses the raw scope path, so normalizing here
+        # can only ever *under*-exempt — never expose a gated handler.
+        path = posixpath.normpath(request.url.path)
         if request.method == 'OPTIONS' \
                 or path == '/' \
                 or path.startswith('/plugins/'):

--- a/src/radical/orbit/bridge.py
+++ b/src/radical/orbit/bridge.py
@@ -667,7 +667,8 @@ class Bridge:
             resp = JSONResponse({"ok": True})
             if self_._auth_enabled and self_._token:
                 resp.set_cookie(key=utils.AUTH_COOKIE, value=self_._token,
-                                httponly=True, secure=True,
+                                httponly=True,
+                                secure=request.url.scheme == "https",
                                 samesite="strict", path="/")
             return resp
 

--- a/src/radical/orbit/bridge.py
+++ b/src/radical/orbit/bridge.py
@@ -182,9 +182,14 @@ class Bridge:
         # so same-host clients pick it up automatically; cross-host operators
         # copy it like they copy the cert/URL.
         if self._auth_enabled:
-            print(f'[Bridge] auth token ({self._token_source}): {self._token}',
-                  flush=True)
-            print(f'[Bridge] token file: {utils.TOKEN_FILE}', flush=True)
+            # Never echo the token on every start — stdout lands in bridge.log /
+            # container logs, which are far less protected than the 0600 file
+            # (CWE-532).  Print the secret only when we just generated it (so a
+            # first-run operator can grab it); otherwise point at the file.
+            if self._token_source == 'generated':
+                print(f'[Bridge] generated auth token: {self._token}', flush=True)
+            print(f'[Bridge] auth token source: {self._token_source}; '
+                  f'file: {utils.TOKEN_FILE}', flush=True)
         else:
             log.warning("[Bridge] ingress authentication DISABLED (--no-auth)")
             print('[Bridge] WARNING: ingress authentication DISABLED '
@@ -333,14 +338,27 @@ class Bridge:
 
     @staticmethod
     def _strip_headers(request: Request) -> dict:
-        # Also drop the bridge credential (authorization / cookie) so the
-        # shared token is never forwarded on to endpoint plugins.
+        # Also drop the bridge credential (authorization header) so the shared
+        # token is never forwarded on to endpoint plugins.
         to_strip = {"connection", "keep-alive", "proxy-authenticate",
                     "proxy-authorization", "te", "trailers",
                     "transfer-encoding", "upgrade",
-                    "authorization", "cookie"}
-        return {k: v for k, v in request.headers.items()
-                if k.lower() not in to_strip}
+                    "authorization"}
+        headers = {}
+        for k, v in request.headers.items():
+            k_lower = k.lower()
+            if k_lower in to_strip:
+                continue
+            if k_lower == "cookie":
+                # Strip only the bridge auth cookie; preserve any others that
+                # endpoint plugins may rely on.
+                kept = [c.strip() for c in v.split(";")
+                        if not c.strip().startswith(f"{utils.AUTH_COOKIE}=")]
+                if kept:
+                    headers[k] = "; ".join(kept)
+            else:
+                headers[k] = v
+        return headers
 
     # ── middleware + exception handlers ──────────────────────────────
 

--- a/src/radical/orbit/bridge.py
+++ b/src/radical/orbit/bridge.py
@@ -28,6 +28,7 @@ from fastapi               import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi               import Request, Response, HTTPException
 from fastapi.responses     import JSONResponse, FileResponse
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses   import StreamingResponse
 from starlette.websockets  import WebSocketState
 
@@ -83,12 +84,25 @@ class Bridge:
                  key:     Optional[str]     = None,
                  host:    str = '0.0.0.0',
                  port:    int = 8000,
-                 plugins: str = 'default'):
+                 plugins: str = 'default',
+                 token:   Optional[str]     = None,
+                 no_auth: bool              = False):
         # ── Resolve TLS config (cert/key) ────────────────────────────
         cert_path, _ = utils.resolve_bridge_cert(cli=cert)
         key_path,  _ = utils.resolve_bridge_key (cli=key, cert=cert_path)
         self._cert: str = str(cert_path)
         self._key : str = str(key_path)
+
+        # ── Resolve ingress auth token ───────────────────────────────
+        # A shared bearer token gates the HTTP ingress and the endpoint
+        # /register handshake.  ``--no-auth`` (or $RADICAL_ORBIT_BRIDGE_NO_AUTH)
+        # disables the gate for local dev.  When enabled and no token is
+        # configured, one is generated and written to ~/.radical/orbit/bridge.token.
+        self._auth_enabled: bool          = not utils.auth_disabled(no_auth)
+        self._token:        Optional[str] = None
+        self._token_source: str           = 'disabled'
+        if self._auth_enabled:
+            self._token, self._token_source = utils.ensure_bridge_token(cli=token)
 
         # ── Derive advertised URL from (host, port) ──────────────────
         # The bridge produces its URL — it never reads ``bridge.url``.
@@ -163,6 +177,18 @@ class Bridge:
         # the operator can copy whichever is reachable from clients.
         for form in self._url_forms:
             print(f'[Bridge] URL: {form}', flush=True)
+
+        # Surface the ingress auth state.  The token is also in the 0600 file,
+        # so same-host clients pick it up automatically; cross-host operators
+        # copy it like they copy the cert/URL.
+        if self._auth_enabled:
+            print(f'[Bridge] auth token ({self._token_source}): {self._token}',
+                  flush=True)
+            print(f'[Bridge] token file: {utils.TOKEN_FILE}', flush=True)
+        else:
+            log.warning("[Bridge] ingress authentication DISABLED (--no-auth)")
+            print('[Bridge] WARNING: ingress authentication DISABLED '
+                  '(--no-auth)', flush=True)
 
         # Write the URL file only when it does not already exist —
         # never clobber a file the operator may have placed there
@@ -307,15 +333,25 @@ class Bridge:
 
     @staticmethod
     def _strip_headers(request: Request) -> dict:
+        # Also drop the bridge credential (authorization / cookie) so the
+        # shared token is never forwarded on to endpoint plugins.
         to_strip = {"connection", "keep-alive", "proxy-authenticate",
                     "proxy-authorization", "te", "trailers",
-                    "transfer-encoding", "upgrade"}
+                    "transfer-encoding", "upgrade",
+                    "authorization", "cookie"}
         return {k: v for k, v in request.headers.items()
                 if k.lower() not in to_strip}
 
     # ── middleware + exception handlers ──────────────────────────────
 
     def _setup_middleware(self):
+        # Ingress auth gate.  Added BEFORE CORS so CORS ends up outermost
+        # (Starlette applies the most-recently-added middleware first), which
+        # means a 401 still carries CORS headers and the browser can read it.
+        if self._auth_enabled:
+            self._app.add_middleware(BaseHTTPMiddleware,
+                                     dispatch=self._auth_dispatch)
+
         # LUCID needs credentials; browsers reject credentials + wildcard
         # origin, so we list allowed origins explicitly.
         origins = [
@@ -332,6 +368,37 @@ class Bridge:
             allow_methods=["*"],
             allow_headers=["*"],
         )
+
+    @staticmethod
+    def _request_token(request: Request) -> Optional[str]:
+        """Extract the bearer token from a request: ``Authorization: Bearer``
+        header first, else the ``orbit_bridge_token`` cookie (the browser/SSE
+        path set by ``POST /auth``)."""
+        auth = request.headers.get('authorization', '')
+        if auth.lower().startswith('bearer '):
+            return auth[7:].strip()
+        return request.cookies.get(utils.AUTH_COOKIE)
+
+    async def _auth_dispatch(self, request: Request, call_next):
+        """Require the shared token on every capability-bearing route.
+
+        Exempt: CORS preflight (``OPTIONS``), the UI shell (``/``), and the
+        static plugin JS (``/plugins/...``) — these carry no capability and
+        must load so the Explorer can prompt for the token.  ``POST /auth``
+        is *not* exempt: it is reached only with a valid bearer header and
+        then mints the cookie.
+        """
+        path = request.url.path
+        if request.method == 'OPTIONS' \
+                or path == '/' \
+                or path.startswith('/plugins/'):
+            return await call_next(request)
+        if not utils.tokens_match(self._request_token(request), self._token):
+            return JSONResponse(
+                status_code=401,
+                content={"error": True, "status_code": 401,
+                         "detail": "missing or invalid bridge token"})
+        return await call_next(request)
 
     def _setup_exception_handlers(self):
         app = self._app
@@ -442,6 +509,15 @@ class Bridge:
                         if not frame_endpoint_name:
                             log.warning("[Bridge] Registration missing endpoint_name")
                             continue
+                        if self_._auth_enabled and not utils.tokens_match(
+                                data.get("token"), self_._token):
+                            log.warning("[Bridge] Registration with missing/"
+                                        "invalid token from '%s'",
+                                        frame_endpoint_name)
+                            await ws.send_text(json.dumps({
+                                "type": "error",
+                                "message": "missing or invalid bridge token"}))
+                            return
                         if frame_endpoint_name == BRIDGE_ENDPOINT_NAME:
                             log.warning("[Bridge] Endpoint name '%s' is reserved",
                                         frame_endpoint_name)
@@ -579,6 +655,21 @@ class Bridge:
 
             return StreamingResponse(event_generator(),
                                      media_type="text/event-stream")
+
+        # ── /auth (mint the browser/SSE cookie) ──────────────────────
+        # Reaching this handler means the auth middleware already validated a
+        # bearer header (or an existing cookie).  We then set an HttpOnly,
+        # Secure, SameSite=Strict cookie so the browser's EventSource — which
+        # cannot send headers — authenticates on the same connection.  This
+        # route is a no-op (still 200) when auth is disabled.
+        @app.post("/auth", tags=["Auth"])
+        async def auth(request: Request):
+            resp = JSONResponse({"ok": True})
+            if self_._auth_enabled and self_._token:
+                resp.set_cookie(key=utils.AUTH_COOKIE, value=self_._token,
+                                httponly=True, secure=True,
+                                samesite="strict", path="/")
+            return resp
 
         # ── topology / endpoint management ───────────────────────────────
 

--- a/src/radical/orbit/bridge.py
+++ b/src/radical/orbit/bridge.py
@@ -183,14 +183,18 @@ class Bridge:
         # so same-host clients pick it up automatically; cross-host operators
         # copy it like they copy the cert/URL.
         if self._auth_enabled:
-            # Never echo the token on every start — stdout lands in bridge.log /
-            # container logs, which are far less protected than the 0600 file
-            # (CWE-532).  Print the secret only when we just generated it (so a
-            # first-run operator can grab it); otherwise point at the file.
-            if self._token_source == 'generated':
-                print(f'[Bridge] generated auth token: {self._token}', flush=True)
-            print(f'[Bridge] auth token source: {self._token_source}; '
-                  f'file: {utils.TOKEN_FILE}', flush=True)
+            # Never echo the token to stdout — it is captured by container logs,
+            # the systemd journal, or a redirected bridge.log, all far less
+            # protected than the 0600 token file (CWE-532).  Report only where
+            # it came from; the operator reads the secret from the file itself.
+            if self._token_source in ('generated', 'file'):
+                verb = ('generated and written to' if self._token_source
+                        == 'generated' else 'loaded from')
+                print(f'[Bridge] auth token {verb}: {utils.TOKEN_FILE}',
+                      flush=True)
+            else:
+                print(f'[Bridge] auth token source: {self._token_source}',
+                      flush=True)
         else:
             log.warning("[Bridge] ingress authentication DISABLED (--no-auth)")
             print('[Bridge] WARNING: ingress authentication DISABLED '

--- a/src/radical/orbit/client.py
+++ b/src/radical/orbit/client.py
@@ -337,10 +337,11 @@ class BridgeClient:
 
     def _listen_sse(self) -> None:
         log.debug("[client] SSE listener starting: url=%s/events", self._url)
-        sse_headers = {'Authorization': f'Bearer {self._token}'} \
-                          if self._token else {}
+        # Reuse the pooled client: it carries base_url, TLS verification, and
+        # the _inject_req_id request hook (Authorization + X-Request-ID), so we
+        # don't duplicate connection/auth setup here.
         try:
-            with httpx.stream("GET", f"{self._url}/events", headers=sse_headers, verify=self._cert if self._cert else False, timeout=None) as response:
+            with self._http.stream("GET", "/events", timeout=None) as response:
                 log.debug("[client] SSE stream connected: status=%s", response.status_code)
                 self._listener_connected.set()
                 for line in response.iter_lines():

--- a/src/radical/orbit/client.py
+++ b/src/radical/orbit/client.py
@@ -167,7 +167,8 @@ class BridgeClient:
         client.register_topology_callback(on_topology)
     """
 
-    def __init__(self, url: Optional[str] = None, cert: Optional[str] = None):
+    def __init__(self, url: Optional[str] = None, cert: Optional[str] = None,
+                 token: Optional[str] = None):
         """
         Initialize the Bridge Client.
 
@@ -178,6 +179,11 @@ class BridgeClient:
                   ``RADICAL_ORBIT_BRIDGE_CERT`` and
                   ``~/.radical/orbit/bridge_cert.pem``.  Required when
                   the URL scheme is ``https``; ignored for ``http``.
+            token: Shared bridge auth token.  CLI > env
+                  (``RADICAL_ORBIT_BRIDGE_TOKEN``) > file
+                  (``~/.radical/orbit/bridge.token``).  Sent as
+                  ``Authorization: Bearer``.  ``None`` is fine when the
+                  bridge runs with auth disabled.
         """
         from urllib.parse import urlparse
         from . import utils
@@ -192,12 +198,17 @@ class BridgeClient:
         else:
             self._cert = None
 
+        # Ingress auth token (header on every request, incl. the SSE stream).
+        self._token: Optional[str] = utils.resolve_bridge_token(cli=token)[0]
+
         self._prof = rprof.Profiler('client', ns='radical.orbit')
         self._req_counter = itertools.count()
 
         def _inject_req_id(request):
             req_id = 'req.%06d' % next(self._req_counter)
             request.headers['X-Request-ID'] = req_id
+            if self._token:
+                request.headers['Authorization'] = f'Bearer {self._token}'
             # stash for the response hook
             request.extensions['req_id'] = req_id
             self._prof.prof('client_send', uid=req_id, msg=str(request.url))
@@ -326,8 +337,10 @@ class BridgeClient:
 
     def _listen_sse(self) -> None:
         log.debug("[client] SSE listener starting: url=%s/events", self._url)
+        sse_headers = {'Authorization': f'Bearer {self._token}'} \
+                          if self._token else {}
         try:
-            with httpx.stream("GET", f"{self._url}/events", verify=self._cert if self._cert else False, timeout=None) as response:
+            with httpx.stream("GET", f"{self._url}/events", headers=sse_headers, verify=self._cert if self._cert else False, timeout=None) as response:
                 log.debug("[client] SSE stream connected: status=%s", response.status_code)
                 self._listener_connected.set()
                 for line in response.iter_lines():

--- a/src/radical/orbit/client.py
+++ b/src/radical/orbit/client.py
@@ -343,6 +343,9 @@ class BridgeClient:
         try:
             with self._http.stream("GET", "/events", timeout=None) as response:
                 log.debug("[client] SSE stream connected: status=%s", response.status_code)
+                # Don't signal "connected" on an error status (e.g. 401/500) —
+                # raise so the listener exits instead of falsely reporting success.
+                response.raise_for_status()
                 self._listener_connected.set()
                 for line in response.iter_lines():
                     if self._listener_stop.is_set():

--- a/src/radical/orbit/data/orbit_explorer.html
+++ b/src/radical/orbit/data/orbit_explorer.html
@@ -1823,10 +1823,12 @@
         clearTimeout(timeoutId);
 
         if (!res.ok) {
-          // Auth lapsed/missing: re-prompt for the token, refresh the cookie,
-          // and retry once.
+          // Auth lapsed/missing: try a *silent* re-auth first (the cookie may
+          // have expired while the stored token is still valid).  ensureAuth
+          // only prompts if that POST /auth itself 401s, so we don't bother the
+          // user when the token in localStorage still works.
           if (res.status === 401 && !opts._retried) {
-            const ok = await ensureAuth(true);
+            const ok = await ensureAuth(false);
             if (ok) return await apiFetch(path, { ...opts, _retried: true });
           }
           const t = await res.text();

--- a/src/radical/orbit/data/orbit_explorer.html
+++ b/src/radical/orbit/data/orbit_explorer.html
@@ -1760,7 +1760,11 @@
     // Shared bridge auth token.  Kept in localStorage only to (re)authenticate;
     // the live credential the browser sends is the HttpOnly cookie minted by
     // POST /auth, which JS cannot read.
-    let BRIDGE_TOKEN = localStorage.getItem('orbit_bridge_token') || '';
+    let BRIDGE_TOKEN = localStorage.getItem('orbit_bridge_token');
+    // Distinguish "never set" (null) from "set to empty" (e.g. --no-auth) so we
+    // don't re-prompt on every connect once the user has chosen a blank token.
+    let hasTokenSet = BRIDGE_TOKEN !== null;
+    if (BRIDGE_TOKEN === null) BRIDGE_TOKEN = '';
 
     async function ensureAuth(forcePrompt = false) {
       // Obtain/refresh the HttpOnly auth cookie via POST /auth using the shared
@@ -1768,13 +1772,14 @@
       // sets no cookie, so a blank token works.  Returns false only if the user
       // cancels the prompt.
       for (let attempt = 0; attempt < 3; attempt++) {
-        if (forcePrompt || !BRIDGE_TOKEN) {
+        if (forcePrompt || !hasTokenSet) {
           const t = window.prompt(
             'Bridge auth token (leave blank if the bridge runs with --no-auth):',
             BRIDGE_TOKEN || '');
           if (t === null) return false;             // user cancelled
           BRIDGE_TOKEN = t.trim();
           localStorage.setItem('orbit_bridge_token', BRIDGE_TOKEN);
+          hasTokenSet = true;
         }
         const headers = {};
         if (BRIDGE_TOKEN) headers['Authorization'] = 'Bearer ' + BRIDGE_TOKEN;

--- a/src/radical/orbit/data/orbit_explorer.html
+++ b/src/radical/orbit/data/orbit_explorer.html
@@ -1766,7 +1766,18 @@
     let hasTokenSet = BRIDGE_TOKEN !== null;
     if (BRIDGE_TOKEN === null) BRIDGE_TOKEN = '';
 
-    async function ensureAuth(forcePrompt = false) {
+    // Single-flight guard: concurrent 401s would otherwise each open their own
+    // window.prompt.  Coalesce overlapping calls onto one in-flight auth attempt.
+    let activeAuthPromise = null;
+
+    function ensureAuth(forcePrompt = false) {
+      if (activeAuthPromise) return activeAuthPromise;
+      activeAuthPromise = _ensureAuth(forcePrompt)
+                            .finally(() => { activeAuthPromise = null; });
+      return activeAuthPromise;
+    }
+
+    async function _ensureAuth(forcePrompt = false) {
       // Obtain/refresh the HttpOnly auth cookie via POST /auth using the shared
       // bearer token.  If the bridge runs with --no-auth, /auth returns 200 and
       // sets no cookie, so a blank token works.  Returns false only if the user

--- a/src/radical/orbit/data/orbit_explorer.html
+++ b/src/radical/orbit/data/orbit_explorer.html
@@ -1757,6 +1757,41 @@
 
     const API_TIMEOUT_MS = 30000; // 30 second request timeout
 
+    // Shared bridge auth token.  Kept in localStorage only to (re)authenticate;
+    // the live credential the browser sends is the HttpOnly cookie minted by
+    // POST /auth, which JS cannot read.
+    let BRIDGE_TOKEN = localStorage.getItem('orbit_bridge_token') || '';
+
+    async function ensureAuth(forcePrompt = false) {
+      // Obtain/refresh the HttpOnly auth cookie via POST /auth using the shared
+      // bearer token.  If the bridge runs with --no-auth, /auth returns 200 and
+      // sets no cookie, so a blank token works.  Returns false only if the user
+      // cancels the prompt.
+      for (let attempt = 0; attempt < 3; attempt++) {
+        if (forcePrompt || !BRIDGE_TOKEN) {
+          const t = window.prompt(
+            'Bridge auth token (leave blank if the bridge runs with --no-auth):',
+            BRIDGE_TOKEN || '');
+          if (t === null) return false;             // user cancelled
+          BRIDGE_TOKEN = t.trim();
+          localStorage.setItem('orbit_bridge_token', BRIDGE_TOKEN);
+        }
+        const headers = {};
+        if (BRIDGE_TOKEN) headers['Authorization'] = 'Bearer ' + BRIDGE_TOKEN;
+        let res;
+        try {
+          res = await fetch(BRIDGE.replace(/\/$/, '') + '/auth',
+                            { method: 'POST', credentials: 'include', headers });
+        } catch (e) {
+          return true;   // network error — let the connect flow surface it
+        }
+        if (res.ok) return true;
+        if (res.status === 401) { forcePrompt = true; continue; }
+        return true;     // other status — don't block; caller handles
+      }
+      return false;
+    }
+
     async function apiFetch(path, opts = {}) {
       const url = BRIDGE.replace(/\/$/, '') + path;
       const controller = new AbortController();
@@ -1765,12 +1800,19 @@
       try {
         const res = await fetch(url, {
           ...opts,
+          credentials: 'include',
           signal: controller.signal,
           headers: { 'Content-Type': 'application/json', ...(opts.headers || {}) }
         });
         clearTimeout(timeoutId);
 
         if (!res.ok) {
+          // Auth lapsed/missing: re-prompt for the token, refresh the cookie,
+          // and retry once.
+          if (res.status === 401 && !opts._retried) {
+            const ok = await ensureAuth(true);
+            if (ok) return await apiFetch(path, { ...opts, _retried: true });
+          }
           const t = await res.text();
           const errMsg = `HTTP ${res.status}: ${t}`;
 
@@ -1875,6 +1917,10 @@
       } catch (e) {
         // assume relative or invalid, continue fetching
       }
+
+      // Authenticate (mint the HttpOnly cookie) before any capability call.
+      const authed = await ensureAuth();
+      if (!authed) { flash('Authentication cancelled', false); return; }
 
       document.getElementById('connectBtn').disabled = true;
       setConnectionStatus('reconnecting', 'Connecting...');
@@ -1998,7 +2044,9 @@
     function setupEventSource() {
       if (eventSource) eventSource.close();
 
-      eventSource = new EventSource(BRIDGE + '/events');
+      // withCredentials so the HttpOnly auth cookie rides the SSE connection
+      // (EventSource cannot set headers).
+      eventSource = new EventSource(BRIDGE + '/events', { withCredentials: true });
 
       eventSource.onopen = function() {
         setConnectionStatus('connected');

--- a/src/radical/orbit/models.py
+++ b/src/radical/orbit/models.py
@@ -19,6 +19,7 @@ class RegisterMessage(BaseModel):
     endpoint_name: str = Field(..., description="Name of the endpoint service")
     endpoint: Dict[str, Any] = Field(default_factory=dict, description="Endpoint metadata")
     plugins: Dict[str, Dict[str, Any]] = Field(default_factory=dict, description="Plugin metadata keyed by plugin name")
+    token: Optional[str] = Field(None, description="Shared bridge auth token")
 
 
 class ResponseMessage(BaseModel):

--- a/src/radical/orbit/service.py
+++ b/src/radical/orbit/service.py
@@ -101,6 +101,7 @@ class EndpointService(PluginHostBase):
                  plugins:    Optional[list]     = None,
                  tunnel:     str                = 'none',
                  tunnel_via: Optional[str]      = None,
+                 token:      Optional[str]      = None,
                  app:        Optional[FastAPI]  = None):
         """
         Initialize the Endpoint Service.
@@ -157,6 +158,10 @@ class EndpointService(PluginHostBase):
             self._cert: Optional[str] = str(resolved_cert)
         else:
             self._cert = None
+
+        # Shared ingress auth token, sent in the register frame.  None is fine
+        # when the bridge runs with auth disabled.
+        self._token: Optional[str] = utils.resolve_bridge_token(cli=token)[0]
 
         self._app: FastAPI = app if app is not None \
                                  else FastAPI(title="Embedded Endpoint Service")
@@ -546,6 +551,7 @@ class EndpointService(PluginHostBase):
                             endpoint_name=self._name,
                             endpoint={"type": "radical.orbit"},
                             plugins=plugins_data,
+                            token=self._token,
                         )
                         await ws.send(reg.model_dump_json())
 

--- a/src/radical/orbit/utils.py
+++ b/src/radical/orbit/utils.py
@@ -358,8 +358,12 @@ def ensure_bridge_token(cli: Optional[str] = None) -> Tuple[str, str]:
     return token, 'generated'
 
 
-def tokens_match(provided: Optional[str], expected: Optional[str]) -> bool:
-    """Constant-time token comparison; ``False`` if either side is empty."""
+def tokens_match(provided: Any, expected: Any) -> bool:
+    """Constant-time token comparison; ``False`` if either side is empty or
+    not a string (e.g. a non-string token in a JSON ``/register`` payload,
+    which would otherwise raise ``TypeError`` in ``hmac.compare_digest``)."""
+    if not isinstance(provided, str) or not isinstance(expected, str):
+        return False
     if not provided or not expected:
         return False
     return hmac.compare_digest(provided, expected)

--- a/src/radical/orbit/utils.py
+++ b/src/radical/orbit/utils.py
@@ -279,15 +279,18 @@ def resolve_bridge_key(cli: Optional[str] = None, *,
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _read_token_file(path: Optional[Path] = None) -> Optional[str]:
-    """Read the token file, stripped.  ``None`` if absent/empty."""
+    """Read the token file, stripped.  ``None`` if absent/empty.
+
+    Only ``FileNotFoundError`` is swallowed (consistent with ``_read_url_file``):
+    a present-but-unreadable file (e.g. ``PermissionError``) is a real
+    misconfiguration that should surface loudly rather than be masked as
+    "no token" — which would otherwise trigger a regenerate-then-crash-on-write.
+    """
     if path is None:
         path = TOKEN_FILE
     try:
         text = path.read_text().strip()
-    except OSError:
-        # Absent, or present-but-unreadable (e.g. PermissionError).  A missing
-        # or unreadable token is non-fatal on the consumer side, so treat any
-        # OS-level access failure as "no token".
+    except FileNotFoundError:
         return None
     return text or None
 

--- a/src/radical/orbit/utils.py
+++ b/src/radical/orbit/utils.py
@@ -284,7 +284,10 @@ def _read_token_file(path: Optional[Path] = None) -> Optional[str]:
         path = TOKEN_FILE
     try:
         text = path.read_text().strip()
-    except FileNotFoundError:
+    except OSError:
+        # Absent, or present-but-unreadable (e.g. PermissionError).  A missing
+        # or unreadable token is non-fatal on the consumer side, so treat any
+        # OS-level access failure as "no token".
         return None
     return text or None
 

--- a/src/radical/orbit/utils.py
+++ b/src/radical/orbit/utils.py
@@ -5,7 +5,9 @@ Anything with state, threads, side effects, or non-trivial domain logic
 belongs in its own module.
 """
 
+import hmac
 import os
+import secrets
 import socket
 import ssl
 import stat
@@ -42,10 +44,18 @@ DEFAULT_DIR  = Path.home() / '.radical' / 'orbit'
 URL_FILE     = DEFAULT_DIR / 'bridge.url'
 CERT_FILE    = DEFAULT_DIR / 'bridge_cert.pem'
 KEY_FILE     = DEFAULT_DIR / 'bridge_key.pem'
+TOKEN_FILE   = DEFAULT_DIR / 'bridge.token'
 
 ENV_URL      = 'RADICAL_ORBIT_BRIDGE_URL'
 ENV_CERT     = 'RADICAL_ORBIT_BRIDGE_CERT'
 ENV_KEY      = 'RADICAL_ORBIT_BRIDGE_KEY'
+ENV_TOKEN    = 'RADICAL_ORBIT_BRIDGE_TOKEN'
+ENV_NO_AUTH  = 'RADICAL_ORBIT_BRIDGE_NO_AUTH'
+
+# Cookie the browser/SSE path carries (set by the bridge's POST /auth).  The
+# token never lives in a query string, only this HttpOnly cookie or a
+# request header.
+AUTH_COOKIE  = 'orbit_bridge_token'
 
 
 def _read_url_file(path: Optional[Path] = None) -> Optional[str]:
@@ -249,6 +259,104 @@ def resolve_bridge_key(cli: Optional[str] = None, *,
         ctx.load_cert_chain(str(cert), str(path))
 
     return path, source
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Bridge ingress auth token.
+#
+#  A shared bearer token gates the bridge's HTTP ingress and the endpoint
+#  ``/register`` handshake.  It is the deployment-scoped credential (same trust
+#  model as the cert): clients/endpoints present it, the bridge verifies it.
+#
+#    Env var:  RADICAL_ORBIT_BRIDGE_TOKEN
+#    File:     ~/.radical/orbit/bridge.token   (mode 0600)
+#    Disable:  RADICAL_ORBIT_BRIDGE_NO_AUTH=1  (escape hatch for local dev)
+#
+#  Consumer precedence (endpoint / client): CLI > env > file.  A missing token
+#  is *not* an error on the consumer side — the bridge may run with auth off.
+#  The bridge itself uses ``ensure_bridge_token``, which generates and writes a
+#  token when none is configured.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _read_token_file(path: Optional[Path] = None) -> Optional[str]:
+    """Read the token file, stripped.  ``None`` if absent/empty."""
+    if path is None:
+        path = TOKEN_FILE
+    try:
+        text = path.read_text().strip()
+    except FileNotFoundError:
+        return None
+    return text or None
+
+
+def write_bridge_token_file(token: str, path: Optional[Path] = None) -> None:
+    """Write *token* to *path* atomically, mode 0600 (private — like the key)."""
+    if path is None:
+        path = TOKEN_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix='.bridge.token.', dir=str(path.parent))
+    try:
+        with os.fdopen(fd, 'w') as f:
+            f.write(token.rstrip() + '\n')
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    except Exception:
+        try:    os.unlink(tmp)
+        except FileNotFoundError: pass
+        raise
+
+
+def resolve_bridge_token(cli: Optional[str] = None) -> Tuple[Optional[str], str]:
+    """Resolve the bridge token for a *consumer* (endpoint / client).
+
+    Precedence: CLI arg > ``$RADICAL_ORBIT_BRIDGE_TOKEN`` >
+    ``~/.radical/orbit/bridge.token``.  Returns ``(token, source)`` with source
+    one of ``'cli'`` / ``'env'`` / ``'file'``, or ``(None, '')`` when none is
+    configured (a missing token is not fatal — the bridge may have auth off).
+    """
+    if cli:
+        return cli.strip(), 'cli'
+    env_tok = os.environ.get(ENV_TOKEN, '').strip()
+    if env_tok:
+        return env_tok, 'env'
+    file_tok = _read_token_file()
+    if file_tok:
+        return file_tok, 'file'
+    return None, ''
+
+
+def auth_disabled(cli_no_auth: bool = False) -> bool:
+    """Whether bridge ingress auth is disabled (the ``--no-auth`` escape hatch).
+
+    True when *cli_no_auth* is set or ``$RADICAL_ORBIT_BRIDGE_NO_AUTH`` is a
+    truthy value (``1`` / ``true`` / ``yes``).
+    """
+    if cli_no_auth:
+        return True
+    return os.environ.get(ENV_NO_AUTH, '').strip().lower() in ('1', 'true', 'yes')
+
+
+def ensure_bridge_token(cli: Optional[str] = None) -> Tuple[str, str]:
+    """Resolve the bridge token for the *bridge* itself, generating if absent.
+
+    Precedence: CLI > env > file; if none resolves, generate a fresh
+    URL-safe token, write it to ``~/.radical/orbit/bridge.token`` (mode 0600),
+    and return it.  Returns ``(token, source)`` with source one of
+    ``'cli'`` / ``'env'`` / ``'file'`` / ``'generated'``.
+    """
+    token, source = resolve_bridge_token(cli)
+    if token:
+        return token, source
+    token = secrets.token_urlsafe(32)
+    write_bridge_token_file(token)
+    return token, 'generated'
+
+
+def tokens_match(provided: Optional[str], expected: Optional[str]) -> bool:
+    """Constant-time token comparison; ``False`` if either side is empty."""
+    if not provided or not expected:
+        return False
+    return hmac.compare_digest(provided, expected)
 
 
 def host_role(app: Any) -> Dict[str, Any]:

--- a/tests/unittests/test_bridge.py
+++ b/tests/unittests/test_bridge.py
@@ -265,3 +265,13 @@ def test_strip_headers_drops_cookie_header_when_only_auth():
     out = {k.lower(): v for k, v in Bridge._strip_headers(req).items()}
 
     assert "cookie" not in out
+
+
+def test_strip_headers_handles_trailing_semicolon():
+    """A trailing ``;`` (empty segment) must not yield an empty Cookie header."""
+    from radical.orbit import Bridge, utils
+
+    req = _request_with_headers({"cookie": f"{utils.AUTH_COOKIE}=secret;"})
+    out = {k.lower(): v for k, v in Bridge._strip_headers(req).items()}
+
+    assert "cookie" not in out

--- a/tests/unittests/test_bridge.py
+++ b/tests/unittests/test_bridge.py
@@ -224,3 +224,44 @@ def test_disconnect_removes_endpoint_from_both_maps(make_bridge):
     assert _wait_until(lambda: "thinkie" not in bridge.endpoints["endpoints"])
     assert "thinkie" not in bridge.endpoint_ws
     json.dumps(bridge.endpoints)
+
+
+# ---------------------------------------------------------------------------
+# _strip_headers — bridge credential must not leak to endpoint plugins
+# ---------------------------------------------------------------------------
+
+def _request_with_headers(headers: dict):
+    """Build a minimal Starlette ``Request`` carrying *headers*."""
+    from starlette.requests import Request
+    raw = [(k.lower().encode(), v.encode()) for k, v in headers.items()]
+    return Request({"type": "http", "method": "GET", "path": "/",
+                    "headers": raw})
+
+
+def test_strip_headers_drops_auth_keeps_other_cookies():
+    """The auth header and the bridge auth cookie are stripped; unrelated
+    cookies and other headers are forwarded untouched."""
+    from radical.orbit import Bridge, utils
+
+    req = _request_with_headers({
+        "authorization": "Bearer secret",
+        "cookie": f"{utils.AUTH_COOKIE}=secret; session=abc; theme=dark",
+        "content-type": "application/json",
+    })
+    out = {k.lower(): v for k, v in Bridge._strip_headers(req).items()}
+
+    assert "authorization" not in out
+    assert out["content-type"] == "application/json"
+    assert utils.AUTH_COOKIE not in out["cookie"]
+    assert "session=abc" in out["cookie"]
+    assert "theme=dark"  in out["cookie"]
+
+
+def test_strip_headers_drops_cookie_header_when_only_auth():
+    """When the auth cookie is the sole cookie, the whole Cookie header goes."""
+    from radical.orbit import Bridge, utils
+
+    req = _request_with_headers({"cookie": f"{utils.AUTH_COOKIE}=secret"})
+    out = {k.lower(): v for k, v in Bridge._strip_headers(req).items()}
+
+    assert "cookie" not in out

--- a/tests/unittests/test_bridge.py
+++ b/tests/unittests/test_bridge.py
@@ -56,12 +56,16 @@ def make_bridge(self_signed, tmp_path, monkeypatch):
     """
     from radical.orbit import utils
     monkeypatch.setattr(utils, 'URL_FILE', tmp_path / 'bridge.url')
+    monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'bridge.token')
 
     cert, key = self_signed
 
     def _build(**kwargs):
         from radical.orbit import Bridge
-        defaults = dict(cert=str(cert), key=str(key))
+        # Default these bridge tests to auth-off; dedicated auth coverage
+        # lives in test_bridge_auth.py.  Callers override with
+        # ``no_auth=False`` + ``token=...``.
+        defaults = dict(cert=str(cert), key=str(key), no_auth=True)
         defaults.update(kwargs)
         return Bridge(**defaults)
 

--- a/tests/unittests/test_bridge_auth.py
+++ b/tests/unittests/test_bridge_auth.py
@@ -121,3 +121,34 @@ def test_no_auth_bypass(make_bridge):
                       'endpoint': {}})
         msg = ws.receive_json()
         assert msg['type'] == 'topology'
+
+
+# Exercise the middleware directly: httpx (TestClient) collapses ``..`` in the
+# URL before sending, so a traversal path can only be fed to the gate by hand.
+
+def _scope_request(path):
+    from starlette.requests import Request
+    return Request({'type': 'http', 'method': 'GET', 'path': path,
+                    'headers': []})
+
+
+@pytest.mark.asyncio
+async def test_auth_dispatch_normalizes_traversal(make_bridge):
+    """A traversal path that resolves out of an exempt prefix
+    (``/plugins/../endpoint/list``) must be normalized and gated, not exempted."""
+    from starlette.responses import JSONResponse
+
+    bridge = make_bridge()                  # auth on, token='s3cret', no header
+
+    async def _passed(_req):
+        return JSONResponse({'ok': True})   # stands in for an exempted pass-through
+
+    # Traversal out of /plugins → normalized to /endpoint/list → must be gated.
+    resp = await bridge._auth_dispatch(
+        _scope_request('/plugins/../endpoint/list'), _passed)
+    assert resp.status_code == 401
+
+    # A genuine /plugins/ asset stays exempt (passes through without a token).
+    resp = await bridge._auth_dispatch(
+        _scope_request('/plugins/orbit.js'), _passed)
+    assert resp.status_code == 200

--- a/tests/unittests/test_bridge_auth.py
+++ b/tests/unittests/test_bridge_auth.py
@@ -1,0 +1,123 @@
+"""Tests for the bridge ingress auth gate (shared bearer token).
+
+Covers the HTTP middleware (401 without a token, 200 with the bearer header,
+ungated UI shell), the ``POST /auth`` cookie mint, and the ``/register`` WS
+token check.  ``--no-auth`` bypass is verified too.
+"""
+
+import os
+import subprocess
+
+import pytest
+
+from fastapi.testclient import TestClient
+
+
+def _have_openssl() -> bool:
+    try:
+        subprocess.run(['openssl', 'version'], check=True, capture_output=True)
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+@pytest.fixture
+def make_bridge(tmp_path, monkeypatch):
+    """Factory: build a Bridge with redirected resolver paths.
+
+    Defaults to auth ON with a fixed token; pass ``no_auth=True`` for the
+    bypass case.
+    """
+    if not _have_openssl():
+        pytest.skip("openssl not available")
+
+    from radical.orbit import utils
+    monkeypatch.setattr(utils, 'URL_FILE',   tmp_path / 'bridge.url')
+    monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'bridge.token')
+    monkeypatch.delenv(utils.ENV_TOKEN,   raising=False)
+    monkeypatch.delenv(utils.ENV_NO_AUTH, raising=False)
+
+    cert = tmp_path / 'cert.pem'
+    key  = tmp_path / 'key.pem'
+    subprocess.run(
+        ['openssl', 'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+         '-keyout', str(key), '-out', str(cert),
+         '-days', '1', '-subj', '/CN=localhost'],
+        check=True, capture_output=True)
+    os.chmod(key, 0o600)
+
+    def _build(**kwargs):
+        from radical.orbit import Bridge
+        defaults = dict(cert=str(cert), key=str(key), token='s3cret',
+                        no_auth=False)
+        defaults.update(kwargs)
+        return Bridge(**defaults)
+
+    return _build
+
+
+TOK = {'Authorization': 'Bearer s3cret'}
+
+
+def test_capability_route_requires_token(make_bridge):
+    client = TestClient(make_bridge().app)
+    assert client.post('/endpoint/list').status_code == 401
+    assert client.post('/endpoint/list', headers=TOK).status_code == 200
+
+
+def test_wrong_token_rejected(make_bridge):
+    client = TestClient(make_bridge().app)
+    r = client.post('/endpoint/list', headers={'Authorization': 'Bearer nope'})
+    assert r.status_code == 401
+
+
+def test_ui_shell_and_plugins_are_ungated(make_bridge):
+    client = TestClient(make_bridge().app)
+    # Never 401 — the shell must load so the user can supply the token.
+    assert client.get('/').status_code != 401
+    assert client.get('/plugins/anything.js').status_code != 401
+
+
+def test_auth_route_sets_httponly_cookie(make_bridge):
+    client = TestClient(make_bridge().app)
+    r = client.post('/auth', headers=TOK)
+    assert r.status_code == 200
+    set_cookie = r.headers.get('set-cookie', '')
+    assert 'orbit_bridge_token=' in set_cookie
+    assert 'HttpOnly' in set_cookie
+
+
+def test_register_requires_token(make_bridge):
+    bridge = make_bridge()
+    client = TestClient(bridge.app)
+    with client.websocket_connect('/register') as ws:
+        ws.send_json({'type': 'register', 'endpoint_name': 'e1',
+                      'endpoint': {}})
+        msg = ws.receive_json()
+        assert msg['type'] == 'error'
+        assert 'token' in msg['message'].lower()
+
+
+def test_register_with_token_succeeds(make_bridge):
+    bridge = make_bridge()
+    client = TestClient(bridge.app)
+    with client.websocket_connect('/register') as ws:
+        ws.send_json({'type': 'register', 'endpoint_name': 'e1',
+                      'endpoint': {}, 'token': 's3cret'})
+        # A successful register triggers a topology broadcast back to the
+        # just-registered socket (not an error).
+        msg = ws.receive_json()
+        assert msg['type'] == 'topology'
+        # Registered while the socket is live (cleanup runs on context exit).
+        assert 'e1' in bridge.endpoints['endpoints']
+
+
+def test_no_auth_bypass(make_bridge):
+    client = TestClient(make_bridge(no_auth=True).app)
+    # No token, still reachable.
+    assert client.post('/endpoint/list').status_code == 200
+    with client.websocket_connect('/register') as ws:
+        ws.send_json({'type': 'register', 'endpoint_name': 'e2',
+                      'endpoint': {}})
+        msg = ws.receive_json()
+        assert msg['type'] == 'topology'

--- a/tests/unittests/test_utils_token.py
+++ b/tests/unittests/test_utils_token.py
@@ -63,3 +63,8 @@ def test_tokens_match():
     assert utils.tokens_match(None,  'abc') is False
     assert utils.tokens_match('abc', None)  is False
     assert utils.tokens_match('',    '')    is False
+    # Non-string input (e.g. an int/bool token in a JSON /register payload)
+    # must return False, not raise TypeError in hmac.compare_digest.
+    assert utils.tokens_match(123,   'abc') is False
+    assert utils.tokens_match('abc', 123)   is False
+    assert utils.tokens_match(True,  'abc') is False

--- a/tests/unittests/test_utils_token.py
+++ b/tests/unittests/test_utils_token.py
@@ -1,0 +1,65 @@
+"""Unit tests for the bridge ingress auth-token helpers in radical.orbit.utils."""
+
+import pytest
+
+from radical.orbit import utils
+
+
+@pytest.fixture(autouse=True)
+def _isolate_token(tmp_path, monkeypatch):
+    """Redirect the token file and clear the env so tests are hermetic."""
+    monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'bridge.token')
+    monkeypatch.delenv(utils.ENV_TOKEN,   raising=False)
+    monkeypatch.delenv(utils.ENV_NO_AUTH, raising=False)
+    return tmp_path
+
+
+def test_resolve_precedence(monkeypatch):
+    # nothing configured
+    assert utils.resolve_bridge_token() == (None, '')
+
+    # file
+    utils.write_bridge_token_file('filetok')
+    assert utils.resolve_bridge_token() == ('filetok', 'file')
+
+    # env beats file
+    monkeypatch.setenv(utils.ENV_TOKEN, 'envtok')
+    assert utils.resolve_bridge_token() == ('envtok', 'env')
+
+    # cli beats env
+    assert utils.resolve_bridge_token(cli='clitok') == ('clitok', 'cli')
+
+
+def test_write_token_file_is_0600(_isolate_token):
+    utils.write_bridge_token_file('x')
+    mode = utils.TOKEN_FILE.stat().st_mode & 0o777
+    assert mode == 0o600
+
+
+def test_ensure_generates_then_reads(_isolate_token):
+    tok, src = utils.ensure_bridge_token()
+    assert src == 'generated'
+    assert tok
+    assert utils.TOKEN_FILE.read_text().strip() == tok
+
+    # second call picks the written file up
+    tok2, src2 = utils.ensure_bridge_token()
+    assert tok2 == tok
+    assert src2 == 'file'
+
+
+def test_auth_disabled(monkeypatch):
+    assert utils.auth_disabled() is False
+    assert utils.auth_disabled(cli_no_auth=True) is True
+    monkeypatch.setenv(utils.ENV_NO_AUTH, '1')
+    assert utils.auth_disabled() is True
+    monkeypatch.setenv(utils.ENV_NO_AUTH, 'no')
+    assert utils.auth_disabled() is False
+
+
+def test_tokens_match():
+    assert utils.tokens_match('abc', 'abc') is True
+    assert utils.tokens_match('abc', 'xyz') is False
+    assert utils.tokens_match(None,  'abc') is False
+    assert utils.tokens_match('abc', None)  is False
+    assert utils.tokens_match('',    '')    is False


### PR DESCRIPTION
## Why

The bridge HTTP ingress has **no client authentication**: anyone able to reach the bridge port can drive every plugin. The severe case is `psij.submit_job`, which takes an arbitrary `executable` → **arbitrary command execution** on any connected endpoint; `staging` can create files under `$HOME`/`tmp`. CORS is not auth, and the TLS cert authenticates the *bridge to clients*, not clients to the bridge (`_strip_headers` even drops `proxy-authorization`).

This is a **minimal, interim mitigation** on the current architecture — a shared bearer token gating the ingress — shipped as its own PR ahead of the larger broker rework, which will generalize it into a per-participant identity (mTLS). Spec: `plans/security_token_mitigation.md`.

## What

- **`utils.py`** — `resolve_bridge_token` (CLI > env > file), `ensure_bridge_token` (generate + write `~/.radical/orbit/bridge.token` at `0600` when unset), `auth_disabled` escape hatch, constant-time `tokens_match`.
- **`bridge.py`** — auth middleware (`Authorization: Bearer` **or** the cookie) on all routes **except** the UI shell (`/`) and static `/plugins/*`; `POST /auth` mints an **HttpOnly + Secure + SameSite=Strict** cookie for the browser/SSE path; `/register` validates a `token` field; `--no-auth` / `RADICAL_ORBIT_BRIDGE_NO_AUTH` bypass; startup banner; forwarded headers now strip `authorization`/`cookie`.
- **`client.py` / `service.py`** — resolve and send the token automatically (header on every request incl. the SSE stream; `token` field in the register frame).
- **bin** — `--token` (bridge + endpoint), `--no-auth` (bridge).
- **Explorer** — prompts for the token once, `POST /auth`, then rides the HttpOnly cookie (`fetch` + `EventSource`).
- **Docs** — README "Ingress authentication" section + `CLAUDE.md`.

## Behaviour

Auth is **on by default**. The token auto-generates and the `0600` file is read automatically by same-host clients/endpoints, so **local dev keeps working with no config**. Cross-host, copy the token like the cert (or set `RADICAL_ORBIT_BRIDGE_TOKEN`). `--no-auth` disables the gate (loud warning) for pure-local dev.

## Tests

- `test_utils_token.py` — resolution/precedence, 0600 write, generate-then-read, escape hatch, `tokens_match`.
- `test_bridge_auth.py` — 401 without token, 200 with bearer, ungated shell/plugins, `/auth` sets HttpOnly cookie, `/register` accept/reject, `--no-auth` bypass.

`789 passed, 2 skipped` (skips need optional `radical.pilot`); `flake8` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)