### PR TITLE
M2: protocol.py — symmetric msgpack envelope (frozen wire contract)

### DIFF
--- a/src/radical/orbit/protocol.py
+++ b/src/radical/orbit/protocol.py
@@ -1,0 +1,379 @@
+"""
+Wire protocol for broker <-> endpoint (participant) communication.
+
+One symmetric, **versioned** envelope; ``kind`` discriminates the payload.
+Wire encoding is msgpack, always (``use_bin_type=True``, ``raw=False``) — one
+packer, one parser, ``body`` is native bytes (no base64, no JSON/text path).
+Validation is pydantic v2: ``m0_results.md`` measured slotted dataclasses
+against pydantic v2 and found no performance edge (~2.5x baseline both), so
+pydantic wins on clarity and consistency with the rest of the codebase. The
+broker's pure-forwarding role is the documented exception — it never builds
+a model, see ``peek_routing`` below.
+
+There is **no ``ping``/``pong`` kind** in the envelope: liveness is
+WS-protocol-level only (transport keepalive on both sides), never app-level.
+
+``channel`` is reserved for the deferred blocking-served-call / in-band-
+isolation cases: the field exists on every envelope, is always ``None``
+today, and carries no behaviour yet.
+
+``seq`` (``event`` only) is broker-assigned and frozen with the envelope:
+monotone per session for session-scoped events, monotone per the global
+session-less stream otherwise. Consumers detect drops as ``seq`` gaps; the
+optional replay plugin (later milestone) uses ``ts``/``seq`` to splice
+replay into live delivery with no wire change.
+
+``corr_id`` is only meaningful on ``request``/``response`` and is namespaced
+by the requester's ``src`` (see ``mint_corr_id``) so every pending-call table
+has a single, unambiguous owner per entry.
+
+Frame-size cap: ``FRAME_CAP`` bounds the packed frame by the design
+inequality ``frame_cap <= heartbeat_timeout * min_bandwidth / 2`` (e.g. a 3 s
+pong timeout and a 3 MB/s link floor a ~4 MB cap). The same cap doubles as a
+bound on GIL-hold time: M0 measured a 4 MB ``msgpack.unpackb`` pinning the
+GIL ~66 ms with no release, so capping the frame size also caps how long a
+single inbound frame can stall any thread — including the transport thread
+that answers keepalive pings.
+
+Version mismatches are rejected outright at ``parse_message`` time.
+Version *negotiation* (letting old and new peers agree on a shared
+protocol version) is not implemented here — it rides ``register`` /
+``register_ack`` ``capabilities`` in a later milestone; today a mismatch is
+simply a hard error.
+"""
+
+import uuid
+
+from typing import Any, Dict, List, Literal, Optional, Union
+
+import msgpack
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+PROTOCOL_VERSION = 1
+
+# Default frame-size cap in bytes -- see the module docstring for the
+# design inequality and the GIL-hold rationale.
+FRAME_CAP = 4 * 1024 * 1024
+
+
+class ProtocolError(Exception):
+    """Raised on any envelope pack/parse failure.
+
+    Covers: oversized frame, malformed msgpack, unknown ``kind``,
+    missing/invalid fields, and protocol version mismatch.
+    """
+
+
+# ---------------------------------------------------------------------------
+# id / corr_id helpers
+# ---------------------------------------------------------------------------
+
+def mint_id() -> str:
+    """Mint a fresh envelope id (``uuid4``)."""
+    return str(uuid.uuid4())
+
+
+def mint_corr_id(src: str) -> str:
+    """Mint a correlation id namespaced by *src*.
+
+    corr_ids are namespaced by the requesting ``src`` so that every pending-
+    call table (one per broker-side ``src`` bucket, one per endpoint) has a
+    single, unambiguous owner per entry -- timeout/cleanup never has to guess
+    which side's table an id belongs to.
+    """
+    return f"{src}:{uuid.uuid4()}"
+
+
+# ---------------------------------------------------------------------------
+# Nested models
+# ---------------------------------------------------------------------------
+
+class Identity(BaseModel):
+    """Participant identity presented at ``register``."""
+    model_config = ConfigDict(extra='forbid')
+
+    name:       str
+    credential: Optional[str] = None
+    resume_key: Optional[str] = None
+
+
+class SubscribePattern(BaseModel):
+    """One ``subscribe``/``unsubscribe`` interest pattern.
+
+    A ``None`` field is a wildcard -- mirrors the client callback-registry
+    tuples (``endpoint_id``/``plugin_name``/``topic`` all optional).
+    """
+    model_config = ConfigDict(extra='forbid')
+
+    endpoint: Optional[str] = None
+    plugin:   Optional[str] = None
+    topic:    Optional[str] = None
+
+
+class ParticipantInfo(BaseModel):
+    """One entry of a ``topology`` envelope's ``participants`` dict.
+
+    ``plugins`` is a free-form dict keyed by plugin name -- each value
+    carries whatever the hosting plugin publishes (``namespace``,
+    ``version``, ``ui_config``, ``enabled``, ...); this module does not
+    constrain its shape.
+    """
+    model_config = ConfigDict(extra='forbid')
+
+    role:     str
+    plugins:  Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+    liveness: str
+
+
+# ---------------------------------------------------------------------------
+# Envelope base
+# ---------------------------------------------------------------------------
+
+class _Envelope(BaseModel):
+    """Common envelope fields shared by every ``kind``."""
+    model_config = ConfigDict(extra='forbid')
+
+    version: int           = PROTOCOL_VERSION
+    id:      str           = Field(default_factory=mint_id)
+    corr_id: Optional[str] = None
+    channel: Optional[str] = None   # reserved; always None today
+    src:     str
+    dst:     Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Per-kind envelopes
+# ---------------------------------------------------------------------------
+
+class Request(_Envelope):
+    """Proxied HTTP-shaped request, routed by ``dst``."""
+
+    kind:      Literal['request'] = 'request'
+    method:    str
+    path:      str
+    headers:   Dict[str, str] = Field(default_factory=dict)
+    body:      bytes          = b''
+    is_binary: bool            = False
+
+
+class Response(_Envelope):
+    """Reply to a ``request``, correlated via ``corr_id``."""
+
+    kind:      Literal['response'] = 'response'
+    status:    int
+    headers:   Dict[str, str] = Field(default_factory=dict)
+    body:      bytes          = b''
+    is_binary: bool            = False
+
+
+class Event(_Envelope):
+    """A plugin-originated notification.
+
+    ``seq`` is broker-assigned: monotone per session for session-scoped
+    events (``session`` set), monotone per the global session-less stream
+    otherwise (``session`` is ``None``).
+    """
+
+    kind:    Literal['event'] = 'event'
+    plugin:  str
+    topic:   str
+    session: Optional[str] = None
+    ts:      float
+    seq:     int
+    data:    Dict[str, Any] = Field(default_factory=dict)
+
+
+class Register(_Envelope):
+    """Endpoint -> broker registration handshake."""
+
+    kind:         Literal['register'] = 'register'
+    identity:     Identity
+    role:         str
+    plugins:      List[Dict[str, Any]] = Field(default_factory=list)
+    capabilities: Dict[str, Any]       = Field(default_factory=dict)
+
+
+class RegisterAck(_Envelope):
+    """Broker -> endpoint reply to ``register``.
+
+    ``resume_key`` is minted on first registration of an identity (broker
+    memory only); a reconnect presenting it replaces the stale socket.
+    """
+
+    kind:         Literal['register_ack'] = 'register_ack'
+    ok:           bool
+    reason:       Optional[str] = None
+    capabilities: Dict[str, Any] = Field(default_factory=dict)
+    resume_key:   str
+
+
+class Subscribe(_Envelope):
+    """Register live-event interest patterns."""
+
+    kind:     Literal['subscribe'] = 'subscribe'
+    patterns: List[SubscribePattern] = Field(default_factory=list)
+
+
+class Unsubscribe(_Envelope):
+    """Withdraw live-event interest patterns (same shape as ``subscribe``)."""
+
+    kind:     Literal['unsubscribe'] = 'unsubscribe'
+    patterns: List[SubscribePattern] = Field(default_factory=list)
+
+
+class Topology(_Envelope):
+    """Full or partial topology snapshot."""
+
+    kind:         Literal['topology'] = 'topology'
+    participants: Dict[str, ParticipantInfo] = Field(default_factory=dict)
+
+
+class Control(_Envelope):
+    """Administrative operation (shutdown/error/terminate/disconnect)."""
+
+    kind: Literal['control'] = 'control'
+    op:   Literal['shutdown', 'error', 'terminate', 'disconnect']
+    data: Dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Union type for annotations + kind -> model dispatch
+# ---------------------------------------------------------------------------
+
+Message = Union[
+    Request, Response, Event, Register, RegisterAck,
+    Subscribe, Unsubscribe, Topology, Control,
+]
+
+
+_KIND_TO_MODEL = {
+    'request':       Request,
+    'response':      Response,
+    'event':         Event,
+    'register':      Register,
+    'register_ack':  RegisterAck,
+    'subscribe':     Subscribe,
+    'unsubscribe':   Unsubscribe,
+    'topology':      Topology,
+    'control':       Control,
+}
+
+
+# ---------------------------------------------------------------------------
+# pack / parse
+# ---------------------------------------------------------------------------
+
+def pack_message(msg: BaseModel, cap: int = FRAME_CAP) -> bytes:
+    """Serialize an envelope model to a msgpack frame.
+
+    Raises ``ProtocolError`` if the packed frame exceeds *cap* bytes.
+    """
+    data = msg.model_dump(mode='python')
+    try:
+        packed = msgpack.packb(data, use_bin_type=True)
+    except Exception as e:
+        raise ProtocolError(f"failed to pack {msg.kind!r} message: {e}") from e
+
+    if len(packed) > cap:
+        raise ProtocolError(
+            f"frame size {len(packed)} bytes exceeds cap {cap} bytes")
+
+    return packed
+
+
+def parse_message(data: bytes, cap: int = FRAME_CAP) -> Message:
+    """Parse + validate a msgpack frame into its ``kind``-specific model.
+
+    Raises ``ProtocolError`` on: oversized frame, malformed msgpack, unknown
+    ``kind``, missing/invalid fields, or a protocol version mismatch.
+    """
+    if len(data) > cap:
+        raise ProtocolError(
+            f"frame size {len(data)} bytes exceeds cap {cap} bytes")
+
+    try:
+        raw = msgpack.unpackb(data, raw=False)
+    except Exception as e:
+        raise ProtocolError(f"malformed msgpack frame: {e}") from e
+
+    if not isinstance(raw, dict):
+        raise ProtocolError(
+            f"malformed frame: expected a mapping, got {type(raw).__name__}")
+
+    version = raw.get('version')
+    if version != PROTOCOL_VERSION:
+        raise ProtocolError(
+            f"protocol version mismatch: frame is v{version!r}, this "
+            f"process speaks v{PROTOCOL_VERSION} (version negotiation "
+            "rides register/register_ack capabilities, not yet implemented)")
+
+    kind = raw.get('kind')
+    cls  = _KIND_TO_MODEL.get(kind)
+    if cls is None:
+        raise ProtocolError(f"unknown message kind: {kind!r}")
+
+    try:
+        return cls(**raw)
+    except ValidationError as e:
+        raise ProtocolError(f"invalid {kind!r} message: {e}") from e
+
+
+def peek_routing(data: bytes):
+    """Extract routing fields from a msgpack frame **without** validation.
+
+    This is the broker's pure-forwarding fast path: it routes by
+    ``kind``/``src``/``dst``/``corr_id`` and never inspects or mutates
+    bodies, so it has no reason to pay pydantic validation cost or to build
+    a model at all -- a plain msgpack unpack is enough (and, unlike
+    ``parse_message``, tolerates an otherwise-invalid frame as long as the
+    routing fields are present).
+
+    Returns ``(kind, src, dst, corr_id)``.
+    """
+    try:
+        raw = msgpack.unpackb(data, raw=False)
+    except Exception as e:
+        raise ProtocolError(f"malformed msgpack frame: {e}") from e
+
+    if not isinstance(raw, dict):
+        raise ProtocolError(
+            f"malformed frame: expected a mapping, got {type(raw).__name__}")
+
+    return raw.get('kind'), raw.get('src'), raw.get('dst'), raw.get('corr_id')
+
+
+# ---------------------------------------------------------------------------
+# Convenience constructors
+# ---------------------------------------------------------------------------
+
+def make_request(src: str, dst: str, method: str, path: str, *,
+                  headers:   Optional[Dict[str, str]] = None,
+                  body:      bytes                    = b'',
+                  is_binary: bool                      = False,
+                  corr_id:   Optional[str]              = None) -> Request:
+    """Build a ``request`` envelope; mints a namespaced ``corr_id`` by default."""
+    return Request(
+        src=src, dst=dst, method=method, path=path,
+        headers=headers or {}, body=body, is_binary=is_binary,
+        corr_id=corr_id or mint_corr_id(src))
+
+
+def make_response(request: Request, status: int, *,
+                   headers:   Optional[Dict[str, str]] = None,
+                   body:      bytes                    = b'',
+                   is_binary: bool                      = False) -> Response:
+    """Build the ``response`` envelope for *request*.
+
+    ``src``/``dst`` are the request's swapped; ``corr_id`` is copied so the
+    caller's pending-table lookup resolves.
+    """
+    return Response(
+        src=request.dst, dst=request.src, status=status,
+        headers=headers or {}, body=body, is_binary=is_binary,
+        corr_id=request.corr_id)

--- a/tests/unittests/test_protocol.py
+++ b/tests/unittests/test_protocol.py
@@ -1,0 +1,357 @@
+"""
+Tests for the broker/endpoint wire protocol (``protocol.py``).
+"""
+import msgpack
+import pytest
+
+from radical.orbit.protocol import (
+    PROTOCOL_VERSION, FRAME_CAP, ProtocolError,
+    Identity, SubscribePattern, ParticipantInfo,
+    Request, Response, Event, Register, RegisterAck,
+    Subscribe, Unsubscribe, Topology, Control,
+    mint_id, mint_corr_id, pack_message, parse_message, peek_routing,
+    make_request, make_response,
+)
+
+
+NON_UTF8_BODY = b'\x00\xff\x80'
+
+
+def _roundtrip(msg):
+    """Pack + parse and return the reconstructed message."""
+    data = pack_message(msg)
+    return parse_message(data), data
+
+
+class TestIdHelpers:
+    """id / corr_id minting helpers."""
+
+    def test_mint_id_is_uuid4_str(self):
+        import uuid
+        mid = mint_id()
+        assert isinstance(mid, str)
+        assert uuid.UUID(mid).version == 4
+
+    def test_mint_id_unique(self):
+        assert mint_id() != mint_id()
+
+    def test_mint_corr_id_namespaced_by_src(self):
+        cid = mint_corr_id('endpoint-1')
+        assert cid.startswith('endpoint-1:')
+
+    def test_mint_corr_id_unique(self):
+        assert mint_corr_id('a') != mint_corr_id('a')
+
+
+class TestRoundTrip:
+    """Round-trip every kind through pack_message/parse_message."""
+
+    def test_request_roundtrip(self):
+        msg = Request(
+            src='client.1', dst='endpoint.1', method='POST',
+            path='/rhapsody/submit/session.abc',
+            headers={'content-type': 'application/json'},
+            body=NON_UTF8_BODY, is_binary=True,
+            corr_id=mint_corr_id('client.1'))
+        parsed, _ = _roundtrip(msg)
+        assert isinstance(parsed, Request)
+        assert parsed.version == PROTOCOL_VERSION
+        assert parsed.src == 'client.1'
+        assert parsed.dst == 'endpoint.1'
+        assert parsed.method == 'POST'
+        assert parsed.path == '/rhapsody/submit/session.abc'
+        assert parsed.headers == {'content-type': 'application/json'}
+        assert parsed.body == NON_UTF8_BODY
+        assert isinstance(parsed.body, bytes)
+        assert parsed.is_binary is True
+        assert parsed.corr_id == msg.corr_id
+
+    def test_response_roundtrip(self):
+        msg = Response(
+            src='endpoint.1', dst='client.1', status=200,
+            headers={'content-type': 'application/octet-stream'},
+            body=NON_UTF8_BODY, is_binary=True, corr_id='client.1:abc')
+        parsed, _ = _roundtrip(msg)
+        assert isinstance(parsed, Response)
+        assert parsed.status == 200
+        assert parsed.body == NON_UTF8_BODY
+        assert isinstance(parsed.body, bytes)
+        assert parsed.corr_id == 'client.1:abc'
+
+    def test_event_roundtrip(self):
+        msg = Event(
+            src='broker', dst=None, plugin='rhapsody', topic='task_status',
+            session='session.xyz', ts=1234.5, seq=42,
+            data={'uid': 'task-1', 'state': 'DONE'})
+        parsed, _ = _roundtrip(msg)
+        assert isinstance(parsed, Event)
+        assert parsed.plugin == 'rhapsody'
+        assert parsed.topic == 'task_status'
+        assert parsed.session == 'session.xyz'
+        assert parsed.ts == 1234.5
+        assert parsed.seq == 42
+        assert parsed.data == {'uid': 'task-1', 'state': 'DONE'}
+
+    def test_event_roundtrip_sessionless(self):
+        msg = Event(
+            src='broker', plugin='sysinfo', topic='metrics', session=None,
+            ts=1.0, seq=1, data={})
+        parsed, _ = _roundtrip(msg)
+        assert parsed.session is None
+
+    def test_register_roundtrip(self):
+        msg = Register(
+            src='endpoint.1',
+            identity=Identity(name='endpoint.1', credential='tok',
+                               resume_key=None),
+            role='endpoint',
+            plugins=[{'name': 'sysinfo', 'namespace': '/endpoint.1/sysinfo/x'}],
+            capabilities={'protocol_version': PROTOCOL_VERSION})
+        parsed, _ = _roundtrip(msg)
+        assert isinstance(parsed, Register)
+        assert parsed.identity.name == 'endpoint.1'
+        assert parsed.identity.credential == 'tok'
+        assert parsed.identity.resume_key is None
+        assert parsed.role == 'endpoint'
+        assert parsed.plugins == [
+            {'name': 'sysinfo', 'namespace': '/endpoint.1/sysinfo/x'}]
+        assert parsed.capabilities == {'protocol_version': PROTOCOL_VERSION}
+
+    def test_register_ack_roundtrip_ok(self):
+        msg = RegisterAck(
+            src='broker', dst='endpoint.1', ok=True, reason=None,
+            capabilities={}, resume_key='rk-123')
+        parsed, _ = _roundtrip(msg)
+        assert parsed.ok is True
+        assert parsed.reason is None
+        assert parsed.resume_key == 'rk-123'
+
+    def test_register_ack_roundtrip_failure(self):
+        msg = RegisterAck(
+            src='broker', dst='endpoint.1', ok=False,
+            reason='name in use', capabilities={}, resume_key='')
+        parsed, _ = _roundtrip(msg)
+        assert parsed.ok is False
+        assert parsed.reason == 'name in use'
+        assert parsed.resume_key == ''
+
+    def test_subscribe_roundtrip_with_wildcards(self):
+        msg = Subscribe(
+            src='endpoint.1', dst='broker',
+            patterns=[
+                SubscribePattern(endpoint=None, plugin='rhapsody', topic='task_status'),
+                SubscribePattern(endpoint=None, plugin=None, topic=None),
+            ])
+        parsed, _ = _roundtrip(msg)
+        assert isinstance(parsed, Subscribe)
+        assert len(parsed.patterns) == 2
+        assert parsed.patterns[0].endpoint is None
+        assert parsed.patterns[0].plugin == 'rhapsody'
+        assert parsed.patterns[0].topic == 'task_status'
+        assert parsed.patterns[1].endpoint is None
+        assert parsed.patterns[1].plugin is None
+        assert parsed.patterns[1].topic is None
+
+    def test_unsubscribe_roundtrip(self):
+        msg = Unsubscribe(
+            src='endpoint.1', dst='broker',
+            patterns=[SubscribePattern(endpoint='e1', plugin='p', topic='t')])
+        parsed, _ = _roundtrip(msg)
+        assert isinstance(parsed, Unsubscribe)
+        assert parsed.patterns[0].endpoint == 'e1'
+
+    def test_topology_roundtrip(self):
+        msg = Topology(
+            src='broker', dst='endpoint.1',
+            participants={
+                'endpoint.1': ParticipantInfo(
+                    role='endpoint',
+                    plugins={'sysinfo': {'namespace': '/endpoint.1/sysinfo/x',
+                                         'version': '1.0',
+                                         'ui_config': {},
+                                         'enabled': True}},
+                    liveness='present'),
+                'consumer.2': ParticipantInfo(
+                    role='consumer', plugins={}, liveness='suspect'),
+            })
+        parsed, _ = _roundtrip(msg)
+        assert isinstance(parsed, Topology)
+        assert set(parsed.participants) == {'endpoint.1', 'consumer.2'}
+        ep = parsed.participants['endpoint.1']
+        assert ep.role == 'endpoint'
+        assert ep.liveness == 'present'
+        assert ep.plugins['sysinfo']['namespace'] == '/endpoint.1/sysinfo/x'
+        assert parsed.participants['consumer.2'].liveness == 'suspect'
+
+    def test_control_roundtrip(self):
+        msg = Control(src='broker', dst='endpoint.1', op='terminate',
+                      data={'reason': 'operator request'})
+        parsed, _ = _roundtrip(msg)
+        assert isinstance(parsed, Control)
+        assert parsed.op == 'terminate'
+        assert parsed.data == {'reason': 'operator request'}
+
+    def test_control_default_data(self):
+        msg = Control(src='broker', op='shutdown')
+        parsed, _ = _roundtrip(msg)
+        assert parsed.data == {}
+
+
+class TestMakeRequestResponse:
+    """make_request / make_response convenience constructors."""
+
+    def test_make_request_mints_namespaced_corr_id(self):
+        req = make_request('client.1', 'endpoint.1', 'GET', '/health')
+        assert req.corr_id.startswith('client.1:')
+        assert req.src == 'client.1'
+        assert req.dst == 'endpoint.1'
+        assert req.method == 'GET'
+        assert req.path == '/health'
+        assert req.body == b''
+        assert req.headers == {}
+        assert req.is_binary is False
+
+    def test_make_request_explicit_corr_id(self):
+        req = make_request('client.1', 'endpoint.1', 'GET', '/health',
+                            corr_id='client.1:fixed')
+        assert req.corr_id == 'client.1:fixed'
+
+    def test_make_response_swaps_src_dst_and_copies_corr_id(self):
+        req  = make_request('client.1', 'endpoint.1', 'POST', '/submit',
+                             body=b'{"x": 1}')
+        resp = make_response(req, 200, body=b'{"ok": true}')
+        assert resp.src == 'endpoint.1'
+        assert resp.dst == 'client.1'
+        assert resp.corr_id == req.corr_id
+        assert resp.status == 200
+        assert resp.body == b'{"ok": true}'
+
+    def test_make_response_roundtrips(self):
+        req  = make_request('client.1', 'endpoint.1', 'GET', '/x')
+        resp = make_response(req, 404, body=b'not found')
+        parsed, _ = _roundtrip(resp)
+        assert parsed.status == 404
+        assert parsed.src == 'endpoint.1'
+        assert parsed.dst == 'client.1'
+        assert parsed.corr_id == req.corr_id
+
+
+class TestFrameCap:
+    """Oversized-frame enforcement, on both pack and parse."""
+
+    def test_pack_message_raises_over_small_cap(self):
+        msg = Request(src='a', dst='b', method='GET', path='/x',
+                      body=b'0123456789')
+        with pytest.raises(ProtocolError, match='exceeds cap'):
+            pack_message(msg, cap=8)
+
+    def test_pack_message_ok_under_cap(self):
+        msg = Request(src='a', dst='b', method='GET', path='/x', body=b'x')
+        data = pack_message(msg, cap=FRAME_CAP)
+        assert isinstance(data, bytes)
+
+    def test_parse_message_enforces_cap(self):
+        msg  = Request(src='a', dst='b', method='GET', path='/x',
+                       body=b'0123456789')
+        data = pack_message(msg, cap=FRAME_CAP)
+        with pytest.raises(ProtocolError, match='exceeds cap'):
+            parse_message(data, cap=8)
+
+    def test_default_frame_cap_is_four_mib(self):
+        assert FRAME_CAP == 4 * 1024 * 1024
+
+
+class TestErrors:
+    """Malformed / invalid frames raise ProtocolError."""
+
+    def test_unknown_kind(self):
+        raw  = {'version': PROTOCOL_VERSION, 'id': mint_id(), 'corr_id': None,
+                'channel': None, 'src': 'a', 'dst': 'b', 'kind': 'bogus'}
+        data = msgpack.packb(raw, use_bin_type=True)
+        with pytest.raises(ProtocolError, match='unknown message kind'):
+            parse_message(data)
+
+    def test_missing_required_field(self):
+        # request without 'method'
+        raw  = {'version': PROTOCOL_VERSION, 'id': mint_id(), 'corr_id': None,
+                'channel': None, 'src': 'a', 'dst': 'b', 'kind': 'request',
+                'path': '/x', 'headers': {}, 'body': b'', 'is_binary': False}
+        data = msgpack.packb(raw, use_bin_type=True)
+        with pytest.raises(ProtocolError, match="invalid 'request' message"):
+            parse_message(data)
+
+    def test_wrong_version(self):
+        req  = Request(src='a', dst='b', method='GET', path='/x')
+        raw  = req.model_dump(mode='python')
+        raw['version'] = 999
+        data = msgpack.packb(raw, use_bin_type=True)
+        with pytest.raises(ProtocolError) as exc_info:
+            parse_message(data)
+        msg = str(exc_info.value)
+        assert '999' in msg
+        assert str(PROTOCOL_VERSION) in msg
+
+    def test_malformed_msgpack(self):
+        with pytest.raises(ProtocolError, match='malformed msgpack'):
+            parse_message(b'\xff\xff\xff\xff\xff\xff')
+
+    def test_non_mapping_frame(self):
+        data = msgpack.packb([1, 2, 3], use_bin_type=True)
+        with pytest.raises(ProtocolError, match='expected a mapping'):
+            parse_message(data)
+
+    def test_control_invalid_op_rejected(self):
+        raw  = {'version': PROTOCOL_VERSION, 'id': mint_id(), 'corr_id': None,
+                'channel': None, 'src': 'broker', 'dst': None,
+                'kind': 'control', 'op': 'reboot', 'data': {}}
+        data = msgpack.packb(raw, use_bin_type=True)
+        with pytest.raises(ProtocolError, match="invalid 'control' message"):
+            parse_message(data)
+
+    def test_control_valid_ops_accepted(self):
+        for op in ('shutdown', 'error', 'terminate', 'disconnect'):
+            msg = Control(src='broker', op=op)
+            parsed, _ = _roundtrip(msg)
+            assert parsed.op == op
+
+
+class TestPeekRouting:
+    """peek_routing extracts routing fields without pydantic validation."""
+
+    def test_agrees_with_parse_message_on_valid_frame(self):
+        msg  = make_request('client.1', 'endpoint.1', 'GET', '/health')
+        data = pack_message(msg)
+        kind, src, dst, corr_id = peek_routing(data)
+        parsed = parse_message(data)
+        assert kind == parsed.kind == 'request'
+        assert src == parsed.src == 'client.1'
+        assert dst == parsed.dst == 'endpoint.1'
+        assert corr_id == parsed.corr_id
+
+    def test_survives_invalid_non_routing_field(self):
+        # 'method' missing entirely -- parse_message would reject this,
+        # but peek_routing only looks at kind/src/dst/corr_id.
+        raw  = {'version': PROTOCOL_VERSION, 'id': mint_id(),
+                'corr_id': 'client.1:abc', 'channel': None,
+                'src': 'client.1', 'dst': 'endpoint.1', 'kind': 'request'}
+        data = msgpack.packb(raw, use_bin_type=True)
+        with pytest.raises(ProtocolError):
+            parse_message(data)
+        kind, src, dst, corr_id = peek_routing(data)
+        assert kind == 'request'
+        assert src == 'client.1'
+        assert dst == 'endpoint.1'
+        assert corr_id == 'client.1:abc'
+
+    def test_does_not_validate_unknown_kind(self):
+        raw  = {'kind': 'bogus', 'src': 'a', 'dst': 'b', 'corr_id': None}
+        data = msgpack.packb(raw, use_bin_type=True)
+        kind, src, dst, corr_id = peek_routing(data)
+        assert kind == 'bogus'
+        assert src == 'a'
+        assert dst == 'b'
+        assert corr_id is None
+
+    def test_malformed_msgpack_raises(self):
+        with pytest.raises(ProtocolError, match='malformed msgpack'):
+            peek_routing(b'\xff\xff\xff\xff\xff\xff')


### PR DESCRIPTION
Second milestone of `plans/broker_architecture_plan.md` (M2 — protocol foundation), stacked on #64. New module + tests only; `models.py` and the whole old stack are untouched (build-alongside).

## What

`src/radical/orbit/protocol.py`: the one symmetric, versioned envelope, `kind`-discriminated — `request`, `response`, `event`, `register`, `register_ack`, `subscribe`/`unsubscribe`, `topology`, `control`.

- **msgpack-only on the wire** (`use_bin_type=True`), `body` is native bytes — no base64, no JSON path.
- **pydantic v2 validation** — the M0-measured decision (`plans/m0_results.md`: slotted dataclasses showed no performance edge, ~2.5× raw-dict baseline for both; validated throughput ~140–160k msgs/s ≫ the ~30k events/s storm estimate).
- **`peek_routing(data) → (kind, src, dst, corr_id)`** — the documented raw-dict fast path for the broker's pure-forwarding role; never builds a model.
- **`mint_corr_id(src)`** — corr_ids namespaced by src, single owner per pending entry.
- **No ping/pong kinds** — liveness is WS-protocol-level only. `channel` present but reserved (always `None`).
- **`FRAME_CAP` = 4 MB** per `frame_cap ≤ heartbeat_timeout × min_bandwidth / 2`; doubles as a GIL-hold bound (M0: 4 MB `unpackb` pins ~66 ms).
- Version mismatch → hard `ProtocolError`; negotiation rides `register`/`register_ack` capabilities later.
- `make_request`/`make_response` builders (`make_response` swaps src/dst, copies corr_id).

## Testing

- 35 new tests: round-trip for every kind (incl. non-UTF8 binary bodies), cap enforcement both directions, unknown kind / missing fields / wrong version, `peek_routing` tolerance of invalid non-routing fields, subscribe wildcard semantics, control-op constraint.
- Full suite: **846 passed, 2 skipped**; `flake8 src/` clean. No dependency changes (msgpack + pydantic already required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)