### PR TITLE
M1: session lifetime model (create-or-reconnect, ttl/persistent, reserved default)

### DIFF
--- a/plans/m0_results.md
+++ b/plans/m0_results.md
@@ -1,0 +1,151 @@
+# M0 spike — results
+
+Campaign of `plans/broker_architecture_plan.md` §M0, run 2026-07-02 in a 2-node
+Perlmutter allocation (`nid[001049,001052]`, job 55382432). Spike code (throwaway,
+uncommitted) lives in `~/radical/m0_spike/`; this document records the
+measurements and the design decisions they validate for the M2 freeze.
+
+Environment: python 3.11 (`ve3`), websockets 16.0, msgpack, pydantic 2.13.3,
+rhapsody 0.1.2 + Dragon. Link emulation: userspace TCP delay proxy (50 ms each
+way + 3 MB/s token bucket per direction) — no root on HPC, no `tc netem`.
+
+## Verdicts against the M0 gates
+
+| Gate | Verdict |
+|---|---|
+| Correlation table survives reconnect-mid-flight (no leaks, no double-resolution, resume-key replace/reject) | **PASS** — 10/10 checks, localhost and over the emulated WAN link |
+| Caller handle composes with strict `(owning_sid, pool_name)` ownership across the two-loop boundary | **PASS** — plugin-host thread → `run_coroutine_threadsafe` → routing loop; pool goes `creating→ready` with the probe result |
+| Transport isolation: pings answered through a 60 s work-loop block | **PASS** — endpoint stays `present` the full 60 s; no `suspect` ever broadcast; both localhost and over the link |
+| Dragon off-thread viability + max GIL hold | **PASS** — `rh.Session` constructs off the main thread (29.7 s wall, task runs, clean close); max GIL hold during init only 2.8 ms; see below |
+| Throughput gate (rhapsody-shaped e2e vs current-stack baseline) | **DEFERRED** (user decision; `rhapsody_throughput.py` baseline not locatable). Handoff microbenchmark half was run and passed. |
+
+No kill criteria were hit.
+
+## Measurements
+
+### Cross-thread handoff (transport loop ↔ work loop)
+
+Coalesced-wakeup pattern: bounded deque + at most one outstanding
+`call_soon_threadsafe` per burst, swap-drain under lock.
+
+- Sustained: **~2.2 M msgs/s round-trip (0.46 µs/msg amortized, 2 crossings/msg)**, zero overflow.
+- Idle wakeup (parked loop): **p50 ≈ 75–97 µs, p99 ≈ 105–135 µs**, max ≈ 440 µs — dominated by the epoll wake, not the queue.
+
+Implication: the two-loop split costs nothing at storm rates; don't expect
+sub-10 µs latency for sparse single messages.
+
+### Envelope validation cost (decides pydantic vs slotted dataclasses)
+
+200k messages/variant, 1 KB-body `request` and small `event`:
+
+| variant | request ns/msg | request msgs/s | event ns/msg | event msgs/s |
+|---|---|---|---|---|
+| raw dict msgpack (baseline) | 2 580 | 388 k | 2 971 | 337 k |
+| + pydantic v2 validate | 6 324 | 158 k | 7 325 | 137 k |
+| + slots dataclass w/ checks | 6 510 | 154 k | 7 498 | 133 k |
+
+**Decision input:** slotted dataclasses have *no* performance edge over pydantic
+v2 (~2.5× baseline both). Recommendation: **pydantic v2** for the envelope
+(clarity, consistency with the codebase), with the broker's pure-forwarding path
+allowed to stay raw-dict (it only reads `kind`/`dst`/`corr_id` and never mutates
+bodies). Even fully validated, ~137–158 k msgs/s sits ~5× above the ~30 k
+events/s storm estimate (rationale §4).
+
+### Two-node run over the emulated WAN link
+
+Broker + proxy on nid001052, endpoints on nid001049; 15/15 checks pass.
+
+- Echo RTT: p50 **203.6 ms** (min 202.9, max 205.7) — exactly 4 crossings × 50 ms;
+  the real inter-node network adds ≪ 1 ms.
+- Storm: 2000 pipelined requests (window 64), 0 failures, 304 req/s —
+  latency-bound (64 ÷ 0.204 s ≈ 314/s theoretical), not a stack limit.
+- **Pong latency during the storm: max 102.8 ms** — precisely the 2 × 50 ms the
+  ping itself pays on the link; request traffic did not perturb keepalive at all.
+- Kill mid-flight over the link: all 50 in-flight fast-failed with synthesized
+  504s at exactly the 10 s grace, zero leaked/double-resolved entries; resume-key
+  recovery then restores `present` and new calls complete.
+
+### Dragon gates
+
+Measured with a GIL-observer thread (0.5 ms sampling; gaps ≫ sleep = GIL held
+or scheduler noise). `sys.getswitchinterval()` = 5 ms (default, unchanged).
+Raw numbers: `~/radical/m0_spike/dragon_gate_results.txt`.
+
+**(a) Off-thread `rh.Session` construction: YES.** Mirroring
+`plugin_rhapsody.py` (`get_backend('dragon_v3')` → `rh.Session(backends=[b])`)
+inside a non-main `threading.Thread` with its own asyncio loop: constructs in
+29.7 s, runs a trivial `ComputeTask` to `DONE`, closes cleanly. **Constraint:
+the process must be launched via the `dragon` launcher** — plain `python`
+cannot bring up the Dragon runtime. (The dragon launcher placed its primary
+process on the second allocation node; multi-node bring-up is part of init.)
+
+**(b) Max GIL hold:**
+
+| workload | max gap | >5 ms | >50 ms | >500 ms |
+|---|---|---|---|---|
+| idle baseline (10 s) | 0.58 ms | 0 | 0 | 0 |
+| Dragon/rhapsody session init (off-thread) | **2.8 ms** | 0 | 0 | 0 |
+| `msgpack.unpackb`, ~4 MB frame | **65.8 ms** | 30 | 26 | 0 |
+| `cloudpickle.loads`, ~10 MB blob | **57.8 ms** | 60 | 30 | 0 |
+
+Key finding: session init's 30 s wall is runtime bring-up with the GIL
+*released* — it never threatens the heartbeat. The real GIL threats are the C
+deserialisers: a 4 MB `unpackb` pins the GIL ~66 ms, a 10 MB `cloudpickle.loads`
+~58 ms; neither releases the GIL, so every thread — including the transport
+thread — freezes for that span. Scaling ~linearly: an 8 MB frame ⇒ ~130 ms; an
+unpack+unpickle chain ⇒ ~120 ms+.
+
+**Heartbeat floor (the number M0 owed):** pong-timeout floor **≥ 500 ms,
+prefer 1 s**. The plan's proposed default (ping 1 s / pong timeout 3 s) clears
+the worst observed hold by >20×, so it **stands**. The aggressive LAN profile
+(`suspect` ≈ 1 s) is feasible only *with* the M4 offload-hygiene item (large
+unpack/unpickle via `asyncio.to_thread` keeps the holds bounded per-call, and
+the frame cap bounds them by construction: a 4 MB cap ⇒ ≤ ~66 ms hold).
+
+## Design lessons for M2–M4 (from building the spike)
+
+1. **Fast-fail needs a broker-side forwarding table.** Keep a lightweight
+   `inflight: corr_id → (src, dst)` map besides the requester-owned pending
+   entry. On `lost`, synthesizing 504s from it converts client-timeout waits
+   into grace-bounded failures with zero leaks — and it is what lets "single
+   owner per pending entry" coexist with fast failure.
+2. **The teardown guard is load-bearing on *both* paths.** `registry.get(name)
+   is ws` must guard `_on_socket_drop` *and* `_on_lost`: a replaced socket's
+   handler fires its `finally` after resume has installed the new socket and
+   would otherwise re-suspect a live participant.
+3. **websockets 16 keepalive is genuinely transport-independent.** With
+   `ping_interval=1 / ping_timeout=3` on a dedicated transport thread, a work
+   loop pinned in `time.sleep(60)` never trips the timeout. The structural
+   isolation claim holds with the stock library — no custom ping machinery.
+4. **Coalesced wakeups are the whole handoff game.** One `call_soon_threadsafe`
+   per burst (re-armed only after a drain) is what yields ~2.2 M msgs/s;
+   naive one-wakeup-per-message would be ~10× worse at the p50 wakeup cost.
+5. **Inbound handoff must never block the transport loop.** A hard-bounded
+   inbound queue would stall keepalive — the exact failure isolation exists to
+   prevent. Spike used soft-bound + overflow counter; the real implementation
+   answers overflow with the 503 fast-fail contract instead (the per-src pending
+   cap stays strict and synchronous at the caller).
+6. **`ClientConnection.latency` (websockets) gives pong RTT for free** — usable
+   for the liveness tie-in and ops visibility; no envelope ping needed,
+   confirming the "no app-level heartbeat" decision.
+7. **An endpoint hosting the Dragon-backed rhapsody plugin must be launched
+   via the `dragon` launcher** — session construction is thread-agnostic (M0
+   verdict) but runtime bring-up is launcher-dependent. This lands on the
+   endpoint wrapper script / M4 runtime docs, not on the plugin.
+8. **Non-interactive SSH on Perlmutter drops `PYTHONUSERBASE`** (NERSC sets it
+   to `~/.local/perlmutter/python-3.11`, where user-site packages live) — remote
+   process launch must carry the env explicitly; this is exactly the job of the
+   endpoint wrapper script.
+
+## Caveats
+
+- 2 nodes only: Dragon GIL-hold numbers are a **lower bound**
+  (`Batch(num_nodes=…)` cost grows with allocation size); the heartbeat floor
+  carries a safety margin and must be re-validated at target scale before an
+  aggressive profile ships (plan §M0).
+- The delay proxy shapes bandwidth per direction with a token bucket
+  (100 ms-worth initial burst); `--bw-mbps` is decimal megabytes/s.
+- The spike broker enforces its pending cap globally, not per-src (single-`src`
+  table in the spike); the real broker implements the per-src cap as specified.
+- The e2e rhapsody-shaped throughput comparison against the current stack is
+  deferred with the throughput-gate baseline (see verdict table).

--- a/src/radical/orbit/client.py
+++ b/src/radical/orbit/client.py
@@ -603,14 +603,29 @@ class PluginClient:
         origin = '/'.join(filter(None, [self._endpoint_id, self._plugin_name]))
         _raise(resp, f"[{origin}] {context}" if context else f"[{origin}]")
 
-    def register_session(self, **kwargs: Any) -> None:
+    def register_session(self, sid: Optional[str] = None,
+                         lifetime: Optional[str] = None,
+                         ttl: Optional[float] = None, **kwargs: Any) -> None:
         """
-        Register a session with the plugin.
+        Register (or reconnect to) a session with the plugin.
+
+        Args:
+            sid:      Client-supplied session ID for create-or-reconnect
+                      (``None`` mints a fresh one).
+            lifetime: Session lifetime policy — ``'ephemeral'`` (default),
+                      ``'ttl'``, or ``'persistent'``.
+            ttl:      Seconds until expiry; required (and only valid) when
+                      ``lifetime='ttl'``.
 
         Subclasses may override to accept plugin-specific keyword
         arguments (e.g. ``backends``).
         """
-        resp = self._http.post(self._url("register_session"))
+        payload = {}
+        if sid      is not None: payload['sid']      = sid
+        if lifetime is not None: payload['lifetime'] = lifetime
+        if ttl      is not None: payload['ttl']      = ttl
+        resp = self._http.post(self._url("register_session"),
+                               json=payload or None)
         self._raise(resp)
         self._sid = resp.json()['sid']
 

--- a/src/radical/orbit/plugin_base.py
+++ b/src/radical/orbit/plugin_base.py
@@ -13,6 +13,10 @@ from .ui_schema import UIConfig, ui_config_to_dict
 
 log = logging.getLogger("radical.orbit")
 
+# Reserved session ID.  The 'default' session is persistent and per plugin
+# instance — a `rhapsody` default and a `psij` default are distinct sessions.
+DEFAULT_SID = 'default'
+
 
 class Plugin(object):
     """
@@ -148,6 +152,14 @@ class Plugin(object):
 
         self._sessions: Dict[str, PluginSession] = {}
         self._session_last_access: Dict[str, float] = {}  # Track last access time
+        # Per-session lifetime record: sid -> {lifetime, ttl, owner}.  The
+        # mutable last_access field of the record lives in the hot
+        # `_session_last_access` map above.  Sessions with no record fall back
+        # to the ephemeral idle-timeout stub (see `_session_expired`).
+        self._session_policy: Dict[str, Dict[str, Any]] = {}
+        # Guards on-demand creation of the reserved 'default' session so two
+        # concurrent first requests cannot double-create it.
+        self._default_lock = asyncio.Lock()
         self._main_loop: Optional[asyncio.AbstractEventLoop] = None
         self._cleanup_task: Optional[asyncio.Task] = None
 
@@ -303,19 +315,189 @@ class Plugin(object):
                           self.instance_name)
 
     async def register_session(self, request: Request) -> dict:
-        """Register a new session and return its unique session ID."""
+        """Register (or reconnect to) a session and return its session ID.
+
+        Session policy
+        --------------
+        The request body (JSON, all fields optional) selects a lifetime
+        policy and, for reconnect, a client-supplied session ID::
+
+            {"sid": <str>, "lifetime": "ephemeral"|"ttl"|"persistent",
+             "ttl": <seconds>}
+
+        - ``sid`` omitted                    -> a fresh session ID is minted.
+        - ``sid`` names an existing session  -> *reconnect*: its last-access
+          time is bumped and the same ``sid`` is returned (409 if the supplied
+          lifetime/ttl differs from the one it was created with).
+        - ``sid`` names no session           -> a session is created under
+          exactly that ID.
+
+        Each session records ``{lifetime, ttl, last_access, owner}`` (``owner``
+        is reserved for owner-checked reattach and is ``None`` for now):
+
+        - ``ephemeral`` (default): liveness-driven expiry is a documented stub
+          — until it lands, an ephemeral session retains the plugin idle-timeout
+          behavior (``session_ttl``) so idle sessions are not leaked.
+        - ``ttl``: expires once ``now - last_access`` exceeds ``ttl`` seconds
+          (time-driven, enforced by the cleanup pass); requires ``ttl > 0``.
+        - ``persistent``: never expires; its resources are reclaimed only by
+          explicit operator action (e.g. ``unregister_session`` / ``cancel_all``)
+          — there is no liveness reclaim.
+
+        The session registry is per plugin *instance*, so the reserved
+        ``default`` session (always ``persistent``, auto-created on demand) is
+        per-plugin: a ``rhapsody`` default and a ``psij`` default are distinct
+        sessions.
+
+        Raises:
+            HTTPException 409: an incoherent lifetime/ttl pair, an unknown
+                lifetime value, or a reconnect whose policy conflicts with the
+                existing session.
+        """
         self._ensure_cleanup_task()
-        sid = f"session.{uuid.uuid4().hex[:8]}"
-        self._sessions[sid] = self._create_session(sid)
-        self._session_last_access[sid] = time.time()
-        log.info("[%s] Registered session %s", self.instance_name, sid)
+        try:
+            data = await request.json()
+        except Exception:
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+
+        sid, lifetime, ttl = self._normalize_session_policy(data)
+        sid = await self._open_session(sid, lifetime, ttl)
         return {"sid": sid}
+
+    def _normalize_session_policy(self, data: Dict[str, Any]) -> tuple:
+        """Validate the session-policy fields of a register_session body.
+
+        Returns the normalized ``(sid, lifetime, ttl)`` triple; ``sid`` may be
+        ``None`` (the caller mints one).  The reserved ``default`` session is
+        special-cased *before* lifetime validation, so a bare
+        ``register_session(sid='default')`` — where ``lifetime`` still carries
+        its ``'ephemeral'`` default — resolves to the persistent default rather
+        than being rejected; only an *explicitly* non-persistent policy for
+        ``default`` is incoherent.
+
+        Raises:
+            HTTPException 409: incoherent lifetime/ttl pair or unknown lifetime.
+        """
+        sid      = data.get('sid')
+        lifetime = data.get('lifetime', 'ephemeral')
+        ttl      = data.get('ttl')
+
+        if sid == DEFAULT_SID:
+            if 'lifetime' in data and data['lifetime'] != 'persistent':
+                raise HTTPException(
+                    status_code=409,
+                    detail="reserved session 'default' is always persistent")
+            if ttl is not None:
+                raise HTTPException(
+                    status_code=409,
+                    detail="reserved session 'default' takes no ttl")
+            return sid, 'persistent', None
+
+        if lifetime not in ('ephemeral', 'ttl', 'persistent'):
+            raise HTTPException(
+                status_code=409,
+                detail=f"unknown session lifetime: {lifetime!r}")
+
+        if lifetime == 'ttl':
+            if not isinstance(ttl, (int, float)) or isinstance(ttl, bool) \
+                    or ttl <= 0:
+                raise HTTPException(
+                    status_code=409,
+                    detail="lifetime='ttl' requires a positive ttl")
+            ttl = float(ttl)
+        elif ttl is not None:
+            raise HTTPException(
+                status_code=409,
+                detail=f"ttl is incoherent with lifetime={lifetime!r}")
+
+        return sid, lifetime, ttl
+
+    async def _open_session(self, sid: Optional[str], lifetime: str,
+                            ttl: Optional[float]) -> str:
+        """Create-or-reconnect a session under the given policy.
+
+        ``sid=None`` mints a fresh ID; an existing ``sid`` reconnects (after a
+        policy-conflict check); the reserved ``default`` is created on demand
+        under a lock.  Returns the resolved session ID.
+        """
+        if sid == DEFAULT_SID:
+            await self._ensure_default_session()
+            self._session_last_access[sid] = time.time()
+            return sid
+
+        if sid is None:
+            sid = f"session.{uuid.uuid4().hex[:8]}"
+            while sid in self._sessions:
+                sid = f"session.{uuid.uuid4().hex[:8]}"
+
+        if sid in self._sessions:
+            self._check_policy_conflict(sid, lifetime, ttl)
+            self._session_last_access[sid] = time.time()
+            log.info("[%s] Reconnected session %s", self.instance_name, sid)
+            return sid
+
+        self._record_session(sid, self._create_session(sid), lifetime, ttl)
+        log.info("[%s] Registered session %s", self.instance_name, sid)
+        return sid
+
+    def _record_session(self, sid: str, session: PluginSession,
+                        lifetime: str, ttl: Optional[float]) -> None:
+        """Store a session together with its lifetime record.
+
+        The record is ``{lifetime, ttl, owner}`` (``owner`` reserved for
+        owner-checked reattach, ``None`` for now); the mutable ``last_access``
+        field lives in ``self._session_last_access``.
+        """
+        self._sessions[sid]            = session
+        self._session_policy[sid]      = {'lifetime': lifetime,
+                                          'ttl':      ttl,
+                                          'owner':    None}
+        self._session_last_access[sid] = time.time()
+
+    def _check_policy_conflict(self, sid: str, lifetime: str,
+                               ttl: Optional[float]) -> None:
+        """Reject a reconnect whose policy differs from the live session's.
+
+        Sessions created outside the policy model (no recorded policy — e.g. a
+        plugin that builds sessions directly) accept any reconnect; there is
+        nothing to conflict with.
+        """
+        record = self._session_policy.get(sid)
+        if record is None:
+            return
+        if record['lifetime'] != lifetime or record['ttl'] != ttl:
+            raise HTTPException(
+                status_code=409,
+                detail=f"session {sid} exists with a different lifetime policy")
+
+    async def _ensure_default_session(self) -> PluginSession:
+        """Return the reserved ``default`` session, creating it on demand.
+
+        ``default`` is persistent and per plugin instance.  Creation is guarded
+        by a lock so two concurrent first requests cannot double-create it.
+        Persistent-default-owned resources have no liveness reclaim — they are
+        released only by explicit operator action (e.g. ``cancel_all``).
+        """
+        session = self._sessions.get(DEFAULT_SID)
+        if session is not None:
+            return session
+        async with self._default_lock:
+            session = self._sessions.get(DEFAULT_SID)
+            if session is None:
+                session = self._create_session(DEFAULT_SID)
+                self._record_session(DEFAULT_SID, session, 'persistent', None)
+                log.info("[%s] Created persistent 'default' session",
+                         self.instance_name)
+            return session
 
     async def unregister_session(self, request: Request) -> dict:
         """Unregister a session by its session ID and close it."""
         sid = request.path_params['sid']
         inst = self._sessions.pop(sid, None)
         self._session_last_access.pop(sid, None)
+        self._session_policy.pop(sid, None)
 
         if not inst:
             raise HTTPException(status_code=404, detail=f"unknown session id: {sid}")
@@ -421,13 +603,14 @@ class Plugin(object):
                 has already been cleaned up before this is raised.
             HTTPException 500: Unexpected error inside the session method.
         """
-        if self.session_ttl > 0:
-            # Detect expiry of THIS session before the background cleanup removes it
-            last        = self._session_last_access.get(sid)
-            sid_expired = (last is not None and (time.time() - last) > self.session_ttl)
-            if sid_expired:
-                await self._cleanup_expired_sessions()
-                raise HTTPException(status_code=410, detail=f"session expired: {sid}")
+        # On-demand creation of the reserved persistent 'default' session.
+        if sid == DEFAULT_SID and sid not in self._sessions:
+            await self._ensure_default_session()
+
+        # Detect expiry of THIS session before the background cleanup removes it
+        if self._session_expired(sid, time.time()):
+            await self._cleanup_expired_sessions()
+            raise HTTPException(status_code=410, detail=f"session expired: {sid}")
 
         session = self._sessions.get(sid)
         if not session:
@@ -449,25 +632,52 @@ class Plugin(object):
                 detail=f"[{self.instance_name}/{sid}] {func.__name__}: {e}"
             ) from e
 
+    def _session_expired(self, sid: str, now: float) -> bool:
+        """Return True if the session has passed its lifetime policy.
+
+        - ``persistent`` never expires.
+        - ``ttl`` expires once ``now - last_access`` exceeds its ``ttl``.
+        - ``ephemeral`` (and any session with no recorded policy) falls back to
+          the plugin idle timeout (``session_ttl``) — the documented stub that
+          stands in for liveness-driven expiry until it lands.
+        """
+        last = self._session_last_access.get(sid)
+        if last is None:
+            return False
+
+        record   = self._session_policy.get(sid)
+        lifetime = record['lifetime'] if record else 'ephemeral'
+
+        if lifetime == 'persistent':
+            return False
+
+        if lifetime == 'ttl':
+            ttl = record['ttl']
+            return ttl is not None and (now - last) > ttl
+
+        # 'ephemeral' stub — idle timeout until liveness-driven expiry lands.
+        return self.session_ttl > 0 and (now - last) > self.session_ttl
+
     async def _cleanup_expired_sessions(self) -> int:
         """
-        Clean up sessions that have exceeded their TTL.
+        Close and drop every session past its lifetime policy.
+
+        ``ttl`` sessions expire on time; ``ephemeral`` sessions on idle
+        timeout; ``persistent`` sessions are never touched here.
 
         Returns:
             Number of sessions cleaned up.
         """
-        if self.session_ttl <= 0:
-            return 0
-
         now = time.time()
         expired_sids = [
-            sid for sid, last_access in self._session_last_access.items()
-            if (now - last_access) > self.session_ttl
+            sid for sid in list(self._session_last_access.keys())
+            if self._session_expired(sid, now)
         ]
 
         for sid in expired_sids:
             session = self._sessions.pop(sid, None)
             self._session_last_access.pop(sid, None)
+            self._session_policy.pop(sid, None)
             if session:
                 try:
                     await session.close()
@@ -492,8 +702,7 @@ class Plugin(object):
         """Background task: expire stale sessions every 5 seconds."""
         while True:
             await asyncio.sleep(5)
-            if self.session_ttl > 0:
-                await self._cleanup_expired_sessions()
+            await self._cleanup_expired_sessions()
 
     def _log_routes(self) -> None:
         """Log all registered routes for debugging."""

--- a/src/radical/orbit/plugin_rhapsody.py
+++ b/src/radical/orbit/plugin_rhapsody.py
@@ -18,7 +18,7 @@ import uuid
 from fastapi import FastAPI, HTTPException, Request
 
 from .plugin_session_base import PluginSession
-from .plugin_base import Plugin
+from .plugin_base import Plugin, DEFAULT_SID
 from .client import PluginClient
 
 log = logging.getLogger("radical.orbit")
@@ -1418,7 +1418,9 @@ class PluginRhapsody(Plugin):
     async def register_session(self, request: Request) -> dict:
         """Register a new Rhapsody session.
 
-        Accepts an optional JSON body with ``{"backends": ["name", ...]}``.
+        Accepts an optional JSON body with ``{"backends": ["name", ...]}``
+        plus the base session-policy fields ``sid`` / ``lifetime`` / ``ttl``
+        (see :meth:`Plugin.register_session`).
 
         Session initialization happens asynchronously in the background.
         The SID is returned immediately.  The client should wait for a
@@ -1429,6 +1431,10 @@ class PluginRhapsody(Plugin):
             data = await request.json()
         except Exception:
             data = {}
+        if not isinstance(data, dict):
+            data = {}
+
+        sid, lifetime, ttl = self._normalize_session_policy(data)
 
         backend_names       = data.get('backends')
         # Endpoint-startup default: when the client doesn't specify a
@@ -1446,9 +1452,30 @@ class PluginRhapsody(Plugin):
         notify_batch_size   = data.get('notify_batch_size',
                                        NOTIFY_BATCH_SIZE)
 
-        # Build session directly to avoid race on shared plugin state
         self._ensure_cleanup_task()
-        sid     = f"session.{uuid.uuid4().hex[:8]}"
+
+        # Reserved persistent 'default' — created on demand (see the
+        # `_ensure_default_session` override), reporting its real status.
+        if sid == DEFAULT_SID:
+            session = await self._ensure_default_session()
+            self._session_last_access[sid] = time.time()
+            return {"sid": sid, "status": self._session_status(session)}
+
+        if sid is None:
+            sid = f"session.{uuid.uuid4().hex[:8]}"
+
+        # Reconnect to an existing session — do not rebuild it.  Report the
+        # session's real status: its init may have long completed, and the
+        # reconnecting client would otherwise wait for a `session_status`
+        # notification that was emitted before it attached.
+        if sid in self._sessions:
+            self._check_policy_conflict(sid, lifetime, ttl)
+            self._session_last_access[sid] = time.time()
+            log.info("[%s] Reconnected session %s", self.instance_name, sid)
+            status = self._session_status(self._sessions[sid])
+            return {"sid": sid, "status": status}
+
+        # Build session directly to avoid race on shared plugin state
         session = self.session_class(
             sid,
             backend_names=backend_names,
@@ -1456,8 +1483,7 @@ class PluginRhapsody(Plugin):
             notify_batch_size=int(notify_batch_size),
         )
         session._plugin = self
-        self._sessions[sid]            = session
-        self._session_last_access[sid] = time.time()
+        self._record_session(sid, session, lifetime, ttl)
         log.info("[%s] Registered session %s", self.instance_name, sid)
 
         # Kick off initialization in the background so the HTTP response
@@ -1465,6 +1491,49 @@ class PluginRhapsody(Plugin):
         asyncio.create_task(self._init_session(sid, session))
 
         return {"sid": sid, "status": "initializing"}
+
+    @staticmethod
+    def _session_status(session) -> str:
+        """Report a session's real initialization state.
+
+        ``initializing`` while the background init is still running,
+        ``failed`` once init errored, ``ready`` otherwise.
+        """
+        if not session._init_ready.is_set():
+            return "initializing"
+        if session._init_error:
+            return "failed"
+        return "ready"
+
+    async def _ensure_default_session(self):
+        """Return the persistent ``default`` session, creating it on demand.
+
+        Rhapsody sessions need their background initialization kicked, so
+        the base on-demand path does not suffice: the session is built
+        through rhapsody's direct-build path (endpoint-startup backend
+        defaults — no client body is available here) and its init task is
+        started, exactly like a fresh create.  Creation is guarded by the
+        base default lock so two concurrent first requests cannot
+        double-create it.
+        """
+        session = self._sessions.get(DEFAULT_SID)
+        if session is not None:
+            return session
+        async with self._default_lock:
+            session = self._sessions.get(DEFAULT_SID)
+            if session is None:
+                backend_names = None
+                env_backend   = os.environ.get('RADICAL_ORBIT_RHAPSODY_BACKEND')
+                if env_backend:
+                    backend_names = [env_backend]
+                session = self.session_class(
+                    DEFAULT_SID, backend_names=backend_names)
+                session._plugin = self
+                self._record_session(DEFAULT_SID, session, 'persistent', None)
+                log.info("[%s] Created persistent 'default' session",
+                         self.instance_name)
+                asyncio.create_task(self._init_session(DEFAULT_SID, session))
+            return session
 
     async def _init_session(self, sid: str, session) -> None:
         """Background task: initialize a session and notify via SSE."""

--- a/tests/unittests/test_plugin_base.py
+++ b/tests/unittests/test_plugin_base.py
@@ -306,6 +306,196 @@ async def test_plugin_session_cleanup():
     assert "new_session" in plugin._sessions
 
 
+# ---------------------------------------------------------------------------
+# Session policy: create-or-reconnect, lifetime validation, expiry, default
+# ---------------------------------------------------------------------------
+
+def _body_request(payload):
+    '''Build a minimal Request-like mock whose .json() returns `payload`.'''
+    async def _json():
+        return payload
+    request = Mock(spec=Request)
+    request.json = _json
+    return request
+
+
+@pytest.mark.asyncio
+async def test_session_create_or_reconnect():
+    '''A client-supplied sid that exists reconnects (same sid, last_access
+    bumped); a fresh sid creates under exactly that id.'''
+    app = FastAPI()
+    plugin = Plugin(app, "test_plugin")
+    plugin.session_class = PluginSession
+
+    # Explicit-sid create
+    data = await plugin.register_session(_body_request({"sid": "s1"}))
+    assert data['sid'] == "s1"
+    assert "s1" in plugin._sessions
+    obj = plugin._sessions["s1"]
+
+    # Reconnect: same sid returned, last_access bumped, session not rebuilt
+    plugin._session_last_access["s1"] = 0.0
+    data = await plugin.register_session(_body_request({"sid": "s1"}))
+    assert data['sid'] == "s1"
+    assert plugin._sessions["s1"] is obj              # not rebuilt
+    assert plugin._session_last_access["s1"] > 0.0    # bumped
+
+
+@pytest.mark.asyncio
+async def test_session_mint_when_sid_omitted():
+    '''sid=None mints a fresh session id.'''
+    app = FastAPI()
+    plugin = Plugin(app, "test_plugin")
+    plugin.session_class = PluginSession
+
+    data = await plugin.register_session(_body_request({}))
+    assert data['sid'].startswith("session.")
+    assert data['sid'] in plugin._sessions
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [
+    {"lifetime": "ttl"},                       # ttl lifetime, no ttl
+    {"lifetime": "ttl", "ttl": 0},             # ttl not > 0
+    {"lifetime": "ttl", "ttl": -5},            # ttl not > 0
+    {"lifetime": "persistent", "ttl": 10},     # ttl with non-ttl lifetime
+    {"lifetime": "ephemeral", "ttl": 10},      # ttl with non-ttl lifetime
+    {"lifetime": "forever"},                   # unknown lifetime
+])
+async def test_session_incoherent_policy_409(payload):
+    '''Incoherent lifetime/ttl pairs and unknown lifetimes map to HTTP 409.'''
+    app = FastAPI()
+    plugin = Plugin(app, "test_plugin")
+    plugin.session_class = PluginSession
+
+    with pytest.raises(HTTPException) as exc_info:
+        await plugin.register_session(_body_request(payload))
+    assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_session_reconnect_policy_conflict_409():
+    '''Reconnecting to a sid with a different lifetime/ttl is a 409.'''
+    app = FastAPI()
+    plugin = Plugin(app, "test_plugin")
+    plugin.session_class = PluginSession
+
+    await plugin.register_session(
+        _body_request({"sid": "s1", "lifetime": "ttl", "ttl": 10}))
+
+    # Different lifetime
+    with pytest.raises(HTTPException) as exc_info:
+        await plugin.register_session(
+            _body_request({"sid": "s1", "lifetime": "persistent"}))
+    assert exc_info.value.status_code == 409
+
+    # Different ttl
+    with pytest.raises(HTTPException) as exc_info:
+        await plugin.register_session(
+            _body_request({"sid": "s1", "lifetime": "ttl", "ttl": 20}))
+    assert exc_info.value.status_code == 409
+
+    # Same policy reconnects cleanly
+    data = await plugin.register_session(
+        _body_request({"sid": "s1", "lifetime": "ttl", "ttl": 10}))
+    assert data['sid'] == "s1"
+
+
+@pytest.mark.asyncio
+async def test_session_ttl_expiry_via_cleanup():
+    '''A 'ttl' session expires once now-last_access > ttl (time-driven).'''
+    app = FastAPI()
+    plugin = Plugin(app, "test_plugin")
+    plugin.session_class = PluginSession
+    plugin.session_ttl = 0  # ensure ephemeral idle-timeout does not interfere
+
+    await plugin.register_session(
+        _body_request({"sid": "s1", "lifetime": "ttl", "ttl": 0.5}))
+    assert "s1" in plugin._sessions
+
+    # Not yet expired
+    assert await plugin._cleanup_expired_sessions() == 0
+    assert "s1" in plugin._sessions
+
+    # Backdate last_access past the ttl and clean up (no real sleep)
+    plugin._session_last_access["s1"] = time.time() - 5
+    cleaned = await plugin._cleanup_expired_sessions()
+    assert cleaned == 1
+    assert "s1" not in plugin._sessions
+    assert "s1" not in plugin._session_policy
+
+
+@pytest.mark.asyncio
+async def test_session_persistent_never_expires():
+    '''A 'persistent' session is never reclaimed by the cleanup pass.'''
+    app = FastAPI()
+    plugin = Plugin(app, "test_plugin")
+    plugin.session_class = PluginSession
+    plugin.session_ttl = 1
+
+    await plugin.register_session(
+        _body_request({"sid": "s1", "lifetime": "persistent"}))
+
+    # Backdate far past any idle/ttl horizon — persistent stays put
+    plugin._session_last_access["s1"] = time.time() - 10_000
+    assert await plugin._cleanup_expired_sessions() == 0
+    assert "s1" in plugin._sessions
+
+
+@pytest.mark.asyncio
+async def test_session_default_auto_create_under_concurrency():
+    '''Two concurrent first requests for 'default' create exactly one session.'''
+    import asyncio
+
+    app = FastAPI()
+    plugin = Plugin(app, "test_plugin")
+    plugin.session_class = PluginSession
+
+    results = await asyncio.gather(
+        plugin.register_session(_body_request({"sid": "default"})),
+        plugin.register_session(_body_request({"sid": "default"})),
+    )
+    assert all(r['sid'] == "default" for r in results)
+    assert list(plugin._sessions.keys()) == ["default"]
+
+
+@pytest.mark.asyncio
+async def test_session_default_forced_persistent():
+    '''The reserved 'default' session is always persistent.'''
+    app = FastAPI()
+    plugin = Plugin(app, "test_plugin")
+    plugin.session_class = PluginSession
+
+    # Bare register (lifetime defaults to 'ephemeral') resolves to persistent
+    data = await plugin.register_session(_body_request({"sid": "default"}))
+    assert data['sid'] == "default"
+    assert plugin._session_policy["default"]['lifetime'] == "persistent"
+
+    # An explicitly conflicting lifetime for 'default' is a 409
+    with pytest.raises(HTTPException) as exc_info:
+        await plugin.register_session(
+            _body_request({"sid": "default", "lifetime": "ephemeral"}))
+    assert exc_info.value.status_code == 409
+
+    # Explicit 'persistent' is accepted (reconnect)
+    data = await plugin.register_session(
+        _body_request({"sid": "default", "lifetime": "persistent"}))
+    assert data['sid'] == "default"
+
+
+@pytest.mark.asyncio
+async def test_session_default_auto_create_via_forward():
+    '''An unregistered '_forward' to 'default' auto-creates it (persistent).'''
+    app = FastAPI()
+    plugin = Plugin(app, "test_plugin")
+    plugin.session_class = PluginSession
+
+    assert "default" not in plugin._sessions
+    await plugin._forward("default", PluginSession.close)
+    assert "default" in plugin._sessions
+    assert plugin._session_policy["default"]['lifetime'] == "persistent"
+
+
 def test_plugin_session_ttl_default():
     '''
     Test that session_ttl has a sensible default.

--- a/tests/unittests/test_plugin_rhapsody.py
+++ b/tests/unittests/test_plugin_rhapsody.py
@@ -76,6 +76,7 @@ def _patch_rhapsody():
 
 
 # Now import after the mock is in place
+from radical.orbit.plugin_base import DEFAULT_SID  # noqa: E402
 from radical.orbit.plugin_rhapsody import (  # noqa: E402
     PluginRhapsody,
     RhapsodySession,
@@ -164,6 +165,111 @@ def test_register_multiple_sessions():
 
     assert len(set(sids)) == 3
     assert len(plugin._sessions) == 3
+
+
+def test_register_session_policy_passthrough():
+    '''The rhapsody override forwards the base sid/lifetime/ttl policy:
+    explicit-sid create, reconnect, and 409 on an incoherent pair.'''
+    _, plugin, client = _make_plugin()
+
+    # Explicit sid + ttl lifetime create
+    resp = client.post(f"{plugin.namespace}/register_session",
+                       json={"sid": "s1", "lifetime": "ttl", "ttl": 30})
+    assert resp.status_code == 200
+    assert resp.json()['sid'] == "s1"
+    assert plugin._session_policy["s1"] == {'lifetime': 'ttl',
+                                            'ttl': 30.0, 'owner': None}
+    plugin._sessions["s1"]._init_ready.set()
+
+    # Reconnect with the same policy — no rebuild, same sid
+    obj  = plugin._sessions["s1"]
+    resp = client.post(f"{plugin.namespace}/register_session",
+                       json={"sid": "s1", "lifetime": "ttl", "ttl": 30})
+    assert resp.status_code == 200
+    assert resp.json()['sid'] == "s1"
+    assert plugin._sessions["s1"] is obj
+
+    # Incoherent pair maps to 409
+    resp = client.post(f"{plugin.namespace}/register_session",
+                       json={"lifetime": "ttl"})
+    assert resp.status_code == 409
+
+
+def test_register_session_reconnect_real_status():
+    '''Reconnect reports the session's real init status — 'ready' once
+    init completed, 'failed' once it errored — not 'initializing'.'''
+    _, plugin, client = _make_plugin()
+
+    resp = client.post(f"{plugin.namespace}/register_session",
+                       json={"sid": "s1"})
+    assert resp.status_code == 200
+    assert resp.json()['status'] == 'initializing'
+
+    # Reconnect to a ready session reports 'ready'
+    session = plugin._sessions["s1"]
+    session._init_ready.set()
+    resp = client.post(f"{plugin.namespace}/register_session",
+                       json={"sid": "s1"})
+    assert resp.status_code == 200
+    assert resp.json() == {'sid': 's1', 'status': 'ready'}
+
+    # ... and 'failed' once init errored
+    session._init_error = 'boom'
+    resp = client.post(f"{plugin.namespace}/register_session",
+                       json={"sid": "s1"})
+    assert resp.json()['status'] == 'failed'
+
+
+@pytest.mark.asyncio
+async def test_register_default_session():
+    '''register_session(sid='default') creates the persistent default
+    session, kicks its background init, and reports the real status.'''
+    _, plugin, _ = _make_plugin()
+
+    with patch.object(PluginRhapsody, '_init_session',
+                      new_callable=AsyncMock) as init_mock:
+        request = MagicMock(spec=Request)
+        request.json = AsyncMock(return_value={"sid": DEFAULT_SID})
+        resp = await plugin.register_session(request)
+        await asyncio.sleep(0)   # let the init task run
+
+    assert resp['sid']    == DEFAULT_SID
+    assert resp['status'] == 'initializing'
+    assert plugin._session_policy[DEFAULT_SID]['lifetime'] == 'persistent'
+    init_mock.assert_called_once_with(
+        DEFAULT_SID, plugin._sessions[DEFAULT_SID])
+
+    # Re-register once ready reports the real status; no rebuild, no re-init
+    session = plugin._sessions[DEFAULT_SID]
+    session._init_ready.set()
+    with patch.object(PluginRhapsody, '_init_session',
+                      new_callable=AsyncMock) as init_mock:
+        resp = await plugin.register_session(request)
+    assert resp == {'sid': DEFAULT_SID, 'status': 'ready'}
+    assert plugin._sessions[DEFAULT_SID] is session
+    init_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_default_session_via_forward():
+    '''An unregistered `_forward` to 'default' auto-creates the rhapsody
+    default session (persistent) and kicks its background init.'''
+    _, plugin, _ = _make_plugin()
+
+    assert DEFAULT_SID not in plugin._sessions
+    with patch.object(PluginRhapsody, '_init_session',
+                      new_callable=AsyncMock) as init_mock:
+        # The call itself 409s — init has not completed yet — but the
+        # session must exist afterwards with its init task started.
+        with pytest.raises(HTTPException) as exc_info:
+            await plugin._forward(DEFAULT_SID, RhapsodySession.list_tasks)
+        await asyncio.sleep(0)   # let the init task run
+
+    assert exc_info.value.status_code == 409
+    assert DEFAULT_SID in plugin._sessions
+    assert plugin._session_policy[DEFAULT_SID]['lifetime'] == 'persistent'
+    init_mock.assert_called_once_with(
+        DEFAULT_SID, plugin._sessions[DEFAULT_SID])
 
 
 def test_unregister_session():


### PR DESCRIPTION
First milestone of `plans/broker_architecture_plan.md` (M1 — sessions, transport-agnostic slice). Lands on the current stack in `plugin_base.py`/`plugin_session_base.py` territory; this code survives the broker rewrite untouched. Also carries the M0 spike results doc.

## What

`register_session` accepts an optional JSON body `{sid, lifetime, ttl}`:

| Input | Result |
|---|---|
| `sid` omitted | fresh `session.<hex>` minted |
| `sid` exists, same policy re-stated | reconnect: `last_access` bumped, same sid returned |
| `sid` exists, different lifetime/ttl | **409** |
| `sid` new | created under exactly that id |
| `lifetime='ttl'` without positive `ttl`; `ttl` with non-ttl lifetime; unknown lifetime | **409** |
| `sid='default'` | persistent reserved session, auto-created on demand under a lock; explicit non-persistent policy for it → **409** |

- Sessions record `{lifetime, ttl, last_access, owner}` (`owner` reserved for owner-checked reattach, arrives with liveness integration).
- Expiry: `ttl` = time-driven via the cleanup pass; `persistent` = never (explicit operator action only, e.g. `cancel_all`); `ephemeral` = documented stub retaining the idle-timeout behavior until liveness-driven expiry lands.
- `default` is per plugin instance (a `rhapsody` default and a `psij` default are distinct sessions).
- rhapsody: its direct-build override adopts the policy model; reconnect/default paths report the session's **real** init status (`ready`/`failed`/`initializing`) so a reconnecting client doesn't wait for a `session_status` notification that fired before it attached; `_ensure_default_session` override kicks rhapsody's background init for the default session.
- `PluginClient.register_session` gains optional `sid`/`lifetime`/`ttl` passthrough (no args → no body → unchanged behavior).

## Notes for review

- Reconnect requires **re-stating** the original policy (omitted `lifetime` means `ephemeral`, which 409s against e.g. a `ttl` session) — deterministic over guessy.
- `iri_instance` (fixed `_auto_sid`) is exempt per the plan and unmodified; task_dispatcher delegates to the base and needed nothing.

## Testing

- `pytest tests/unittests/`: **811 passed, 2 skipped** (pre-existing `radical.pilot` skips); +18 new tests covering the full validation matrix, ttl expiry, default-creation race, rhapsody status reporting and default init.
- `flake8 src/`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)