### PR TITLE
M3: broker core — lean routing loop, two-stage liveness, resume keys, event fan-out

### DIFF
--- a/src/radical/orbit/bridge_plugin_host.py
+++ b/src/radical/orbit/bridge_plugin_host.py
@@ -47,8 +47,13 @@ class BridgePluginHost(PluginHostBase):
         self._load_plugins_from_filter(plugin_names)
 
         # Reference the live list — not a copy — so dynamically registered
-        # plugin routes are visible immediately.
-        self._direct_routes: list = getattr(self._app.state, 'direct_routes', [])
+        # plugin routes are visible immediately.  Ensure the list exists on
+        # app.state first: with an empty plugin set nothing created it yet, so
+        # a bare ``getattr(..., [])`` default would detach from the list a
+        # later dynamic plugin appends to (its routes would never match).
+        if not hasattr(self._app.state, 'direct_routes'):
+            self._app.state.direct_routes = []
+        self._direct_routes: list = self._app.state.direct_routes
 
     # ------------------------------------------------------------------
     # topology announcement  (PluginHostBase contract)

--- a/src/radical/orbit/broker.py
+++ b/src/radical/orbit/broker.py
@@ -1,0 +1,944 @@
+"""ORBIT Broker — the active hub (routing loop + hosted-plugin host).
+
+The broker is the sole hub of the participant star: endpoints dial in over a
+single outbound WebSocket, the broker routes ``request``/``response`` frames
+between them by ``dst``, fans out ``event`` frames to interested subscribers,
+tracks topology + liveness, and is itself a participant (``src='broker'``)
+that hosts plugins and can *call* endpoints.
+
+**Transport isolation (load-bearing).**  The uvicorn/server loop is the *lean
+routing loop*: every frame it touches is a handful of dict operations
+(``msgpack`` unpack, a registry lookup, ``msgpack`` repack, a socket send).
+The hosted-plugin host runs on its **own event loop in its own thread**, so a
+blocking plugin handler stalls request *handling*, never liveness — the
+routing loop keeps answering WS keepalive pings the whole time.  The two loops
+exchange work through the M0-validated thread-aware handoff
+(``run_coroutine_threadsafe`` in either direction, coalesced).
+
+**Liveness is transport-level and two-stage.**  Server-wide WS keepalive
+(``ws_ping_interval``/``ws_ping_timeout`` on uvicorn) closes a silent socket;
+a socket drop makes the identity ``suspect`` immediately (topology signal); a
+grace timer then declares it ``lost`` (actionable — inflight calls to it
+fast-fail).  A valid re-register cancels the grace timer; a clean close skips
+``suspect`` (immediate removal).
+
+**Build-alongside.**  This module lives next to the untouched ``bridge.py``
+(``bin/`` still defaults to the old stack) and owns a *minimal* app: only the
+token-gated WS ``/register`` route.  HTTP catch-all, SSE ``/events``, the
+Explorer UI and CORS are the M5 gateway module's job — it attaches onto this
+same app through the constructor-declared **gateway seam**, the
+attributes/methods a later ``gateway.py`` is handed:
+
+* :attr:`Broker.app`               — the FastAPI app to mount HTTP routes on.
+* :attr:`Broker.pending`           — the broker-side pending-call table.
+* :attr:`Broker.caller`            — the :class:`BrokerCaller` handle.
+* :meth:`Broker.tap`               — subscribe to the raw event stream.
+* :meth:`Broker.topology_snapshot` — the current rich topology dict.
+* :attr:`Broker.token` / :attr:`Broker.auth_enabled` — the credential config.
+
+Resume keys live in broker memory only — a broker restart clears them, so
+re-registration is first-come after a restart (same as the old stack).
+"""
+
+# pylint: disable=protected-access
+
+import asyncio
+import concurrent.futures
+import itertools
+import json
+import logging
+import os
+import signal
+import threading
+import time
+
+from contextlib import asynccontextmanager
+from typing     import Any, Callable, Dict, List, Optional, Tuple
+
+import msgpack
+
+from fastapi              import FastAPI, WebSocket, WebSocketDisconnect, \
+                                 HTTPException
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests   import Request
+from starlette.responses  import JSONResponse
+
+from . import _prof as rprof
+from . import protocol
+from . import utils
+
+from .bridge_plugin_host import BridgePluginHost
+from .broker_events      import EventRouter
+
+
+log = logging.getLogger("radical.orbit.broker")
+
+BROKER_NAME = 'broker'
+
+
+# ---------------------------------------------------------------------------
+# Supervised task creation
+# ---------------------------------------------------------------------------
+
+def spawn(coro, label: str, loop: Optional[asyncio.AbstractEventLoop] = None
+          ) -> asyncio.Task:
+    """Create a background task whose exceptions are never swallowed.
+
+    Handler *raises* are already isolated at the two plugin hosts; the real
+    gap is ``create_task``'d background coroutines whose exceptions die
+    silently.  Every background task in the broker goes through here so a
+    crash is logged (and thus reportable) rather than lost.
+    """
+    loop = loop or asyncio.get_event_loop()
+    task = loop.create_task(coro)
+
+    def _done(t: asyncio.Task) -> None:
+        if t.cancelled():
+            return
+        exc = t.exception()
+        if exc is not None:
+            log.error("[Broker] background task %r failed: %r", label, exc,
+                      exc_info=exc)
+
+    task.add_done_callback(_done)
+    return task
+
+
+# ---------------------------------------------------------------------------
+# Broker-as-participant caller handle
+# ---------------------------------------------------------------------------
+
+class BrokerCaller:
+    """In-process caller handle: the broker calling an endpoint (``src='broker'``).
+
+    :meth:`call` is awaitable on the routing loop; :meth:`call_threadsafe`
+    returns a ``concurrent.futures.Future`` for the plugin-host thread (the M7
+    dispatcher seam).  Both route through the single broker-side pending table
+    with the per-``src`` cap enforced synchronously at the caller.
+    """
+
+    def __init__(self, broker: 'Broker'):
+        self._broker = broker
+
+    async def call(self, dst: str, method: str, path: str, *,
+                   body:    bytes                    = b'',
+                   headers: Optional[Dict[str, str]] = None,
+                   timeout: Optional[float]          = None) -> Dict[str, Any]:
+        """Send a ``request`` to *dst* and await its ``response`` (as a dict).
+
+        Raises ``RuntimeError`` immediately when the broker's pending table is
+        at the per-``src`` cap, or on an unroutable ``dst``; raises
+        ``asyncio.TimeoutError`` if *timeout* elapses first.
+        """
+        return await self._broker._broker_call(
+            dst, method, path, body=body, headers=headers, timeout=timeout)
+
+    def call_threadsafe(self, dst: str, method: str, path: str, *,
+                        body:    bytes                    = b'',
+                        headers: Optional[Dict[str, str]] = None,
+                        timeout: Optional[float]          = None
+                        ) -> 'concurrent.futures.Future':
+        """Schedule :meth:`call` on the routing loop from another thread."""
+        return asyncio.run_coroutine_threadsafe(
+            self.call(dst, method, path, body=body, headers=headers,
+                      timeout=timeout),
+            self._broker._loop)
+
+
+# ---------------------------------------------------------------------------
+# Broker
+# ---------------------------------------------------------------------------
+
+class Broker:
+    """The active broker — lean routing loop + own-thread plugin host.
+
+    The transport/auth args (``app``, ``cert``/``key``, ``host``/``port``,
+    ``plugins``, ``token``/``no_auth``) mirror :class:`radical.orbit.bridge.\
+Bridge`.  The tunable liveness/backpressure knobs — ``ping_interval`` and
+    ``ping_timeout`` (uvicorn WS keepalive; ``ping_timeout`` doubles as the
+    loop-lag watchdog's stall budget), ``grace`` (``suspect`` → ``lost``
+    window), ``pending_cap`` (per-``src`` pending-table cap), ``event_queue``
+    (per-subscriber delivery depth), ``frame_cap`` (uvicorn ``ws_max_size``),
+    ``clock`` and ``watchdog_interval`` — are all injectable so unit tests run
+    with tiny values and no long sleeps.
+    """
+
+    def __init__(self,
+                 app:      Optional[FastAPI] = None,
+                 cert:     Optional[str]     = None,
+                 key:      Optional[str]     = None,
+                 host:     str = '0.0.0.0',
+                 port:     int = 8000,
+                 plugins:  str = '',
+                 token:    Optional[str]     = None,
+                 no_auth:  bool              = False,
+                 ping_interval:     float = 1.0,
+                 ping_timeout:      float = 3.0,
+                 grace:             float = 10.0,
+                 pending_cap:       int   = 1024,
+                 event_queue:       int   = 1024,
+                 frame_cap:         int   = protocol.FRAME_CAP,
+                 clock:             Callable[[], float] = time.monotonic,
+                 watchdog_interval: float = 1.0):
+
+        # ── TLS config ───────────────────────────────────────────────
+        cert_path, _ = utils.resolve_bridge_cert(cli=cert)
+        key_path,  _ = utils.resolve_bridge_key (cli=key, cert=cert_path)
+        self._cert: str = str(cert_path)
+        self._key : str = str(key_path)
+
+        # ── Ingress auth token (carried over from the bridge) ─────────
+        self._auth_enabled: bool          = not utils.auth_disabled(no_auth)
+        self._token:        Optional[str] = None
+        self._token_source: str           = 'disabled'
+        if self._auth_enabled:
+            self._token, self._token_source = utils.ensure_bridge_token(cli=token)
+
+        # ── Advertised URL ───────────────────────────────────────────
+        self._host = host
+        self._port = port
+        self._url_forms = utils.public_url_forms(self._host, self._port)
+        self._url: str  = self._url_forms[0]
+
+        # ── Tunables ─────────────────────────────────────────────────
+        self._ping_interval     = ping_interval
+        self._ping_timeout       = ping_timeout
+        self._grace             = grace
+        self._pending_cap       = pending_cap
+        self._event_queue       = event_queue
+        self._frame_cap         = frame_cap
+        self._clock             = clock
+        self._watchdog_interval = watchdog_interval
+        self._plugins_spec: str = plugins or ''
+
+        # ── Routing state (all touched only on the routing loop) ──────
+        self.registry:       Dict[str, Any]         = {}   # name -> transport ws
+        self._participants:  Dict[str, Dict[str, Any]] = {}  # name->{role,plugins}
+        self._liveness:      Dict[str, str]         = {}   # name -> present/...
+        self._resume_keys:   Dict[str, str]         = {}   # name -> resume_key
+        self._grace_timers:  Dict[str, Any]         = {}   # name -> TimerHandle
+
+        # Correlation: one broker-side pending table (src='broker') plus a
+        # lightweight inflight forwarding table for grace-bounded fast-fail.
+        self.pending:  Dict[str, asyncio.Future]        = {}   # corr_id -> future
+        self._inflight: Dict[str, Tuple[str, str]]      = {}   # corr_id -> (src,dst)
+
+        # Event delivery + subscriptions live in a sibling module (the routing
+        # loop stays lean); the router shares the live ``registry`` reference.
+        self._prof     = rprof.Profiler('broker', ns='radical.orbit')
+        self._events   = EventRouter(self.registry, spawn, self._prof,
+                                     event_queue, lambda: self._host_loop)
+
+        # Watchdog suppression window (loop-lag safety net).
+        self._suppress_until: float = 0.0
+
+        # Loops / host thread (populated in startup()).
+        self._loop:      Optional[asyncio.AbstractEventLoop] = None
+        self._host_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._host_thread: Optional[threading.Thread]        = None
+        self._host:      Optional[BridgePluginHost]          = None
+        self._watchdog_task: Optional[asyncio.Task]          = None
+        self._started:   bool = False
+
+        self.caller = BrokerCaller(self)
+
+        # Profiling — ported from the bridge with broker_* labels
+        # (``self._prof`` is created above with the event router).
+        self._req_ctr  = itertools.count()
+
+        # ── App ──────────────────────────────────────────────────────
+        if app is None:
+            app = FastAPI(title="ORBIT Broker",
+                          lifespan=self._lifespan,
+                          description="ORBIT active broker — participant star hub.",
+                          version="0.1.0")
+        self._app: FastAPI = app
+        self._app.state.is_bridge = True   # role detection: broker hosts plugins
+
+        self._setup_middleware()
+        self._register_routes()
+
+    # ── public API / gateway seam ─────────────────────────────────────
+
+    @property
+    def app(self) -> FastAPI:
+        """The FastAPI app (gateway seam: mount HTTP routes here)."""
+        return self._app
+
+    @property
+    def url(self) -> str:
+        """The broker's advertised URL (canonical FQDN form)."""
+        return self._url
+
+    @property
+    def token(self) -> Optional[str]:
+        """The shared ingress token (gateway seam: credential config)."""
+        return self._token
+
+    @property
+    def auth_enabled(self) -> bool:
+        """Whether the ingress token gate is active (gateway seam)."""
+        return self._auth_enabled
+
+    def tap(self, callback: Callable[[Dict[str, Any]], Any]) -> Callable[[], None]:
+        """Register an in-process subscriber for the raw (unfiltered) event
+        stream — the M8 replay plugin's hook and the M5 gateway's SSE fan-out.
+
+        The callback receives every event dict and is run supervised on the
+        **plugin-host loop**, never the routing loop.  Returns an unsubscribe
+        callable.
+        """
+        return self._events.tap(callback)
+
+    def topology_snapshot(self) -> Dict[str, Dict[str, Any]]:
+        """The current rich topology dict (gateway seam).
+
+        ``{name: {role, plugins:{pname:{...}}, liveness}}`` including the
+        broker's own hosted-plugin participant.
+        """
+        return {name: info.model_dump()
+                for name, info in self._participants_for_topology().items()}
+
+    # ── lifecycle ─────────────────────────────────────────────────────
+
+    async def startup(self) -> None:
+        """Capture the routing loop, start the host thread + the watchdog.
+
+        Idempotent; called from the FastAPI lifespan and directly from unit
+        tests that drive the broker without uvicorn.
+        """
+        if self._started:
+            return
+        self._loop = asyncio.get_running_loop()
+        self._start_host_thread()
+        self._watchdog_task = spawn(self._watchdog(), 'broker_watchdog')
+        self._started = True
+
+    async def shutdown(self) -> None:
+        """Tear down: close sockets, stop the watchdog and the host thread."""
+        if not self._started:
+            return
+        self._started = False
+        if self._watchdog_task:
+            self._watchdog_task.cancel()
+        for name in list(self.registry):
+            self._events.pause_sender(name)
+        for name, ws in list(self.registry.items()):
+            try:    await ws.close(code=1001)
+            except Exception as e:
+                log.debug("[Broker] close of %s failed: %s", name, e)
+        self.registry.clear()
+        self._stop_host_thread()
+
+    def _start_host_thread(self) -> None:
+        """Bring up the hosted-plugin host on its own loop/thread.
+
+        Plugins are constructed *on* the host loop (some create cleanup tasks
+        that need a running loop), so the build is scheduled onto the thread
+        and awaited before startup returns.
+        """
+        ready = threading.Event()
+
+        def _run() -> None:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            self._host_loop = loop
+            loop.call_soon(ready.set)
+            loop.run_forever()
+
+        self._host_thread = threading.Thread(
+            target=_run, name='broker-host', daemon=True)
+        self._host_thread.start()
+        ready.wait(timeout=5.0)
+
+        # The host is always built (empty plugin list is valid) so that
+        # ``dst=='broker'`` requests always have somewhere to route — the
+        # broker is a participant in its own right.  Plugins are constructed
+        # on the host loop (some create cleanup tasks needing a running loop).
+        names = [t.strip() for t in self._plugins_spec.split(',') if t.strip()]
+        fut: 'concurrent.futures.Future' = concurrent.futures.Future()
+
+        def _build() -> None:
+            try:
+                host = BridgePluginHost(
+                    names, self._host_broadcast, BROKER_NAME,
+                    on_topology_changed=None, bridge_url=self._url)
+                fut.set_result(host)
+            except Exception as e:                         # pragma: no cover
+                fut.set_exception(e)
+
+        self._host_loop.call_soon_threadsafe(_build)
+        self._host = fut.result(timeout=30.0)
+        if names:
+            log.info("[Broker] hosted plugins: %s", names)
+
+    def _stop_host_thread(self) -> None:
+        if self._host_loop:
+            self._host_loop.call_soon_threadsafe(self._host_loop.stop)
+        if self._host_thread:
+            self._host_thread.join(timeout=5.0)
+
+    # ── run (uvicorn) ─────────────────────────────────────────────────
+
+    def run(self) -> None:
+        """Start uvicorn.  Blocks until shutdown."""
+        import uvicorn
+
+        for form in self._url_forms:
+            print(f'[Broker] URL: {form}', flush=True)
+        # Lifespan (startup/shutdown) is attached at FastAPI construction.
+        # Never echo the token (CWE-532); report only its source/path.
+        if not self._auth_enabled:
+            log.warning("[Broker] ingress authentication DISABLED (--no-auth)")
+            print('[Broker] WARNING: ingress authentication DISABLED '
+                  '(--no-auth)', flush=True)
+        elif self._token_source in ('generated', 'file'):
+            verb = ('generated and written to' if self._token_source
+                    == 'generated' else 'loaded from')
+            print(f'[Broker] auth token {verb}: {utils.TOKEN_FILE}', flush=True)
+        else:
+            print(f'[Broker] auth token source: {self._token_source}', flush=True)
+
+        uvicorn.run(self._app,
+                    host=self._host,
+                    port=self._port,
+                    reload=False,
+                    ssl_certfile=self._cert,
+                    ssl_keyfile=self._key,
+                    log_level="info",
+                    # Transport enforces the frame cap; peek_routing does not.
+                    ws_max_size=self._frame_cap,
+                    ws_per_message_deflate=True,
+                    # Server-wide WS keepalive — verified (M3) to disconnect a
+                    # silent client at ping_interval + ping_timeout on
+                    # uvicorn 0.46 + websockets 16.
+                    ws_ping_interval=self._ping_interval,
+                    ws_ping_timeout=self._ping_timeout,
+                    timeout_graceful_shutdown=3)
+
+    @asynccontextmanager
+    async def _lifespan(self, app: FastAPI):
+        await self.startup()
+        try:
+            yield
+        finally:
+            await self.shutdown()
+
+    # ── middleware (token gate only — no CORS, that is the gateway's) ──
+
+    def _setup_middleware(self) -> None:
+        if self._auth_enabled:
+            self._app.add_middleware(BaseHTTPMiddleware,
+                                     dispatch=self._auth_dispatch)
+
+    async def _auth_dispatch(self, request: Request, call_next):
+        """Gate every HTTP route on the shared token.
+
+        The broker core exposes no capability-bearing HTTP surface of its own
+        (the WS ``/register`` gate is separate, inside the handler), so the
+        only exemption is the CORS preflight.
+        """
+        if request.method == 'OPTIONS':
+            return await call_next(request)
+        auth  = request.headers.get('authorization', '')
+        token = auth[7:].strip() if auth.lower().startswith('bearer ') else \
+                request.cookies.get(utils.AUTH_COOKIE)
+        if not utils.tokens_match(token, self._token):
+            return JSONResponse(
+                status_code=401,
+                content={"error": True, "status_code": 401,
+                         "detail": "missing or invalid broker token"})
+        return await call_next(request)
+
+    # ── /register ─────────────────────────────────────────────────────
+
+    def _register_routes(self) -> None:
+        self_ = self
+        app   = self._app
+
+        @app.websocket("/register")
+        async def register(ws: WebSocket):
+            await ws.accept()
+            name: Optional[str] = None
+            clean = False
+            try:
+                first = await ws.receive_bytes()
+                try:
+                    msg = protocol.parse_message(first, cap=self_._frame_cap)
+                except protocol.ProtocolError as e:
+                    log.warning("[Broker] bad first frame: %s", e)
+                    await self_._close_quiet(ws)
+                    return
+                if msg.kind != 'register':
+                    log.warning("[Broker] first frame is %r, not register",
+                                msg.kind)
+                    await self_._close_quiet(ws)
+                    return
+
+                ok, name = await self_._register(ws, msg)
+                if not ok:
+                    # _register already sent the rejecting ack; close cleanly.
+                    await self_._close_quiet(ws)
+                    return
+
+                while True:
+                    data = await ws.receive_bytes()
+                    await self_._route_frame(name, data)
+
+            except WebSocketDisconnect as e:
+                clean = e.code in (1000, 1001)
+            except protocol.ProtocolError as e:
+                log.warning("[Broker] protocol error from %s: %s", name, e)
+            except Exception as e:
+                log.exception("[Broker] connection error (%s): %s", name, e)
+            finally:
+                if name:
+                    await self_._on_socket_drop(name, ws, clean=clean)
+
+    # ── registration + resume ─────────────────────────────────────────
+
+    async def _register(self, ws, msg: protocol.Register) -> Tuple[bool, Optional[str]]:
+        """Handle a ``register`` frame; returns ``(ok, name)``.
+
+        Mints a ``resume_key`` on first registration; a reconnect presenting
+        the key **replaces** the stale socket; a same-name register without it
+        is rejected while the old registration is live or within grace.
+        """
+        identity = msg.identity
+        name     = identity.name
+
+        # Token gate.
+        if self._auth_enabled and not utils.tokens_match(
+                identity.credential, self._token):
+            log.warning("[Broker] register with missing/invalid token: %s", name)
+            await self._send(ws, self._ack(False, '', reason='invalid-credential'))
+            return False, None
+
+        # Reserved name.
+        if name == BROKER_NAME:
+            await self._send(ws, self._ack(False, '', reason='name-reserved'))
+            return False, None
+
+        self._prof.prof('broker_register', uid=name)
+
+        if name in self.registry:
+            # Name occupied (present or suspect-within-grace): require the key.
+            if identity.resume_key and utils.tokens_match(
+                    identity.resume_key, self._resume_keys.get(name)):
+                self._prof.prof('broker_resume', uid=name)
+                old = self.registry[name]
+                self.registry[name] = ws                  # install new first
+                self._cancel_grace(name)
+                self._liveness[name] = 'present'
+                self._participants[name]['role'] = msg.role
+                self._participants[name]['plugins'] = \
+                    self._plugins_list_to_dict(msg.plugins)
+                self._events.restart_sender(name)
+                await self._send(ws, self._ack(True, self._resume_keys[name]))
+                # Close the old socket; its teardown no-ops via the guard.
+                if old is not ws:
+                    spawn(self._close_quiet(old), 'broker_close_old')
+                # Broadcast reaches the resumed endpoint too (full topology).
+                await self._broadcast_topology()
+                return True, name
+
+            log.warning("[Broker] name-in-use (no/invalid resume_key): %s", name)
+            await self._send(ws, self._ack(False, '', reason='name-in-use'))
+            return False, None
+
+        # Fresh registration.
+        key = protocol.mint_id()
+        self.registry[name]       = ws
+        self._resume_keys[name]   = key
+        self._liveness[name]      = 'present'
+        self._participants[name]  = {
+            'role':    msg.role,
+            'plugins': self._plugins_list_to_dict(msg.plugins),
+        }
+        self._events.add_endpoint(name)
+
+        await self._send(ws, self._ack(True, key))
+        # Broadcast reaches the newcomer too — its full-topology snapshot.
+        await self._broadcast_topology()
+        return True, name
+
+    def _ack(self, ok: bool, resume_key: str,
+             reason: Optional[str] = None) -> bytes:
+        return protocol.pack_message(protocol.RegisterAck(
+            src=BROKER_NAME, ok=ok, reason=reason, resume_key=resume_key),
+            cap=self._frame_cap)
+
+    # ── frame routing (the lean loop) ─────────────────────────────────
+
+    async def _route_frame(self, name: str, data: bytes) -> None:
+        """Dispatch one inbound frame.  Pure msgpack dict ops — the measured
+        fast path never builds a pydantic model on the forwarding path."""
+        raw  = msgpack.unpackb(data, raw=False)
+        kind = raw.get('kind')
+
+        if   kind == 'request':      await self._route_request(name, raw)
+        elif kind == 'response':     await self._route_response(name, raw)
+        elif kind == 'event':        self._events.ingest(name, raw)
+        elif kind == 'subscribe':    self._events.update_subscription(name, raw, True)
+        elif kind == 'unsubscribe':  self._events.update_subscription(name, raw, False)
+        elif kind == 'control':      await self._handle_control(name, raw)
+        elif kind == 'register':
+            log.warning("[Broker] unexpected mid-stream register from %s", name)
+        else:
+            log.debug("[Broker] unknown frame kind %r from %s", kind, name)
+
+    async def _route_request(self, src_name: str, raw: dict) -> None:
+        # Never trust a client-supplied src — overwrite with the sender's
+        # registered name (plan security decision).
+        raw['src'] = src_name
+        dst        = raw.get('dst')
+        corr_id    = raw.get('corr_id')
+        self._prof.prof('broker_route_request', uid=corr_id or '',
+                        msg='%s->%s' % (src_name, dst))
+
+        if dst == BROKER_NAME:
+            spawn(self._dispatch_to_host(src_name, raw), 'broker_host_dispatch')
+            return
+
+        target = self.registry.get(dst)
+        if target is None:
+            await self._send(self.registry.get(src_name),
+                             self._error_response(raw, 502,
+                                                  f"endpoint {dst!r} unknown"))
+            return
+
+        self._inflight[corr_id] = (src_name, dst)
+        await self._send(target, msgpack.packb(raw, use_bin_type=True))
+
+    async def _route_response(self, src_name: str, raw: dict) -> None:
+        corr_id = raw.get('corr_id')
+        dst     = raw.get('dst')
+        self._inflight.pop(corr_id, None)
+        self._prof.prof('broker_route_response', uid=corr_id or '',
+                        msg='%s->%s' % (src_name, dst))
+
+        if dst == BROKER_NAME:
+            self._resolve_pending(corr_id, raw)
+            return
+        target = self.registry.get(dst)
+        if target is not None:
+            await self._send(target, msgpack.packb(raw, use_bin_type=True))
+
+    # ── broker-as-caller (pending table) ──────────────────────────────
+
+    async def _broker_call(self, dst: str, method: str, path: str, *,
+                           body:    bytes,
+                           headers: Optional[Dict[str, str]],
+                           timeout: Optional[float]) -> Dict[str, Any]:
+        # Per-src pending cap — overflow raises synchronously at the caller.
+        if len(self.pending) >= self._pending_cap:
+            raise RuntimeError(
+                f"broker pending table at cap ({self._pending_cap}): too many "
+                "in-flight calls")
+
+        req     = protocol.make_request(BROKER_NAME, dst, method, path,
+                                        headers=headers, body=body)
+        corr_id = req.corr_id
+        target  = self.registry.get(dst)
+        if target is None:
+            raise RuntimeError(f"endpoint {dst!r} unknown")
+
+        fut = self._loop.create_future()
+        self.pending[corr_id]  = fut
+        self._inflight[corr_id] = (BROKER_NAME, dst)
+        try:
+            await self._send(target, protocol.pack_message(req, cap=self._frame_cap))
+            return await asyncio.wait_for(fut, timeout=timeout)
+        except Exception:
+            self.pending.pop(corr_id, None)
+            self._inflight.pop(corr_id, None)
+            raise
+
+    def _resolve_pending(self, corr_id: str, resp: Dict[str, Any]) -> None:
+        fut = self.pending.pop(corr_id, None)
+        if fut is not None and not fut.done():
+            fut.set_result(resp)
+
+    # ── hosted-plugin host dispatch (across the thread boundary) ──────
+
+    async def _dispatch_to_host(self, src_name: str, raw: dict) -> None:
+        """Route a ``dst='broker'`` request into the host and reply."""
+        status  = 502
+        headers : Dict[str, str] = {}
+        body    : bytes          = b''
+        if self._host is None:
+            body = json.dumps({"error": True, "detail": "no broker host"}).encode()
+            status = 503
+        else:
+            try:
+                query = ''
+                path  = raw.get('path', '/')
+                if '?' in path:
+                    path, query = path.split('?', 1)
+                cfut = asyncio.run_coroutine_threadsafe(
+                    self._host.handle_request(
+                        method       = raw.get('method', 'GET'),
+                        path         = path,
+                        headers      = raw.get('headers', {}),
+                        body_bytes   = self._as_bytes(raw.get('body', b'')),
+                        query_string = query),
+                    self._host_loop)
+                resp    = await asyncio.wrap_future(cfut)
+                status  = resp.status_code
+                headers = dict(resp.headers)
+                body    = bytes(resp.body)
+            except HTTPException as e:
+                status = e.status_code
+                body   = json.dumps({"error": True, "detail": e.detail}).encode()
+            except Exception as e:
+                log.exception("[Broker] host dispatch failed: %s", e)
+                status = 500
+                body   = json.dumps({"error": True, "detail": str(e)}).encode()
+
+        out = protocol.Response(src=BROKER_NAME, dst=src_name, status=status,
+                                headers={k: v for k, v in headers.items()},
+                                body=body, corr_id=raw.get('corr_id'))
+        target = self.registry.get(src_name)
+        if target is not None:
+            await self._send(target, protocol.pack_message(out, cap=self._frame_cap))
+
+    def _host_broadcast(self, topic: str, data: dict):
+        """``broadcast_fn`` handed to :class:`BridgePluginHost`.
+
+        A hosted plugin's notification becomes a broker ``event`` fanned out on
+        the routing loop; topology pings just trigger a rebroadcast.  Runs on
+        the host loop, so the ingest is scheduled onto the routing loop.
+        """
+        async def _noop() -> None:
+            return
+        if self._loop is None:
+            return _noop()
+        if topic == 'notification':
+            raw = {
+                'kind':    'event',
+                'version': protocol.PROTOCOL_VERSION,
+                'src':     BROKER_NAME,
+                'plugin':  data.get('plugin'),
+                'topic':   data.get('topic'),
+                'session': None,
+                'ts':      0.0,
+                'seq':     0,
+                'data':    data.get('data') or {},
+            }
+            self._loop.call_soon_threadsafe(
+                self._events.ingest, BROKER_NAME, raw)
+        return _noop()
+
+    # ── control ───────────────────────────────────────────────────────
+
+    async def _handle_control(self, name: str, raw: dict) -> None:
+        op = raw.get('op')
+        if op == 'terminate':
+            # Process floor: self-SIGTERM (uvicorn's own handler stops it),
+            # mirroring bridge.terminate_bridge.
+            log.info("[Broker] terminate requested by %s", name)
+            spawn(self._delayed_terminate(), 'broker_terminate')
+        elif op == 'disconnect':
+            target = (raw.get('data') or {}).get('name')
+            if target:
+                await self._disconnect(target)
+
+    async def _delayed_terminate(self) -> None:
+        await asyncio.sleep(0.5)
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    async def _disconnect(self, target: str) -> None:
+        """Operator disconnect: clean close skips suspect (immediate removal)."""
+        ws = self.registry.get(target)
+        if ws is None:
+            return
+        self._remove_participant(target)
+        await self._broadcast_topology()
+        spawn(self._close_quiet(ws), 'broker_disconnect_close')
+
+    # ── liveness ──────────────────────────────────────────────────────
+
+    async def _on_socket_drop(self, name: str, ws, clean: bool = False) -> None:
+        """Teardown guard (M0 lesson #2): a replaced socket's handler fires its
+        ``finally`` after resume installed the new socket — proceed only if
+        this socket is still the live one."""
+        if self.registry.get(name) is not ws:
+            log.debug("[Broker] stale socket drop for %s ignored (replaced)", name)
+            return
+
+        if clean:
+            # A clean close skips suspect — immediate removal + broadcast.
+            self._remove_participant(name)
+            await self._broadcast_topology()
+            return
+
+        self._prof.prof('broker_suspect', uid=name)
+        self._liveness[name] = 'suspect'
+        # Pause event delivery on the dead socket; buffered events survive.
+        self._events.pause_sender(name)
+        await self._broadcast_topology()
+        self._arm_grace(name, ws)
+
+    def _arm_grace(self, name: str, ws) -> None:
+        self._cancel_grace(name)
+        self._grace_timers[name] = self._loop.call_later(
+            self._grace, self._fire_lost, name, ws)
+
+    def _cancel_grace(self, name: str) -> None:
+        t = self._grace_timers.pop(name, None)
+        if t is not None:
+            t.cancel()
+
+    def _fire_lost(self, name: str, ws) -> None:
+        self._grace_timers.pop(name, None)
+        spawn(self._on_lost(name, ws), 'broker_lost:%s' % name)
+
+    async def _on_lost(self, name: str, ws) -> None:
+        # Same guard on the lost path.
+        if self.registry.get(name) is not ws:
+            return
+
+        # Loop-lag watchdog: if the routing loop was blind (stalled) we must
+        # not mass-declare lost on resumption — re-arm and log instead.
+        if self._clock() < self._suppress_until:
+            log.warning("[Broker] watchdog window: suppressing lost for %s", name)
+            self._arm_grace(name, ws)
+            return
+
+        self._prof.prof('broker_lost', uid=name)
+        self._remove_participant(name)
+        await self._fail_inflight_for(name)
+        await self._broadcast_topology()
+
+    async def _fail_inflight_for(self, name: str) -> None:
+        """Fast-fail every inflight entry touching *name* (M0 lesson #1).
+
+        A ``dst==name`` entry becomes a synthesized 504: broker-owned entries
+        resolve their pending future, endpoint-owned entries get the 504 sent
+        to the requester.  A ``src==name`` entry (the requester itself is gone)
+        is simply dropped — its response would go nowhere.
+        """
+        for corr_id, (src, dst) in list(self._inflight.items()):
+            if dst == name:
+                self._inflight.pop(corr_id, None)
+                if src == BROKER_NAME:
+                    self._resolve_pending(corr_id, {
+                        'kind': 'response', 'status': 504,
+                        'src': name, 'dst': BROKER_NAME, 'corr_id': corr_id,
+                        'headers': {}, 'body': b'', 'is_binary': False,
+                        'reason': 'endpoint lost'})
+                else:
+                    target = self.registry.get(src)
+                    if target is not None:
+                        out = protocol.Response(
+                            src=name, dst=src, status=504,
+                            body=b'endpoint lost', corr_id=corr_id)
+                        await self._send(target, protocol.pack_message(
+                            out, cap=self._frame_cap))
+            elif src == name:
+                # Requester gone — the response would go nowhere; drop it.
+                self._inflight.pop(corr_id, None)
+
+    def _remove_participant(self, name: str) -> None:
+        """Free name + resume_key + meta + delivery machinery (no broadcast)."""
+        self.registry.pop(name, None)
+        self._participants.pop(name, None)
+        self._liveness.pop(name, None)
+        self._resume_keys.pop(name, None)
+        self._cancel_grace(name)
+        self._events.remove_endpoint(name)
+
+    # ── loop-lag watchdog ─────────────────────────────────────────────
+
+    async def _watchdog(self) -> None:
+        """Measure routing-loop drift; open a suppression window on a stall."""
+        last = self._clock()
+        while self._started:
+            try:
+                await asyncio.sleep(self._watchdog_interval)
+            except asyncio.CancelledError:
+                return
+            last = self._watchdog_check(last, self._clock())
+
+    def _watchdog_check(self, last: float, now: float) -> float:
+        """One drift sample (factored out so tests can drive it with a fake
+        clock).  A drift beyond the heartbeat budget opens the window during
+        which ``lost`` declarations become log-only re-arms."""
+        drift = (now - last) - self._watchdog_interval
+        if drift > self._ping_timeout:
+            self._suppress_until = now + self._ping_timeout + self._grace
+            log.warning("[Broker] routing-loop stall %.2fs — suppressing lost",
+                        drift)
+        return now
+
+    # ── topology ──────────────────────────────────────────────────────
+
+    def _participants_for_topology(self) -> Dict[str, protocol.ParticipantInfo]:
+        parts: Dict[str, protocol.ParticipantInfo] = {}
+        for name, info in self._participants.items():
+            parts[name] = protocol.ParticipantInfo(
+                role=info.get('role', 'endpoint'),
+                plugins=info.get('plugins', {}),
+                liveness=self._liveness.get(name, 'present'))
+        # The broker is itself a participant (its hosted-plugin host).
+        broker_plugins: Dict[str, Dict[str, Any]] = {}
+        if self._host is not None:
+            broker_plugins = self._host.get_topology_info().get('plugins', {})
+        parts[BROKER_NAME] = protocol.ParticipantInfo(
+            role='broker', plugins=broker_plugins, liveness='present')
+        return parts
+
+    def _build_topology_msg(self) -> bytes:
+        topo = protocol.Topology(src=BROKER_NAME,
+                                 participants=self._participants_for_topology())
+        return protocol.pack_message(topo, cap=self._frame_cap)
+
+    async def _broadcast_topology(self) -> None:
+        packed = self._build_topology_msg()
+        for name, ws in list(self.registry.items()):
+            await self._send(ws, packed)
+
+    # ── low-level helpers ─────────────────────────────────────────────
+
+    async def _send(self, ws, data: bytes) -> None:
+        if ws is None:
+            return
+        try:
+            await ws.send_bytes(data)
+        except Exception as e:
+            log.debug("[Broker] send failed: %s", e)
+
+    @staticmethod
+    async def _close_quiet(ws) -> None:
+        try:    await ws.close(code=1000)
+        except Exception:
+            pass
+
+    def _error_response(self, req_raw: dict, status: int, detail: str) -> bytes:
+        out = protocol.Response(
+            src=BROKER_NAME, dst=req_raw.get('src'), status=status,
+            headers={'content-type': 'application/json'},
+            body=json.dumps({"error": True, "status_code": status,
+                             "detail": detail}).encode(),
+            corr_id=req_raw.get('corr_id'))
+        return protocol.pack_message(out, cap=self._frame_cap)
+
+    @staticmethod
+    def _as_bytes(body) -> bytes:
+        if isinstance(body, bytes):
+            return body
+        if isinstance(body, str):
+            return body.encode()
+        return b''
+
+    @staticmethod
+    def _plugins_list_to_dict(plugins: List[Dict[str, Any]]
+                              ) -> Dict[str, Dict[str, Any]]:
+        """Normalise ``register.plugins`` (a list of per-plugin dicts) into the
+        topology's name-keyed rich dict.  Each entry names itself via ``name``
+        or ``type``; anonymous entries fall back to positional keys."""
+        out: Dict[str, Dict[str, Any]] = {}
+        for i, p in enumerate(plugins or []):
+            key = p.get('name') or p.get('type') or 'plugin.%d' % i
+            out[key] = p
+        return out

--- a/src/radical/orbit/broker_events.py
+++ b/src/radical/orbit/broker_events.py
@@ -1,0 +1,212 @@
+"""Broker live-event delivery + subscription machinery.
+
+Factored out of :mod:`radical.orbit.broker` so the routing loop's core stays
+lean and readable.  :class:`EventRouter` owns everything about *events*: the
+per-endpoint subscription interest sets, the broker-assigned ``seq``/``ts``
+stamping, the per-subscriber bounded (drop-oldest) delivery queues with their
+dedicated sender tasks, and the unfiltered raw tap.
+
+Design guarantees carried from the plan:
+
+* A slow subscriber can never backpressure the routing loop or other
+  subscribers — enqueue is non-blocking; overflow drops the *oldest* frame and
+  bumps a per-subscriber counter so the consumer sees the loss as a ``seq`` gap.
+* ``seq`` is broker-assigned and frozen with the envelope: monotone per session
+  for session-scoped events, monotone per the global stream otherwise.
+* The raw tap sees *every* event (stateless, unfiltered) and runs on the
+  plugin-host loop — never the routing loop.
+"""
+
+import asyncio
+import logging
+import time
+
+from collections import deque
+from typing      import Any, Callable, Dict, List, Optional
+
+import msgpack
+
+from . import protocol
+
+
+log = logging.getLogger("radical.orbit.broker")
+
+
+class _OutQueue:
+    """A per-endpoint bounded, drop-oldest event delivery queue."""
+
+    __slots__ = ('buf', 'dropped', 'wake')
+
+    def __init__(self, maxlen: int):
+        self.buf     : deque         = deque(maxlen=maxlen)
+        self.dropped : int           = 0
+        self.wake    : asyncio.Event = asyncio.Event()
+
+    def push(self, data: bytes) -> None:
+        if len(self.buf) == self.buf.maxlen:
+            self.dropped += 1                  # deque drops the oldest on append
+        self.buf.append(data)
+        self.wake.set()
+
+
+class EventRouter:
+    """Owns the broker's subscription registry + event delivery.
+
+    Args:
+      registry:   the broker's live ``name -> transport`` dict (shared ref).
+      spawn:      the broker's supervised-task creator.
+      prof:       the broker's profiler (``broker_event_*`` sites).
+      event_queue: per-subscriber delivery queue depth.
+      host_loop_getter: returns the plugin-host loop (taps run there).
+    """
+
+    def __init__(self, registry: Dict[str, Any], spawn: Callable,
+                 prof, event_queue: int,
+                 host_loop_getter: Callable[[], Optional[asyncio.AbstractEventLoop]]):
+        self._registry    = registry
+        self._spawn       = spawn
+        self._prof        = prof
+        self._event_queue = event_queue
+        self._host_loop   = host_loop_getter
+
+        self._subscriptions: Dict[str, List[protocol.SubscribePattern]] = {}
+        self._out:           Dict[str, _OutQueue]    = {}
+        self._senders:       Dict[str, asyncio.Task] = {}
+        self._session_seq:   Dict[str, int]          = {}
+        self._global_seq:    int                     = 0
+        self._taps:          list                    = []
+
+    # ── endpoint lifecycle ────────────────────────────────────────────
+
+    def add_endpoint(self, name: str) -> None:
+        self._subscriptions.setdefault(name, [])
+        self._out[name] = _OutQueue(self._event_queue)
+        self.restart_sender(name)
+
+    def remove_endpoint(self, name: str) -> None:
+        self._subscriptions.pop(name, None)
+        self._out.pop(name, None)
+        self.pause_sender(name)
+        self._senders.pop(name, None)
+
+    def pause_sender(self, name: str) -> None:
+        s = self._senders.get(name)
+        if s and not s.done():
+            s.cancel()
+
+    def restart_sender(self, name: str) -> None:
+        self.pause_sender(name)
+        self._senders[name] = self._spawn(self._sender(name),
+                                          'broker_sender:%s' % name)
+
+    async def _sender(self, name: str) -> None:
+        oq = self._out.get(name)
+        if oq is None:
+            return
+        while True:
+            await oq.wake.wait()
+            oq.wake.clear()
+            while oq.buf:
+                data = oq.buf.popleft()
+                ws   = self._registry.get(name)
+                if ws is None:
+                    return
+                try:
+                    await ws.send_bytes(data)
+                except Exception as e:
+                    log.debug("[Broker] event send to %s failed: %s", name, e)
+                    return
+
+    def dropped(self, name: str) -> int:
+        oq = self._out.get(name)
+        return oq.dropped if oq else 0
+
+    # ── subscriptions ─────────────────────────────────────────────────
+
+    def update_subscription(self, name: str, raw: dict, add: bool) -> None:
+        patterns = [protocol.SubscribePattern(**p)
+                    for p in raw.get('patterns', [])]
+        cur = self._subscriptions.setdefault(name, [])
+        if add:
+            cur.extend(patterns)
+        else:
+            for p in patterns:
+                if p in cur:
+                    cur.remove(p)
+
+    @staticmethod
+    def _matches(patterns: List[protocol.SubscribePattern],
+                 endpoint: str, plugin: Optional[str],
+                 topic: Optional[str]) -> bool:
+        for p in patterns:
+            if p.endpoint is not None and p.endpoint != endpoint:
+                continue
+            if p.plugin   is not None and p.plugin   != plugin:
+                continue
+            if p.topic    is not None and p.topic    != topic:
+                continue
+            return True
+        return False
+
+    # ── raw tap ───────────────────────────────────────────────────────
+
+    def tap(self, callback: Callable[[Dict[str, Any]], Any]) -> Callable[[], None]:
+        self._taps.append(callback)
+
+        def _remove() -> None:
+            try:    self._taps.remove(callback)
+            except ValueError:
+                pass
+        return _remove
+
+    def _dispatch_tap(self, cb: Callable, event: Dict[str, Any]) -> None:
+        loop = self._host_loop()
+        if loop is None:
+            return
+
+        async def _run() -> None:
+            try:
+                res = cb(event)
+                if asyncio.iscoroutine(res):
+                    await res
+            except Exception as e:
+                log.error("[Broker] tap callback failed: %r", e, exc_info=e)
+
+        asyncio.run_coroutine_threadsafe(_run(), loop)
+
+    # ── ingest ────────────────────────────────────────────────────────
+
+    def ingest(self, src_name: str, raw: dict) -> None:
+        """Stamp ``seq``/``ts``, fan out to matching subscribers, feed the tap.
+
+        Runs on the routing loop; every step is a dict op or a non-blocking
+        enqueue, so a storm never stalls routing.
+        """
+        raw['src'] = src_name
+        session    = raw.get('session')
+        if session:
+            seq = self._session_seq.get(session, 0)
+            self._session_seq[session] = seq + 1
+            raw['seq'] = seq
+        else:
+            raw['seq'] = self._global_seq
+            self._global_seq += 1
+        if not raw.get('ts'):
+            raw['ts'] = time.time()
+
+        self._prof.prof('broker_event_in', uid=str(raw['seq']),
+                        msg='%s/%s' % (raw.get('plugin'), raw.get('topic')))
+
+        packed = msgpack.packb(raw, use_bin_type=True)
+        plugin = raw.get('plugin')
+        topic  = raw.get('topic')
+        for sub_name, patterns in self._subscriptions.items():
+            if self._matches(patterns, src_name, plugin, topic):
+                oq = self._out.get(sub_name)
+                if oq is not None:
+                    oq.push(packed)
+                    self._prof.prof('broker_event_out', uid=str(raw['seq']),
+                                    msg=sub_name)
+
+        for cb in list(self._taps):
+            self._dispatch_tap(cb, dict(raw))

--- a/tests/unittests/test_broker.py
+++ b/tests/unittests/test_broker.py
@@ -1,0 +1,779 @@
+"""Tests for :class:`radical.orbit.broker.Broker` (M3 broker core).
+
+The suite drives the broker two ways, matching how the code is reached in
+production:
+
+* Through its app with the Starlette ``TestClient`` (register handshake +
+  token gate over a real WS), and
+* By direct method calls with a lightweight ``FakeWS`` where timing/teardown
+  can't be expressed through the client (drop/grace/watchdog).
+
+No test sleeps for more than ~1 s; liveness knobs are injected tiny.
+"""
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from starlette.websockets import WebSocketDisconnect
+from fastapi.testclient   import TestClient
+
+from radical.orbit import protocol
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+import subprocess
+
+
+def _have_openssl() -> bool:
+    try:
+        subprocess.run(['openssl', 'version'], check=True, capture_output=True)
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+@pytest.fixture
+def self_signed(tmp_path):
+    if not _have_openssl():
+        pytest.skip("openssl not available")
+    import os
+    cert = tmp_path / 'cert.pem'
+    key  = tmp_path / 'key.pem'
+    subprocess.run(
+        ['openssl', 'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+         '-keyout', str(key), '-out', str(cert),
+         '-days', '1', '-subj', '/CN=localhost'],
+        check=True, capture_output=True)
+    os.chmod(key, 0o600)
+    return cert, key
+
+
+@pytest.fixture
+def make_broker(self_signed, tmp_path, monkeypatch):
+    """Factory: build a Broker with tmp resolver paths and tiny timers.
+
+    Returns the *unstarted* broker — direct-method tests call
+    ``await broker.startup()`` / ``await broker.shutdown()`` themselves so
+    they own the loop; TestClient tests let the app lifespan do it.
+    """
+    from radical.orbit import utils
+    monkeypatch.setattr(utils, 'URL_FILE',   tmp_path / 'bridge.url')
+    monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'bridge.token')
+
+    cert, key = self_signed
+
+    def _build(**kwargs):
+        from radical.orbit.broker import Broker
+        defaults = dict(cert=str(cert), key=str(key), no_auth=True,
+                        grace=0.05, ping_timeout=0.05, watchdog_interval=0.02)
+        defaults.update(kwargs)
+        return Broker(**defaults)
+
+    return _build
+
+
+class FakeWS:
+    """A minimal transport stand-in: records sent frames, notes a close."""
+
+    def __init__(self):
+        self.sent   = []
+        self.closed = None
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.sent.append(data)
+
+    async def close(self, code: int = 1000) -> None:
+        self.closed = code
+
+    def msgs(self):
+        return [protocol.parse_message(d) for d in self.sent]
+
+
+def _register_msg(name, plugins=None, credential=None, resume_key=None,
+                  role='endpoint'):
+    return protocol.Register(
+        src=name, role=role, plugins=plugins or [],
+        identity=protocol.Identity(name=name, credential=credential,
+                                   resume_key=resume_key))
+
+
+async def _register(broker, name, ws, **kw):
+    return await broker._register(ws, _register_msg(name, **kw))
+
+
+def _event_bytes(src, plugin, topic, session=None, data=None):
+    ev = protocol.Event(src=src, plugin=plugin, topic=topic, session=session,
+                        ts=0.0, seq=0, data=data or {})
+    return protocol.pack_message(ev)
+
+
+def _subscribe_bytes(src, patterns):
+    sub = protocol.Subscribe(
+        src=src, patterns=[protocol.SubscribePattern(**p) for p in patterns])
+    return protocol.pack_message(sub)
+
+
+# ---------------------------------------------------------------------------
+# Registration + topology (TestClient — real WS handshake)
+# ---------------------------------------------------------------------------
+
+def test_register_happy_path_ack_and_topology(make_broker):
+    broker = make_broker()
+    with TestClient(broker.app) as client:
+        with client.websocket_connect("/register") as ws:
+            ws.send_bytes(protocol.pack_message(
+                _register_msg("e1", plugins=[{"name": "sysinfo"}])))
+
+            ack = protocol.parse_message(ws.receive_bytes())
+            assert ack.kind == 'register_ack'
+            assert ack.ok is True
+            assert ack.resume_key           # minted, non-empty
+
+            topo = protocol.parse_message(ws.receive_bytes())
+            assert topo.kind == 'topology'
+            assert 'e1'     in topo.participants
+            assert 'broker' in topo.participants           # broker is a participant
+            assert topo.participants['e1'].liveness == 'present'
+            assert 'sysinfo' in topo.participants['e1'].plugins
+
+
+def test_first_frame_not_register_is_rejected(make_broker):
+    broker = make_broker()
+    with TestClient(broker.app) as client:
+        with client.websocket_connect("/register") as ws:
+            # An event as the first frame -> handler returns -> socket closes.
+            ws.send_bytes(_event_bytes("e1", "p", "t"))
+            with pytest.raises(WebSocketDisconnect):
+                ws.receive_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Token gate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_token_gate_rejects_bad_and_missing(make_broker):
+    broker = make_broker(no_auth=False, token='sekret')
+    await broker.startup()
+    try:
+        ws_bad = FakeWS()
+        ok, name = await _register(broker, 'e1', ws_bad, credential='wrong')
+        assert ok is False and name is None
+        assert ws_bad.msgs()[0].reason == 'invalid-credential'
+
+        ws_missing = FakeWS()
+        ok, _ = await _register(broker, 'e1', ws_missing, credential=None)
+        assert ok is False
+
+        ws_good = FakeWS()
+        ok, name = await _register(broker, 'e1', ws_good, credential='sekret')
+        assert ok is True and name == 'e1'
+        assert broker.registry['e1'] is ws_good
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_auth_disabled_accepts_no_credential(make_broker):
+    broker = make_broker(no_auth=True)
+    await broker.startup()
+    try:
+        ws = FakeWS()
+        ok, name = await _register(broker, 'e1', ws, credential=None)
+        assert ok is True and name == 'e1'
+    finally:
+        await broker.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Resume key: replace vs name-in-use
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_resume_key_replaces_and_old_socket_teardown_noops(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        ws1 = FakeWS()
+        ok, _ = await _register(broker, 'e1', ws1)
+        key = protocol.parse_message(ws1.sent[0]).resume_key
+
+        ws2 = FakeWS()
+        ok, _ = await _register(broker, 'e1', ws2, resume_key=key)
+        assert ok is True
+        assert broker.registry['e1'] is ws2
+        await asyncio.sleep(0)                 # let the old-socket close run
+        assert ws1.closed == 1000
+
+        # The replaced socket's teardown must no-op via the guard.
+        await broker._on_socket_drop('e1', ws1, clean=False)
+        assert broker.registry['e1'] is ws2
+        assert broker._liveness['e1'] == 'present'
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_keyless_reregister_within_grace_is_name_in_use(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        ws1 = FakeWS()
+        await _register(broker, 'e1', ws1)
+
+        ws2 = FakeWS()
+        ok, name = await _register(broker, 'e1', ws2)     # no resume_key
+        assert ok is False and name is None
+        assert protocol.parse_message(ws2.sent[0]).reason == 'name-in-use'
+        assert broker.registry['e1'] is ws1
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_name_frees_after_lost_and_new_key_minted(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        ws1 = FakeWS()
+        await _register(broker, 'e1', ws1)
+        key1 = protocol.parse_message(ws1.sent[0]).resume_key
+
+        await broker._on_socket_drop('e1', ws1, clean=False)   # -> suspect
+        broker._fire_lost('e1', ws1)                           # -> lost
+        await asyncio.sleep(0)
+        assert 'e1' not in broker.registry
+
+        ws2 = FakeWS()
+        ok, _ = await _register(broker, 'e1', ws2)             # fresh, no key
+        assert ok is True
+        key2 = protocol.parse_message(ws2.sent[0]).resume_key
+        assert key2 and key2 != key1
+    finally:
+        await broker.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Request / response routing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_request_routing_overwrites_client_src(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        ws1, ws2 = FakeWS(), FakeWS()
+        await _register(broker, 'e1', ws1)
+        await _register(broker, 'e2', ws2)
+        ws2.sent.clear()
+
+        # Client lies about src; broker must overwrite it with 'e1'.
+        req = protocol.make_request('LIAR', 'e2', 'GET', '/x')
+        await broker._route_frame('e1', protocol.pack_message(req))
+
+        fwd = ws2.msgs()[0]
+        assert fwd.kind == 'request'
+        assert fwd.src  == 'e1'                          # overwritten
+        assert broker._inflight[req.corr_id] == ('e1', 'e2')
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_request_to_unknown_dst_gets_502(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        ws1 = FakeWS()
+        await _register(broker, 'e1', ws1)
+        ws1.sent.clear()
+
+        req = protocol.make_request('e1', 'ghost', 'GET', '/x')
+        await broker._route_frame('e1', protocol.pack_message(req))
+
+        resp = ws1.msgs()[0]
+        assert resp.kind == 'response' and resp.status == 502
+        assert resp.corr_id == req.corr_id
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_response_forwards_to_peer(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        ws1, ws2 = FakeWS(), FakeWS()
+        await _register(broker, 'e1', ws1)
+        await _register(broker, 'e2', ws2)
+
+        req = protocol.make_request('e1', 'e2', 'GET', '/x')
+        await broker._route_frame('e1', protocol.pack_message(req))
+        ws1.sent.clear()
+
+        resp = protocol.Response(src='e2', dst='e1', status=200,
+                                corr_id=req.corr_id, body=b'ok')
+        await broker._route_frame('e2', protocol.pack_message(resp))
+
+        got = ws1.msgs()[0]
+        assert got.kind == 'response' and got.status == 200
+        assert req.corr_id not in broker._inflight        # inflight popped
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_response_to_broker_resolves_pending(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        ws2 = FakeWS()
+        await _register(broker, 'e2', ws2)
+        ws2.sent.clear()
+
+        task = asyncio.ensure_future(broker.caller.call('e2', 'GET', '/p'))
+        await asyncio.sleep(0)                            # let call() send
+        sent = ws2.msgs()[0]
+        assert sent.kind == 'request' and sent.src == 'broker'
+
+        resp = protocol.Response(src='e2', dst='broker', status=201,
+                                corr_id=sent.corr_id, body=b'done')
+        await broker._route_frame('e2', protocol.pack_message(resp))
+        out = await asyncio.wait_for(task, timeout=1.0)
+        assert out['status'] == 201
+    finally:
+        await broker.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Fast-fail on lost
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_lost_fastfails_endpoint_and_broker_inflight(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        ws1, ws2 = FakeWS(), FakeWS()
+        await _register(broker, 'e1', ws1)
+        await _register(broker, 'e2', ws2)
+
+        # Endpoint-owned inflight: e1 -> e2.
+        req = protocol.make_request('e1', 'e2', 'GET', '/x')
+        await broker._route_frame('e1', protocol.pack_message(req))
+        ws1.sent.clear()
+
+        # Broker-owned inflight: broker -> e2.
+        task = asyncio.ensure_future(broker.caller.call('e2', 'GET', '/y'))
+        await asyncio.sleep(0)
+
+        broker._fire_lost('e2', ws2)                      # e2 declared lost
+        await asyncio.sleep(0)
+
+        got = ws1.msgs()[0]
+        assert got.kind == 'response' and got.status == 504
+        assert got.corr_id == req.corr_id
+
+        out = await asyncio.wait_for(task, timeout=1.0)
+        assert out['status'] == 504
+        assert 'e2' not in broker.registry
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_pending_cap_raises_synchronously(make_broker):
+    broker = make_broker(pending_cap=2)
+    await broker.startup()
+    try:
+        ws2 = FakeWS()
+        await _register(broker, 'e2', ws2)
+        loop = asyncio.get_running_loop()
+        broker.pending['a'] = loop.create_future()
+        broker.pending['b'] = loop.create_future()
+        with pytest.raises(RuntimeError):
+            await broker.caller.call('e2', 'GET', '/x')
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_call_threadsafe_roundtrips(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        ws2 = FakeWS()
+        await _register(broker, 'e2', ws2)
+        ws2.sent.clear()
+
+        holder = {}
+
+        def worker():
+            cfut = broker.caller.call_threadsafe('e2', 'GET', '/p')
+            holder['r'] = cfut.result(timeout=2.0)
+
+        t = threading.Thread(target=worker)
+        t.start()
+
+        # Drive the routing loop until the call has been sent.
+        for _ in range(200):
+            await asyncio.sleep(0.005)
+            if ws2.sent:
+                break
+        sent = ws2.msgs()[0]
+        resp = protocol.Response(src='e2', dst='broker', status=200,
+                                corr_id=sent.corr_id, body=b'k')
+        await broker._route_frame('e2', protocol.pack_message(resp))
+
+        for _ in range(200):
+            await asyncio.sleep(0.005)
+            if 'r' in holder:
+                break
+        t.join(timeout=2.0)
+        assert holder['r']['status'] == 200
+    finally:
+        await broker.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Events: seq stamping, subscribe filtering, backpressure, tap
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_event_seq_stamping_session_and_global(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        cons = FakeWS()
+        await _register(broker, 'c1', cons)
+        broker._events.update_subscription('c1', {'patterns': [{}]}, True)
+        cons.sent.clear()
+
+        await broker._route_frame('e1', _event_bytes('e1', 'p', 't', session='s'))
+        await broker._route_frame('e1', _event_bytes('e1', 'p', 't', session='s'))
+        await broker._route_frame('e1', _event_bytes('e1', 'p', 't'))  # session-less
+        await broker._route_frame('e1', _event_bytes('e1', 'p', 't'))
+        await asyncio.sleep(0.02)
+
+        evs = cons.msgs()
+        per_session = [e.seq for e in evs if e.session == 's']
+        global_seq  = [e.seq for e in evs if e.session is None]
+        assert per_session == [0, 1]
+        assert global_seq  == [0, 1]
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_filtering_exact_wildcard_unsubscribe(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        c_exact, c_wild, c_none = FakeWS(), FakeWS(), FakeWS()
+        await _register(broker, 'c_exact', c_exact)
+        await _register(broker, 'c_wild',  c_wild)
+        await _register(broker, 'c_none',  c_none)
+        broker._events.update_subscription(
+            'c_exact', {'patterns': [{'plugin': 'psij'}]}, True)
+        broker._events.update_subscription(
+            'c_wild', {'patterns': [{}]}, True)
+        for ws in (c_exact, c_wild, c_none):
+            ws.sent.clear()
+
+        await broker._route_frame('e1', _event_bytes('e1', 'psij', 't'))
+        await broker._route_frame('e1', _event_bytes('e1', 'rhapsody', 't'))
+        await asyncio.sleep(0.02)
+
+        assert [e.plugin for e in c_exact.msgs()] == ['psij']
+        assert [e.plugin for e in c_wild.msgs()]  == ['psij', 'rhapsody']
+        assert c_none.sent == []                          # non-subscriber isolated
+
+        # Unsubscribe the wildcard -> no further delivery.
+        broker._events.update_subscription('c_wild', {'patterns': [{}]}, False)
+        c_wild.sent.clear()
+        await broker._route_frame('e1', _event_bytes('e1', 'psij', 't'))
+        await asyncio.sleep(0.02)
+        assert c_wild.sent == []
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_event_queue_drop_oldest_with_counter(make_broker):
+    broker = make_broker(event_queue=2)
+    await broker.startup()
+    try:
+        cons = FakeWS()
+        await _register(broker, 'c1', cons)
+        broker._events.update_subscription('c1', {'patterns': [{}]}, True)
+        # Pause the sender so the bounded queue actually overflows.
+        broker._events.pause_sender('c1')
+
+        for _ in range(4):
+            broker._events.ingest('e1', {
+                'kind': 'event', 'version': protocol.PROTOCOL_VERSION,
+                'src': 'e1', 'plugin': 'p', 'topic': 't',
+                'session': None, 'ts': 0.0, 'seq': 0, 'data': {}})
+
+        assert broker._events.dropped('c1') == 2
+        buf = broker._events._out['c1'].buf
+        seqs = [protocol.parse_message(d).seq for d in buf]
+        assert seqs == [2, 3]                              # oldest two dropped
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_raw_tap_receives_every_event(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        seen = []
+        lock = threading.Lock()
+
+        def _tap(ev):
+            with lock:
+                seen.append(ev['seq'])
+
+        broker.tap(_tap)
+        for _ in range(3):
+            await broker._route_frame('e1', _event_bytes('e1', 'p', 't'))
+
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            with lock:
+                if len(seen) == 3:
+                    break
+            await asyncio.sleep(0.01)
+        with lock:
+            assert sorted(seen) == [0, 1, 2]
+    finally:
+        await broker.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Liveness: clean close, suspect->lost, re-register cancels grace
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_clean_close_skips_suspect(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        ws1 = FakeWS()
+        await _register(broker, 'e1', ws1)
+        await broker._on_socket_drop('e1', ws1, clean=True)
+        assert 'e1' not in broker.registry
+        assert 'e1' not in broker._liveness
+        assert 'e1' not in broker._grace_timers
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_suspect_then_lost_cascade(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        ws1 = FakeWS()
+        await _register(broker, 'e1', ws1)
+
+        await broker._on_socket_drop('e1', ws1, clean=False)
+        assert broker._liveness['e1'] == 'suspect'
+        assert 'e1' in broker.registry
+        assert 'e1' in broker._grace_timers
+
+        broker._fire_lost('e1', ws1)
+        await asyncio.sleep(0)
+        assert 'e1' not in broker.registry
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_reregister_cancels_grace(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        ws1 = FakeWS()
+        await _register(broker, 'e1', ws1)
+        key = protocol.parse_message(ws1.sent[0]).resume_key
+
+        await broker._on_socket_drop('e1', ws1, clean=False)  # suspect + grace
+        assert 'e1' in broker._grace_timers
+
+        ws2 = FakeWS()
+        ok, _ = await _register(broker, 'e1', ws2, resume_key=key)
+        assert ok is True
+        assert 'e1' not in broker._grace_timers
+        assert broker._liveness['e1'] == 'present'
+        assert broker.registry['e1'] is ws2
+    finally:
+        await broker.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Loop-lag watchdog
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_watchdog_suppresses_lost_after_stall(make_broker):
+    clock = {'t': 0.0}
+    broker = make_broker(clock=lambda: clock['t'], ping_timeout=0.05, grace=0.05)
+    await broker.startup()
+    try:
+        ws1 = FakeWS()
+        await _register(broker, 'e1', ws1)
+        await broker._on_socket_drop('e1', ws1, clean=False)
+
+        # Simulate a routing-loop stall: a large drift opens the window.
+        clock['t'] = 100.0
+        broker._watchdog_check(0.0, 100.0)
+        assert broker._suppress_until > clock['t']
+
+        # A lost firing inside the window must be a log-only re-arm.
+        broker._fire_lost('e1', ws1)
+        await asyncio.sleep(0)
+        assert 'e1' in broker.registry
+        assert 'e1' in broker._grace_timers
+
+        # Past the window, lost proceeds normally.
+        clock['t'] = 1000.0
+        broker._fire_lost('e1', ws1)
+        await asyncio.sleep(0)
+        assert 'e1' not in broker.registry
+    finally:
+        await broker.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Control ops
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_control_terminate_self_sigterms(make_broker, monkeypatch):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        import radical.orbit.broker as bmod
+        killed = {}
+        monkeypatch.setattr(bmod.os, 'kill',
+                            lambda pid, sig: killed.setdefault('sig', sig))
+        await broker._handle_control('e1', {'op': 'terminate'})
+        await asyncio.sleep(0.6)
+        assert killed.get('sig') == bmod.signal.SIGTERM
+    finally:
+        await broker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_control_disconnect_removes_target(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        ws1, ws2 = FakeWS(), FakeWS()
+        await _register(broker, 'e1', ws1)
+        await _register(broker, 'e2', ws2)
+
+        await broker._handle_control('e2', {'op': 'disconnect',
+                                            'data': {'name': 'e1'}})
+        await asyncio.sleep(0)
+        assert 'e1' not in broker.registry
+        assert ws1.closed == 1000
+    finally:
+        await broker.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# dst=='broker' host round-trip + config wiring
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dst_broker_routes_into_host(make_broker):
+    from radical.orbit.plugin_base import Plugin
+
+    class _EchoPlugin(Plugin):
+        plugin_name = 'echo_test'
+        version     = '0.0.1'
+
+        def __init__(self, app, instance_name):
+            super().__init__(app, instance_name)
+            self.add_route_get('ping', self._ping)
+
+        async def _ping(self, request):
+            return {'pong': True}
+
+    broker = make_broker()
+    await broker.startup()
+    try:
+        # Register the test plugin onto the host (on the host loop).
+        import asyncio as _a
+        fut = _a.run_coroutine_threadsafe(
+            broker._host.register_dynamic_plugin(_EchoPlugin, 'echo'),
+            broker._host_loop)
+        fut.result(timeout=5.0)
+
+        ws1 = FakeWS()
+        await _register(broker, 'e1', ws1)
+        ws1.sent.clear()
+
+        req = protocol.make_request('e1', 'broker', 'GET', '/echo/ping')
+        await broker._route_frame('e1', protocol.pack_message(req))
+
+        # The host dispatch runs as a supervised background task; await it.
+        for _ in range(200):
+            await asyncio.sleep(0.005)
+            if ws1.sent:
+                break
+        resp = ws1.msgs()[0]
+        assert resp.kind == 'response' and resp.status == 200
+        assert b'pong' in resp.body
+        assert resp.corr_id == req.corr_id
+    finally:
+        await broker.shutdown()
+
+
+def test_run_sets_ws_max_size_and_keepalive_from_config(make_broker,
+                                                        monkeypatch):
+    broker = make_broker(frame_cap=12345, ping_interval=2.5, ping_timeout=7.5)
+    captured = {}
+
+    import uvicorn
+    monkeypatch.setattr(uvicorn, 'run',
+                        lambda app, **kw: captured.update(kw))
+    broker.run()
+
+    assert captured['ws_max_size']      == 12345
+    assert captured['ws_ping_interval'] == 2.5
+    assert captured['ws_ping_timeout']  == 7.5
+
+
+# ---------------------------------------------------------------------------
+# Gateway seam
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_gateway_seam_surface(make_broker):
+    broker = make_broker()
+    await broker.startup()
+    try:
+        ws1 = FakeWS()
+        await _register(broker, 'e1', ws1)
+
+        # The seam attributes/methods a later gateway is handed.
+        assert broker.app is not None
+        assert broker.pending is broker.pending          # pending table
+        assert broker.caller is not None                 # caller handle
+        assert callable(broker.tap)
+        snap = broker.topology_snapshot()
+        assert 'e1' in snap and 'broker' in snap
+        assert snap['e1']['liveness'] == 'present'
+        assert broker.auth_enabled is False              # no_auth=True
+    finally:
+        await broker.shutdown()


### PR DESCRIPTION
Third milestone of `plans/broker_architecture_plan.md` (M3 — broker core), stacked on #65. `broker.py` + `broker_events.py` are new modules alongside the untouched `bridge.py`; `bin/` defaults stay on the old stack (build-alongside).

## What

**`Broker`** — the active hub as switchboard + self-participant (`src='broker'`):

- **Single uvicorn server, single port** (HPC firewall reality): the broker app owns only the token-gated WS `/register`; HTTP catch-all / SSE / Explorer / CORS arrive as the M5 gateway module through a constructor-declared seam (`app`, `pending`, `caller`, `tap()`, `topology_snapshot()`, token config).
- **Keepalive verified**: uvicorn 0.46 + websockets 16 honor server-wide `ws_ping_interval`/`ws_ping_timeout` — a silent client is disconnected at interval+timeout (empirically measured). App-level liveness enforcement is real; no fallback needed. `ws_max_size` = `protocol.FRAME_CAP`.
- **Lean routing loop**: pure msgpack dict ops on the forwarding path (no pydantic). Requests: `src` overwritten from the registered identity (client-supplied src never trusted), `inflight[corr_id]=(src,dst)` recorded, unknown dst → synthesized 502. Responses: broker-pending vs forward fork.
- **Two-stage liveness**: socket drop → `suspect` + grace timer (default 10 s, injectable) → `lost` (name+resume-key freed, every inflight entry to the lost dst fast-failed with synthesized 504s — the M0-validated grace-bounded fast-fail). Clean close skips suspect. Teardown guards (`registry.get(name) is ws`) on **both** drop and lost paths (M0 lesson: replaced sockets must not re-suspect a live participant).
- **Resume keys**: minted at first registration (broker memory only; restart ⇒ first-come re-registration), reconnect presenting the key replaces the live socket (install new → close old, old teardown no-ops), keyless same-name register rejected `name-in-use` while live/within grace.
- **Events** (`broker_events.py`): subscribe registry (exact/wildcard `SubscribePattern`), broker-assigned `seq` (monotone per session / global stream), fan-out only to matching subscribers, per-subscriber **bounded drop-oldest** queues + dropped counters (slow consumer can never block the routing loop), raw tap for in-process subscribers (M5 SSE fan-out, M8 replay).
- **Hosted plugins on their own loop/thread** (transport isolation, broker side): `BridgePluginHost` reused as-is; `dst=='broker'` requests cross via `run_coroutine_threadsafe`; all background tasks created through a supervised `spawn()` helper that logs/reports background-task exceptions. `BrokerCaller.call_threadsafe()` is the in-process caller handle M7's dispatcher consumes.
- **Loop-lag watchdog**: a detected routing-loop stall opens a suppression window during which `lost` declarations re-arm instead of firing ("we were blind", not "they left").
- `control` ops: `terminate` (self-SIGTERM process floor) and `disconnect` (clean immediate removal). `_prof` sites ported with `broker_*` labels.

Also: 2-line latent-bug fix in `bridge_plugin_host.py` — `app.state.direct_routes` is ensured before binding, so an empty host stays attached to the live route list a later dynamic plugin appends to (the code's own "reference the live list, not a copy" contract).

## Known bound (noted, not a bug)

Request-forward and topology sends `await` the socket directly on the routing loop; a pathological TCP-backpressure stall is bounded by transport write buffering and caught by the watchdog. The storm path (events) is fully decoupled through the bounded queues.

## Testing

27 new tests (registration/token gate/resume/replace/reject, routing forks, 502/504 fast-fail, pending cap, cross-thread caller, seq stamping, subscribe filtering, drop-oldest + counter, raw tap, clean-close, suspect→lost, grace cancel, watchdog suppression, terminate/disconnect, host round-trip, config wiring). Timers injectable; no long sleeps.

Full suite: **873 passed, 2 skipped**; `flake8 src/ bin/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)