### PR TITLE
M4: endpoint participant runtime — transport/work loop split, consumer facade

### DIFF
--- a/src/radical/orbit/bridge_plugin_host.py
+++ b/src/radical/orbit/bridge_plugin_host.py
@@ -9,7 +9,7 @@ from starlette.responses import JSONResponse
 
 from radical.orbit.plugin_base      import Plugin
 from radical.orbit.plugin_host_base import PluginHostBase
-from radical.orbit.service          import RequestShim
+from radical.orbit.dispatch         import RequestShim, match_route
 from radical.orbit.ui_schema        import ui_config_to_dict
 
 log = logging.getLogger("radical.orbit.bridge")
@@ -98,12 +98,7 @@ class BridgePluginHost(PluginHostBase):
 
     def match_route(self, method: str, path: str
                     ) -> Tuple[Optional[Callable], Optional[dict]]:
-        for rt_method, pattern, param_names, handler in self._direct_routes:
-            if rt_method == method:
-                m = pattern.match(path)
-                if m:
-                    return handler, dict(zip(param_names, m.groups()))
-        return None, None
+        return match_route(self._direct_routes, method, path)
 
     async def handle_request(self, method: str, path: str,
                              headers: dict, body_bytes: bytes,

--- a/src/radical/orbit/client.py
+++ b/src/radical/orbit/client.py
@@ -598,6 +598,18 @@ class PluginClient:
         """Construct full URL for a path."""
         return f"{self._base_url}/{path.lstrip('/')}"
 
+    def _request(self, method: str, url: str, **kwargs):
+        """Single transport seam for every helper-facing call.
+
+        Dispatches to the matching verb method on ``self._http``
+        (``self._http.post`` / ``.get`` / …) so behaviour is **bit-identical**
+        to the direct ``self._http.post(...)`` calls the 11 plugin helpers
+        make (and the old suite mocks).  The seam is overridable in two ways:
+        swap ``self._http`` for a transport shim (what ``RuntimePluginClient``
+        does), or override this method.
+        """
+        return getattr(self._http, method.lower())(url, **kwargs)
+
     def _raise(self, resp, context: str = '') -> None:
         """Raise RuntimeError with HTTP status, origin, optional context, and server detail."""
         origin = '/'.join(filter(None, [self._endpoint_id, self._plugin_name]))
@@ -624,8 +636,8 @@ class PluginClient:
         if sid      is not None: payload['sid']      = sid
         if lifetime is not None: payload['lifetime'] = lifetime
         if ttl      is not None: payload['ttl']      = ttl
-        resp = self._http.post(self._url("register_session"),
-                               json=payload or None)
+        resp = self._request("POST", self._url("register_session"),
+                             json=payload or None)
         self._raise(resp)
         self._sid = resp.json()['sid']
 
@@ -634,7 +646,8 @@ class PluginClient:
         Unregister the current session.
         """
         if self._sid:
-            resp = self._http.post(self._url(f"unregister_session/{self._sid}"))
+            resp = self._request(
+                "POST", self._url(f"unregister_session/{self._sid}"))
             self._raise(resp)
             self._sid = None
 

--- a/src/radical/orbit/dispatch.py
+++ b/src/radical/orbit/dispatch.py
@@ -1,0 +1,89 @@
+"""Direct-dispatch machinery shared by the endpoint hosts.
+
+Both the WebSocket endpoint (``service.py`` / ``runtime.py``) and the
+broker-hosted plugin host (``bridge_plugin_host.py``) bypass the ASGI/FastAPI
+stack on the hot request path: they match a forwarded request against a plain
+route table and feed the handler a lightweight request stand-in.  The two
+pieces of that fast path live here so every host imports the *same* code:
+
+* :class:`RequestShim`  — a lazy, encoding-agnostic ``starlette.Request``
+  stand-in exposing exactly the surface plugin handlers use
+  (``path_params``, ``query_params``, ``await .body()``, ``await .json()``).
+* :func:`match_route`   — match ``method`` + ``path`` against a compiled
+  direct-dispatch route table (the ``(method, pattern, param_names, handler)``
+  tuples ``Plugin._register_direct`` appends to ``app.state.direct_routes``).
+
+This is a pure extraction — the behaviour is exactly what ``service.py`` and
+``bridge_plugin_host.py`` carried inline before, and the old test suite proves
+the move changed nothing.
+"""
+
+import json
+
+from typing import Callable, List, Optional, Tuple
+
+import msgpack
+
+
+# ---------------------------------------------------------------------------
+# RequestShim — lightweight stand-in for starlette.requests.Request
+# ---------------------------------------------------------------------------
+
+class RequestShim:
+    """Lightweight adapter for starlette ``Request``.
+
+    Provides the three interfaces that every plugin handler uses:
+    ``path_params``, ``query_params``, and ``await .json()`` / ``await .body()``.
+    Encoding-agnostic: stores raw bytes, decodes lazily based on content_type.
+    """
+
+    def __init__(self, path_params : dict,
+                       query_params: dict,
+                       body_bytes  : bytes,
+                       content_type: str = 'application/json'):
+        self.path_params  = path_params
+        self.query_params = query_params
+        self.content_type = content_type
+        self._body        = body_bytes
+        self._decoded     = None
+
+    async def body(self) -> bytes:
+        """Raw body bytes (matches ``Request.body()``)."""
+        return self._body
+
+    async def json(self) -> dict:
+        """Parse body into a Python dict (matches ``Request.json()``).
+
+        Content-type-aware: JSON or msgpack based on Content-Type header.
+        """
+        if self._decoded is not None:
+            return self._decoded
+
+        ct = self.content_type or 'application/json'
+        if 'msgpack' in ct:
+            self._decoded = msgpack.unpackb(self._body, raw=False)
+        else:
+            self._decoded = json.loads(self._body) if self._body else {}
+        return self._decoded
+
+
+# ---------------------------------------------------------------------------
+# route matching
+# ---------------------------------------------------------------------------
+
+def match_route(direct_routes: List[tuple], method: str, path: str
+                ) -> Tuple[Optional[Callable], Optional[dict]]:
+    """Match *method* + *path* against the direct-dispatch route table.
+
+    *direct_routes* is the shared list of
+    ``(method, pattern, param_names, handler)`` tuples that
+    ``Plugin._register_direct`` populates on ``app.state.direct_routes``.
+
+    Returns ``(handler, path_params)`` or ``(None, None)``.
+    """
+    for rt_method, pattern, param_names, handler in direct_routes:
+        if rt_method == method:
+            m = pattern.match(path)
+            if m:
+                return handler, dict(zip(param_names, m.groups()))
+    return None, None

--- a/src/radical/orbit/plugin_rhapsody.py
+++ b/src/radical/orbit/plugin_rhapsody.py
@@ -165,7 +165,15 @@ class RhapsodySession(PluginSession):
                     b = await b
                 backends.append(b)
 
-            self._rh_session = rh.Session(backends=backends, uid=self._sid)
+            # Offload the blocking ``rh.Session`` construction to a worker
+            # thread (the established ``_prepare_batch`` offload pattern) so it
+            # never runs on the work loop.  This is work-loop hygiene, not
+            # liveness-critical: M0 measures Dragon init holding the GIL for
+            # only ~2.8 ms (runtime bring-up releases the GIL), so with
+            # transport isolation the keepalive never depends on this offload —
+            # it just keeps the work loop responsive to other requests.
+            self._rh_session = await asyncio.to_thread(
+                rh.Session, backends=backends, uid=self._sid)
 
             # start_telemetry only exists on newer rhapsody; older
             # installs don't support it. Skip silently if unavailable.

--- a/src/radical/orbit/runtime.py
+++ b/src/radical/orbit/runtime.py
@@ -1,0 +1,911 @@
+"""ORBIT endpoint (participant) runtime — the single node abstraction.
+
+One :class:`EndpointRuntime` dials the broker over a **single outbound
+WebSocket** and may *serve* plugins, *consume* other participants' plugins, or
+both — the workflow-manager-in-an-allocation case the star is built for.  Zero
+served plugins ⇒ a pure consumer; a served plugin that only pushes events ⇒ a
+callback plugin.
+
+**Transport isolation (load-bearing — this is why liveness is fast).**
+
+* A dedicated **transport thread** runs its own asyncio loop and owns the WS:
+  connect / reconnect / backoff, the ``register`` handshake, WS keepalive, and
+  raw frame ``send``/``recv`` — *nothing else*.  ``websockets`` client keepalive
+  (``ping_interval``/``ping_timeout``) answers pings here regardless of what the
+  work loop is doing, so a blocking plugin handler stalls request *handling*,
+  never liveness (M0 lesson 3: the stock library keepalive is genuinely
+  transport-independent).
+* A **work loop** (its own runtime-owned thread) does envelope pack/parse and
+  all plugin/handler + consumer-call work.
+* User callbacks fire on a **dedicated callback-dispatcher thread** — never the
+  transport or work loop (a slow user callback is user code and can never be
+  "disciplined").
+
+Frames cross the two loops through the M0 coalesced handoff
+(:class:`radical.orbit.runtime_support.Handoff`): a bounded deque with a single
+outstanding ``call_soon_threadsafe`` per burst, swap-drained.  The inbound path
+is soft-bounded and **never blocks the transport loop** (M0 lesson 5); strict
+request backpressure is the 503 fast-fail at the concurrency cap.
+
+**Naming / session recovery.**  A zero-plugin consumer with no name given is
+auto-named ``consumer.<uuid8>`` — fine for fire-and-forget consumers.  Session
+reattach needs a *stable, client-supplied* name: reattach is owner-checked, so
+an auto-named restart cannot recover its sessions by design.  A ``name-in-use``
+register is retried with capped exponential backoff until the stale
+registration passes ``lost`` — a crashed predecessor holds no resume key, and
+under the fast keepalive the name frees in seconds — so "restart with the same
+name → sessions come back" is automatic from the application's view.
+"""
+
+# pylint: disable=protected-access
+
+import asyncio
+import json as _json
+import logging
+import os
+import random
+import socket
+import ssl
+import threading
+import uuid
+
+from collections import deque
+from typing      import Any, Callable, Dict, List, Optional
+from urllib.parse import parse_qsl, urlparse, urlunparse
+
+import websockets
+from websockets import exceptions as ws_exc
+
+from fastapi             import FastAPI, HTTPException
+
+from . import _prof as rprof
+from . import protocol
+from . import utils
+
+from .client            import PluginClient
+from .dispatch          import RequestShim, match_route
+from .plugin_base       import Plugin
+from .plugin_host_base  import PluginHostBase
+from .runtime_client    import RuntimePluginClient, RuntimeResponse, _RuntimeHTTP
+from .runtime_support   import CallbackDispatcher, Handoff
+from .ui_schema         import ui_config_to_dict
+
+
+log = logging.getLogger("radical.orbit.runtime")
+
+
+# ---------------------------------------------------------------------------
+# EndpointRuntime
+# ---------------------------------------------------------------------------
+
+class EndpointRuntime(PluginHostBase):
+    """A participant: serve and/or consume over one outbound WS to the broker.
+
+    Args:
+        broker_url:  Broker URL.  CLI > env (``RADICAL_ORBIT_BRIDGE_URL``) >
+                     file — resolved via :func:`utils.resolve_bridge_url`.
+        cert:        Broker TLS cert (only for ``https``/``wss``).
+        name:        Stable participant name.  ``None`` → ``consumer.<uuid8>``
+                     (auto-named consumers cannot recover sessions on restart).
+        plugins:     Served-plugin filter list (names / ``'all'`` / ``'default'``)
+                     mounted pre-connect; ``None`` → pure consumer unless
+                     :meth:`serve` is called.
+        role:        Advertised role.  Defaults to ``'consumer'`` (no served
+                     plugins) or ``'endpoint'``.
+        tunnel:      ``'none'`` / ``'forward'`` / ``'reverse'`` (see
+                     ``service.py``; boolean is not accepted).
+        request_concurrency: max concurrently-served requests (work loop).
+        accept_queue:        extra admitted-but-waiting requests before 503.
+        callback_queue:      bounded depth of the user-callback dispatcher.
+        ping_interval/ping_timeout: ``websockets`` client keepalive.
+        frame_cap:   ``max_size`` for the WS + the pack/parse cap.
+    """
+
+    def __init__(self,
+                 broker_url:  Optional[str]  = None,
+                 cert:        Optional[str]  = None,
+                 name:        Optional[str]  = None,
+                 plugins:     Optional[list] = None,
+                 role:        Optional[str]  = None,
+                 tunnel:      str            = 'none',
+                 tunnel_via:  Optional[str]  = None,
+                 token:       Optional[str]  = None,
+                 resume_key:  Optional[str]  = None,
+                 app:         Optional[FastAPI] = None,
+                 request_concurrency: int   = 64,
+                 accept_queue:        int   = 64,
+                 callback_queue:      int   = 1024,
+                 call_timeout:        float = 600.0,
+                 retry_after:         float = 1.0,
+                 ping_interval:       float = 1.0,
+                 ping_timeout:        float = 3.0,
+                 frame_cap:           int   = protocol.FRAME_CAP,
+                 backoff_start:       float = 0.5,
+                 backoff_max:         float = 10.0,
+                 backoff_factor:      float = 1.5):
+
+        if tunnel not in ('none', 'forward', 'reverse'):
+            raise ValueError(
+                f"tunnel must be one of 'none' / 'forward' / 'reverse'; "
+                f"got {tunnel!r}")
+
+        # ── URL / TLS / token resolution (service.py shapes) ──────────
+        resolved_url, _ = utils.resolve_bridge_url(cli=broker_url)
+        self._broker_url: str = resolved_url
+        scheme = urlparse(self._broker_url).scheme
+        if scheme in ('https', 'wss'):
+            resolved_cert, _ = utils.resolve_bridge_cert(cli=cert)
+            self._cert: Optional[str] = str(resolved_cert)
+        else:
+            self._cert = None
+        self._token: Optional[str] = utils.resolve_bridge_token(cli=token)[0]
+
+        # ── Identity / role ───────────────────────────────────────────
+        self._name: str = name or ('consumer.%s' % uuid.uuid4().hex[:8])
+        self._role_override = role
+        self._resume_key: Optional[str] = resume_key
+
+        # ── Tunnel ─────────────────────────────────────────────────────
+        self._tunnel     = tunnel
+        self._tunnel_via = tunnel_via
+        self._tunnel_proc = None
+
+        # ── Served-plugin FastAPI app (service.py mounting shape) ──────
+        self._app: FastAPI = app if app is not None \
+                                 else FastAPI(title="ORBIT Endpoint Runtime")
+        self._plugins: Dict[str, Plugin] = {}
+        self._app.state.bridge_url       = self._broker_url
+        self._app.state.endpoint_name    = self._name
+        self._app.state.endpoint_service = self
+        self._app.state.is_bridge        = False
+        if not hasattr(self._app.state, 'direct_routes'):
+            self._app.state.direct_routes = []
+        self._direct_routes: list = self._app.state.direct_routes
+
+        if plugins:
+            self._load_plugins_from_filter(list(plugins))
+        # Keep the live list reference (dynamic serve() appends to it).
+        self._direct_routes = self._app.state.direct_routes
+
+        # ── Tunables ───────────────────────────────────────────────────
+        self._request_concurrency = request_concurrency
+        self._accept_queue        = accept_queue
+        self._call_timeout        = call_timeout
+        self._retry_after         = retry_after
+        self._ping_interval       = ping_interval
+        self._ping_timeout        = ping_timeout
+        self._frame_cap           = frame_cap
+        self._backoff_start       = backoff_start
+        self._backoff_max         = backoff_max
+        self._backoff_factor      = backoff_factor
+        self._prof = rprof.Profiler('endpoint', ns='radical.orbit')
+
+        # ── Loops / threads (populated in start()) ────────────────────
+        self._work_loop:      Optional[asyncio.AbstractEventLoop] = None
+        self._transport_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._work_thread:      Optional[threading.Thread] = None
+        self._transport_thread: Optional[threading.Thread] = None
+        self._work_ident:      Optional[int] = None
+        self._transport_ident: Optional[int] = None
+        self._cb = CallbackDispatcher(maxlen=callback_queue)
+
+        # inbound: transport thread -> work loop; outbound: work -> transport.
+        self._inbound  = Handoff(self._drain_inbound)
+        self._outbound = Handoff(self._drain_outbound)
+        self._outbox: deque      = deque()
+        self._outbox_evt: Optional[asyncio.Event] = None
+
+        # ── State ──────────────────────────────────────────────────────
+        self._ws = None
+        self._stopping = False
+        self._fatal    = False
+        self._registered = threading.Event()
+        self._transport_future = None
+
+        # served-request backpressure (touched on the work loop)
+        self._req_inflight = 0
+        self._req_sem: Optional[asyncio.Semaphore] = None
+
+        # consumer pending table (touched on the work loop)
+        self._pending: Dict[str, asyncio.Future] = {}
+
+        # callback registry (guarded — mutated by user threads, read on work)
+        self._cb_lock = threading.Lock()
+        self._callbacks: Dict[Any, List[Callable]] = {}
+        self._topology_callbacks: List[Callable] = []
+
+        # rich topology snapshot (name -> {role, plugins, liveness})
+        self._topology: Dict[str, Dict[str, Any]] = {}
+
+    # ── public identity ───────────────────────────────────────────────
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def resume_key(self) -> Optional[str]:
+        return self._resume_key
+
+    @property
+    def broker_url(self) -> str:
+        return self._broker_url
+
+    def _role(self) -> str:
+        if self._role_override:
+            return self._role_override
+        return 'endpoint' if self._plugins else 'consumer'
+
+    # ── serve a plugin (pre-connect; v1 push/event direction) ──────────
+
+    def serve(self, plugin) -> Plugin:
+        """Mount a served plugin (class or instance) before connecting.
+
+        Requests to the plugin are dispatched through normal served-plugin
+        dispatch; a pure-callback plugin simply also pushes events.
+        """
+        inst = plugin(app=self._app) if isinstance(plugin, type) else plugin
+        self._plugins[inst.instance_name] = inst
+        self._direct_routes = self._app.state.direct_routes
+        return inst
+
+    async def _announce_topology(self) -> None:
+        """PluginHostBase hook.  v1 serves plugins pre-connect; a dynamic
+        change is picked up on the next (re)register — the broker rebuilds this
+        participant's plugin dict from the fresh ``register`` frame."""
+        log.debug("[Runtime] topology announce (served plugins now: %s)",
+                  list(self._plugins))
+
+    # ── lifecycle ──────────────────────────────────────────────────────
+
+    def start(self, wait: bool = True, timeout: float = 30.0) -> 'EndpointRuntime':
+        """Bring up both loops + the callback thread and connect.
+
+        With *wait* the call blocks until the first ``register_ack`` (or
+        *timeout*); either way calls block on the work loop via futures.
+        """
+        self._cb.start()
+
+        wk_ready = threading.Event()
+        self._work_thread = threading.Thread(
+            target=self._run_work_thread, args=(wk_ready,),
+            name='orbit-work', daemon=True)
+        self._work_thread.start()
+        wk_ready.wait(timeout=5.0)
+
+        rt_ready = threading.Event()
+        self._transport_thread = threading.Thread(
+            target=self._run_transport_thread, args=(rt_ready,),
+            name='orbit-transport', daemon=True)
+        self._transport_thread.start()
+        rt_ready.wait(timeout=5.0)
+
+        self._transport_future = asyncio.run_coroutine_threadsafe(
+            self._transport_main(), self._transport_loop)
+
+        if wait:
+            self._registered.wait(timeout=timeout)
+        return self
+
+    def wait_registered(self, timeout: float = 30.0) -> bool:
+        """Block until the first ``register_ack`` arrives; ``True`` on success."""
+        return self._registered.wait(timeout=timeout)
+
+    def stop(self) -> None:
+        """Clean-close the WS (broker treats a clean close as immediate
+        removal) and tear down loops + threads."""
+        self._stopping = True
+        if self._transport_loop is not None and self._transport_loop.is_running():
+            coro = self._graceful_close()
+            try:
+                fut = asyncio.run_coroutine_threadsafe(
+                    coro, self._transport_loop)
+                fut.result(timeout=3.0)
+            except Exception as e:
+                coro.close()
+                log.debug("[Runtime] graceful close failed: %s", e)
+        # Cancel served-plugin background tasks on the work loop before it
+        # stops, so no task is destroyed while pending.
+        if self._work_loop is not None and self._work_loop.is_running() \
+                and self._plugins:
+            coro = self._work_teardown()
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    coro, self._work_loop).result(timeout=3.0)
+            except Exception:
+                coro.close()
+        for loop, thread in ((self._transport_loop, self._transport_thread),
+                             (self._work_loop, self._work_thread)):
+            if loop is not None:
+                loop.call_soon_threadsafe(loop.stop)
+            if thread is not None:
+                thread.join(timeout=5.0)
+        self._cb.stop()
+        if self._tunnel_proc is not None:
+            from . import tunnel as _tunnel
+            _tunnel.cleanup_tunnel(self._tunnel_proc, self._name)
+            self._tunnel_proc = None
+        self._prof.close()
+
+    async def _graceful_close(self) -> None:
+        self._stopping = True
+        if self._ws is not None:
+            try:    await self._ws.close(code=1000)
+            except Exception:
+                pass
+
+    async def _work_teardown(self) -> None:
+        for plugin in list(self._plugins.values()):
+            task = getattr(plugin, '_cleanup_task', None)
+            if task is not None and not task.done():
+                task.cancel()
+
+    def __enter__(self) -> 'EndpointRuntime':
+        return self.start()
+
+    def __exit__(self, *exc) -> None:
+        self.stop()
+
+    # ── loop threads ───────────────────────────────────────────────────
+
+    def _run_work_thread(self, ready: threading.Event) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._work_loop  = loop
+        self._work_ident = threading.get_ident()
+        self._req_sem    = asyncio.Semaphore(self._request_concurrency)
+        self._inbound.bind(loop)
+        loop.call_soon(ready.set)
+        try:
+            loop.run_forever()
+        finally:
+            loop.close()
+
+    def _run_transport_thread(self, ready: threading.Event) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._transport_loop  = loop
+        self._transport_ident = threading.get_ident()
+        self._outbox_evt      = asyncio.Event()
+        self._outbound.bind(loop)
+        loop.call_soon(ready.set)
+        try:
+            loop.run_forever()
+        finally:
+            loop.close()
+
+    # ── transport loop: connect / register / recv / send ───────────────
+
+    async def _transport_main(self) -> None:
+        # One-time tunnel setup before the connect/reconnect loop.
+        try:
+            if self._tunnel == 'forward':
+                await self._open_tunnel_forward()
+            elif self._tunnel == 'reverse':
+                await self._open_tunnel_reverse()
+        except Exception as e:
+            log.error("[Runtime] tunnel setup failed: %s", e)
+            self._fatal = True
+            return
+
+        backoff = self._backoff_start
+        ssl_check_hostname = True
+        while not self._stopping and not self._fatal:
+            try:
+                ws_url  = self._ws_url()
+                ssl_ctx = self._ssl_context(ws_url, ssl_check_hostname)
+                async with websockets.connect(
+                        ws_url, ssl=ssl_ctx,
+                        ping_interval=self._ping_interval,
+                        ping_timeout=self._ping_timeout,
+                        close_timeout=2,
+                        max_size=self._frame_cap,
+                        compression='deflate') as ws:
+
+                    ok = await self._do_register(ws)
+                    if not ok:
+                        if self._fatal:
+                            break
+                        # name-in-use: retry with capped backoff.  A crashed
+                        # predecessor holds no resume key; under the fast
+                        # keepalive the name frees within `lost` seconds.
+                        await asyncio.sleep(backoff)
+                        backoff = min(backoff * self._backoff_factor,
+                                      self._backoff_max)
+                        continue
+
+                    self._ws = ws
+                    backoff  = self._backoff_start
+                    self._registered.set()
+                    self._resync_subscriptions()
+                    await self._serve_ws(ws)
+
+            except ssl.SSLCertVerificationError as e:
+                verify_msg  = getattr(e, 'verify_message', str(e))
+                cert_pinned = bool(self._cert and os.path.exists(self._cert))
+                if self._classify_cert_error(
+                        verify_msg, cert_pinned, ssl_check_hostname) == 'relax':
+                    log.warning("[Runtime] TLS name/IP validation failed: %s; "
+                                "pinned cert present — continuing with name "
+                                "validation DISABLED (dev mode).", e)
+                    ssl_check_hostname = False
+                    continue
+                log.error("[Runtime] TLS verification failed: %s. Aborting.", e)
+                self._fatal = True
+                break
+            except (ws_exc.ConnectionClosed, OSError) as e:
+                if self._stopping:
+                    break
+                jitter = backoff * 0.3 * random.random()
+                log.warning("[Runtime] connection lost: %s; reconnecting in "
+                            "%.1fs", e, backoff + jitter)
+                await asyncio.sleep(backoff + jitter)
+                backoff = min(backoff * self._backoff_factor, self._backoff_max)
+            except Exception as e:
+                if self._stopping:
+                    break
+                log.exception("[Runtime] unexpected transport error: %s", e)
+                await asyncio.sleep(min(backoff, self._backoff_max))
+            finally:
+                self._ws = None
+
+    def _ws_url(self) -> str:
+        url = self._broker_url
+        if   url.startswith('https://'): url = 'wss://' + url[len('https://'):]
+        elif url.startswith('http://'):  url = 'ws://'  + url[len('http://'):]
+        url = url.rstrip('/')
+        if not url.endswith('/register'):
+            url += '/register'
+        return url
+
+    def _ssl_context(self, ws_url: str, check_hostname: bool):
+        if not ws_url.startswith('wss://'):
+            return None
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = check_hostname
+        ctx.verify_mode    = ssl.CERT_REQUIRED
+        if self._cert and os.path.exists(self._cert):
+            ctx.load_verify_locations(self._cert)
+        return ctx
+
+    @staticmethod
+    def _classify_cert_error(verify_message: str, cert_pinned: bool,
+                             check_hostname: bool) -> str:
+        """A hostname/IP mismatch is benign only when a cert is pinned (then
+        ``CERT_REQUIRED`` already guarantees the peer); every other failure
+        aborts (mirrors ``EndpointService._classify_cert_error``)."""
+        msg = (verify_message or '').lower()
+        name_mismatch = 'hostname' in msg or 'ip address' in msg
+        if check_hostname and cert_pinned and name_mismatch:
+            return 'relax'
+        return 'abort'
+
+    async def _do_register(self, ws) -> bool:
+        reg = protocol.Register(
+            src=self._name, role=self._role(),
+            plugins=self._plugin_dicts(),
+            identity=protocol.Identity(name=self._name,
+                                       credential=self._token,
+                                       resume_key=self._resume_key))
+        await ws.send(protocol.pack_message(reg, cap=self._frame_cap))
+        first = await ws.recv()
+        try:
+            ack = protocol.parse_message(first, cap=self._frame_cap)
+        except protocol.ProtocolError as e:
+            log.error("[Runtime] bad register_ack frame: %s", e)
+            self._fatal = True
+            return False
+        if ack.kind != 'register_ack':
+            log.error("[Runtime] first frame is %r, not register_ack", ack.kind)
+            self._fatal = True
+            return False
+        if not ack.ok:
+            if ack.reason == 'name-in-use':
+                log.warning("[Runtime] name %r in use; retrying with backoff",
+                            self._name)
+                return False
+            log.error("[Runtime] register rejected: %s", ack.reason)
+            self._fatal = True
+            return False
+        self._resume_key = ack.resume_key
+        log.info("[Runtime] registered as %r (role=%s, plugins=%s)",
+                 self._name, self._role(), list(self._plugins))
+        return True
+
+    def _plugin_dicts(self) -> List[Dict[str, Any]]:
+        """Rich per-plugin register dicts.  Namespaces are **endpoint-relative**
+        (``/{instance}``) — routing is by ``dst``, so the consumer builds paths
+        relative to the target endpoint."""
+        out: List[Dict[str, Any]] = []
+        for pname, plugin in self._plugins.items():
+            out.append({
+                'name':      pname,
+                'type':      pname,
+                'namespace': plugin.namespace,
+                'version':   getattr(plugin, 'version', '0.0.1'),
+                'enabled':   True,
+                'ui_config': ui_config_to_dict(
+                    getattr(plugin, 'ui_config', None)),
+            })
+        return out
+
+    async def _serve_ws(self, ws) -> None:
+        sender = asyncio.ensure_future(self._sender(ws))
+        try:
+            while not self._stopping:
+                data = await ws.recv()
+                self._inbound.push(data)
+        finally:
+            sender.cancel()
+            try:    await sender
+            except Exception:
+                pass
+
+    async def _sender(self, ws) -> None:
+        try:
+            while True:
+                await self._outbox_evt.wait()
+                self._outbox_evt.clear()
+                while self._outbox:
+                    data = self._outbox.popleft()
+                    await ws.send(data)
+        except asyncio.CancelledError:
+            return
+        except Exception as e:
+            log.debug("[Runtime] sender stopped: %s", e)
+
+    # ── handoff drains ─────────────────────────────────────────────────
+
+    def _drain_outbound(self, items: List[bytes]) -> None:
+        """Runs on the transport loop: queue frames for the sender."""
+        self._outbox.extend(items)
+        if self._outbox_evt is not None:
+            self._outbox_evt.set()
+
+    def _drain_inbound(self, items: List[bytes]) -> None:
+        """Runs on the work loop: parse + dispatch each inbound frame."""
+        for data in items:
+            self._on_frame(data)
+
+    def _emit(self, msg) -> None:
+        """Pack an envelope and hand it to the transport loop (thread-safe)."""
+        try:
+            data = protocol.pack_message(msg, cap=self._frame_cap)
+        except protocol.ProtocolError as e:
+            log.error("[Runtime] failed to pack %s: %s", msg.kind, e)
+            return
+        self._outbound.push(data)
+
+    # ── inbound dispatch (work loop) ───────────────────────────────────
+
+    def _on_frame(self, data: bytes) -> None:
+        try:
+            msg = protocol.parse_message(data, cap=self._frame_cap)
+        except protocol.ProtocolError as e:
+            log.warning("[Runtime] dropping unparseable frame: %s", e)
+            return
+        kind = msg.kind
+        if   kind == 'request':   self._admit_request(msg)
+        elif kind == 'response':  self._resolve_response(msg)
+        elif kind == 'event':     self._on_event(msg)
+        elif kind == 'topology':  self._on_topology(msg)
+        elif kind == 'control':   self._on_control(msg)
+        elif kind == 'register_ack':
+            pass                                   # handled on transport loop
+        else:
+            log.debug("[Runtime] ignoring frame kind %r", kind)
+
+    # ── served-plugin dispatch (work loop) ─────────────────────────────
+
+    def _admit_request(self, req: protocol.Request) -> None:
+        cap = self._request_concurrency + self._accept_queue
+        if self._req_inflight >= cap:
+            # Fast-fail at the cap: 503 + Retry-After, never silently dropped.
+            self._emit(protocol.make_response(
+                req, 503,
+                headers={'content-type': 'application/json',
+                         'retry-after': str(self._retry_after)},
+                body=_json.dumps({"error": True, "status_code": 503,
+                                  "detail": "endpoint at concurrency cap"
+                                  }).encode()))
+            return
+        self._req_inflight += 1
+        self._work_loop.create_task(self._serve_request(req))
+
+    async def _serve_request(self, req: protocol.Request) -> None:
+        try:
+            async with self._req_sem:
+                status, headers, body = await self._dispatch_served(req)
+            self._emit(protocol.make_response(
+                req, status, headers=headers, body=body))
+        except Exception as e:                             # pragma: no cover
+            log.exception("[Runtime] request handling error: %s", e)
+            self._emit(protocol.make_response(
+                req, 500,
+                headers={'content-type': 'application/json'},
+                body=_json.dumps({"error": True, "detail": str(e)}).encode()))
+        finally:
+            self._req_inflight -= 1
+
+    async def _dispatch_served(self, req: protocol.Request):
+        path = req.path
+        if '?' in path:
+            path, qs = path.split('?', 1)
+            query = dict(parse_qsl(qs))
+        else:
+            query = {}
+        self._prof.prof('endpoint_recv', uid=req.corr_id or '',
+                        msg='%s %s' % (req.method, path))
+        handler, path_params = match_route(self._direct_routes, req.method, path)
+        if handler is None:
+            return (404, {'content-type': 'application/json'},
+                    _json.dumps({"detail": f"No route: {req.method} {path}"
+                                 }).encode())
+        content_type = (req.headers or {}).get('content-type',
+                                               'application/json')
+        shim = RequestShim(path_params, query, req.body, content_type)
+        try:
+            result = await handler(shim)
+        except HTTPException as e:
+            return (e.status_code, {'content-type': 'application/json'},
+                    _json.dumps({"detail": e.detail}).encode())
+        except Exception as e:
+            log.exception("[Runtime] handler error: %s %s", req.method, path)
+            return (500, {'content-type': 'application/json'},
+                    _json.dumps({"error": "endpoint-invoke-failed",
+                                 "detail": str(e)}).encode())
+        if hasattr(result, 'status_code'):
+            return (result.status_code, dict(result.headers), bytes(result.body))
+        return (200, {'content-type': 'application/json'},
+                _json.dumps(result).encode())
+
+    # ── consumer: pending table + call ─────────────────────────────────
+
+    def _resolve_response(self, resp: protocol.Response) -> None:
+        fut = self._pending.pop(resp.corr_id, None)
+        if fut is not None and not fut.done():
+            fut.set_result(resp)
+
+    async def _call(self, dst, method, path, body, headers, timeout):
+        req = protocol.make_request(self._name, dst, method, path,
+                                    headers=headers, body=body)
+        fut = self._work_loop.create_future()
+        self._pending[req.corr_id] = fut
+        self._emit(req)
+        try:
+            resp = await asyncio.wait_for(fut, timeout=timeout)
+        except Exception:
+            self._pending.pop(req.corr_id, None)
+            raise
+        return RuntimeResponse(resp.status, dict(resp.headers), bytes(resp.body))
+
+    def call(self, dst: str, method: str, path: str, *,
+             body: bytes = b'', headers: Optional[Dict[str, str]] = None,
+             timeout: Optional[float] = None) -> RuntimeResponse:
+        """Send a ``request`` to *dst* and block for its ``response``.
+
+        Returns a :class:`RuntimeResponse` (``.status``/``.headers``/``.body``
+        plus the httpx-ish surface the plugin helpers use).
+        """
+        timeout = self._call_timeout if timeout is None else timeout
+        fut = asyncio.run_coroutine_threadsafe(
+            self._call(dst, method, path, body, headers, timeout),
+            self._work_loop)
+        return fut.result(timeout=None if timeout is None else timeout + 5.0)
+
+    # ── consumer: plugin client discovery ──────────────────────────────
+
+    def get_plugin(self, endpoint_name: str, plugin_name: str,
+                   **session_kwargs) -> PluginClient:
+        """Return a plugin ``client_class`` helper bound to *endpoint_name*.
+
+        Keeps the ``get_plugin(target, …).method()`` + ``register_session(...)``
+        call-site shape; the namespace is discovered from the rich topology.
+        """
+        info = self._topology.get(endpoint_name)
+        if not info:
+            raise RuntimeError(
+                f"endpoint {endpoint_name!r} not in topology")
+        pinfo = (info.get('plugins') or {}).get(plugin_name)
+        if not pinfo:
+            raise RuntimeError(
+                f"plugin {plugin_name!r} not on {endpoint_name!r}")
+        namespace = pinfo['namespace']
+
+        helper_cls = Plugin.get_plugin_class(plugin_name)
+        if helper_cls is None:
+            raise RuntimeError(f"plugin class for {plugin_name!r} not found")
+        client_cls = getattr(helper_cls, 'client_class', None)
+        if client_cls is None:
+            raise RuntimeError(f"plugin client for {plugin_name!r} not known")
+
+        # Mix the concrete helper on top of the runtime transport seam.  The
+        # standard PluginClient ctor signature is preserved so helpers that
+        # override __init__ keep working.
+        combined = type('Runtime%s' % client_cls.__name__,
+                        (client_cls, RuntimePluginClient), {})
+        client = combined(_RuntimeHTTP(self, endpoint_name), namespace,
+                          bridge_client=None, endpoint_id=endpoint_name,
+                          plugin_name=plugin_name)
+        client._runtime = self
+        client.register_session(**session_kwargs)
+        return client
+
+    # ── events + callbacks (consumer) ──────────────────────────────────
+
+    def register_callback(self, endpoint_id: Optional[str] = None,
+                          plugin_name: Optional[str] = None,
+                          topic: Optional[str] = None,
+                          callback: Callable = None) -> None:
+        """Register an event callback and auto-``subscribe`` for its pattern.
+
+        Same tuple semantics as ``BridgeClient.register_callback``: ``None`` is
+        a wildcard; filtering happens at the edge.
+        """
+        if callback is None:
+            raise ValueError("callback is required")
+        key = (endpoint_id, plugin_name, topic)
+        with self._cb_lock:
+            self._callbacks.setdefault(key, []).append(callback)
+        self._emit(protocol.Subscribe(
+            src=self._name,
+            patterns=[protocol.SubscribePattern(
+                endpoint=endpoint_id, plugin=plugin_name, topic=topic)]))
+
+    def unregister_callback(self, endpoint_id: Optional[str] = None,
+                            plugin_name: Optional[str] = None,
+                            topic: Optional[str] = None,
+                            callback: Callable = None) -> None:
+        key = (endpoint_id, plugin_name, topic)
+        with self._cb_lock:
+            cbs = self._callbacks.get(key)
+            if cbs and callback in cbs:
+                cbs.remove(callback)
+        self._emit(protocol.Unsubscribe(
+            src=self._name,
+            patterns=[protocol.SubscribePattern(
+                endpoint=endpoint_id, plugin=plugin_name, topic=topic)]))
+
+    def register_topology_callback(self, callback: Callable) -> None:
+        with self._cb_lock:
+            self._topology_callbacks.append(callback)
+
+    def unregister_topology_callback(self, callback: Callable) -> None:
+        with self._cb_lock:
+            if callback in self._topology_callbacks:
+                self._topology_callbacks.remove(callback)
+
+    def _resync_subscriptions(self) -> None:
+        """Re-send the full interest set after a (re)connect (state re-sync)."""
+        with self._cb_lock:
+            keys = list(self._callbacks.keys())
+        if not keys:
+            return
+        self._emit(protocol.Subscribe(
+            src=self._name,
+            patterns=[protocol.SubscribePattern(endpoint=e, plugin=p, topic=t)
+                      for (e, p, t) in keys]))
+
+    def _on_event(self, ev: protocol.Event) -> None:
+        endpoint, plugin, topic = ev.src, ev.plugin, ev.topic
+        data = ev.data
+        with self._cb_lock:
+            matched: List[Callable] = []
+            for (e, p, t), cbs in self._callbacks.items():
+                if (e is None or e == endpoint) and \
+                   (p is None or p == plugin) and \
+                   (t is None or t == topic):
+                    matched.extend(cbs)
+        for cb in matched:
+            self._cb.submit(cb, endpoint, plugin, topic, data)
+
+    def _on_topology(self, msg: protocol.Topology) -> None:
+        self._topology = {name: info.model_dump()
+                          for name, info in msg.participants.items()}
+        with self._cb_lock:
+            cbs = list(self._topology_callbacks)
+        snapshot = dict(self._topology)
+        for cb in cbs:
+            self._cb.submit(cb, snapshot)
+
+    def _on_control(self, msg: protocol.Control) -> None:
+        if msg.op in ('shutdown', 'terminate'):
+            log.info("[Runtime] control %s received; closing connection",
+                     msg.op)
+            self._stopping = True
+            if self._transport_loop is not None:
+                asyncio.run_coroutine_threadsafe(
+                    self._graceful_close(), self._transport_loop)
+        elif msg.op == 'error':
+            log.error("[Runtime] broker error: %s", msg.data)
+
+    # ── notifications from served plugins ──────────────────────────────
+
+    async def send_notification(self, plugin_name: str, topic: str,
+                                data: Dict[str, Any]) -> None:
+        """Turn a served plugin's notification into a broker ``event`` frame.
+
+        ``seq`` is a placeholder (0) — the broker stamps the authoritative
+        ``seq``/``ts`` on ingest.  Reuses the notification plumbing shape
+        ``service.py`` exposes as ``send_notification``.
+        """
+        ev = protocol.Event(src=self._name, plugin=plugin_name, topic=topic,
+                            session=None, ts=0.0, seq=0, data=data)
+        self._emit(ev)
+
+    # ── topology snapshot access ───────────────────────────────────────
+
+    def topology(self) -> Dict[str, Dict[str, Any]]:
+        """The current rich topology snapshot (``name -> {role, plugins,
+        liveness}``)."""
+        return dict(self._topology)
+
+    # ── tunnels (service.py shapes) ────────────────────────────────────
+
+    async def _open_tunnel_forward(self) -> None:
+        """Forward mode: open ``ssh -L`` to the login host and rewrite the
+        broker URL to ``localhost:<port>`` (compute → login)."""
+        from . import tunnel as _tunnel
+
+        login_host = (self._tunnel_via
+                      or os.environ.get('PBS_O_HOST')
+                      or os.environ.get('SLURM_SUBMIT_HOST'))
+        if not login_host:
+            raise RuntimeError(
+                "--tunnel forward: no login host available. Pass --tunnel-via "
+                "HOST or set PBS_O_HOST / SLURM_SUBMIT_HOST.")
+        parsed      = urlparse(self._broker_url)
+        broker_host = parsed.hostname or 'localhost'
+        broker_port = parsed.port or (443 if parsed.scheme == 'https' else 8000)
+        proc, port  = await asyncio.to_thread(
+            _tunnel.spawn_tunnel, login_host, broker_host, broker_port,
+            self._name)
+        self._tunnel_proc = proc
+        self._broker_url  = urlunparse(
+            parsed._replace(netloc='localhost:%d' % port))
+        log.info("[Runtime] forward tunnel active; broker URL now %s",
+                 self._broker_url)
+
+    async def _open_tunnel_reverse(self, wait_timeout: float = 15.0) -> None:
+        """Reverse mode: wait for a login-side spawner to open ``ssh -R`` and
+        write the rendezvous file, then rewrite the broker URL (login →
+        compute)."""
+        from . import tunnel as _tunnel
+
+        parsed      = urlparse(self._broker_url)
+        broker_host = parsed.hostname or 'localhost'
+        broker_port = parsed.port or (443 if parsed.scheme in ('https', 'wss')
+                                      else 8000)
+        rdir       = _tunnel.relay_dir()
+        relay_file = rdir / ('%s.port' % self._name)
+        req_file   = rdir / ('%s.req' % self._name)
+        req_payload = _json.dumps({
+            'endpoint_name': self._name,
+            'hostname':      socket.gethostname(),
+            'bridge_host':   broker_host,
+            'bridge_port':   broker_port,
+        })
+        tmp = req_file.with_suffix('.req.tmp')
+        tmp.write_text(req_payload)
+        tmp.rename(req_file)
+        log.info("[Runtime] reverse tunnel: wrote request file %s", req_file)
+
+        deadline = asyncio.get_running_loop().time() + wait_timeout
+        while asyncio.get_running_loop().time() < deadline:
+            try:    contents = set(os.listdir(str(relay_file.parent)))
+            except OSError:
+                contents = set()
+            if relay_file.name in contents:
+                try:    port = int(relay_file.read_text().strip())
+                except (ValueError, OSError):
+                    port = None
+                if port:
+                    self._broker_url = urlunparse(
+                        parsed._replace(netloc='localhost:%d' % port))
+                    log.info("[Runtime] reverse tunnel active; broker URL now "
+                             "%s", self._broker_url)
+                    return
+            await asyncio.sleep(2.0)
+        raise RuntimeError(
+            "--tunnel reverse: rendezvous file %s did not appear within %.0fs"
+            % (relay_file, wait_timeout))

--- a/src/radical/orbit/runtime_client.py
+++ b/src/radical/orbit/runtime_client.py
@@ -1,0 +1,125 @@
+"""Consumer-side plugin-client transport seam for the endpoint runtime.
+
+The 11 plugin ``client_class`` helpers (``SysInfoClient``, ``PSIJClient``, …)
+subclass :class:`radical.orbit.client.PluginClient` and speak an httpx-ish
+surface (``self._http.get/post`` + ``PluginClient._request``).  This module
+lets every one of them ride an :class:`~radical.orbit.runtime.EndpointRuntime`
+WebSocket **unchanged**:
+
+* :class:`RuntimeResponse` — an ``httpx.Response``-shaped result satisfying
+  ``PluginClient._raise`` and the helpers (``status_code``/``json()``/
+  ``content``/``text``/``is_error``) *and* the plain ``status``/``headers``/
+  ``body`` consumer-API contract.
+* :class:`_RuntimeHTTP` — a minimal ``httpx.Client``-shaped adapter bound to
+  ``(runtime, dst)`` installed as the helper's ``self._http``.
+* :class:`RuntimePluginClient` — the seam mixed under a concrete helper class
+  by ``EndpointRuntime.get_plugin``: it overrides *only* the transport-touching
+  surface (the ``_http`` object + notification registration over the runtime's
+  callback registry instead of a ``BridgeClient`` + SSE).
+"""
+
+import json as _json
+
+from typing       import Any, Callable, Dict, Optional
+from urllib.parse import urlencode
+
+from .client import PluginClient
+
+
+class RuntimeResponse:
+    """Response object returned by :meth:`EndpointRuntime.call` and handed to
+    the plugin helpers.  Satisfies both the consumer-API surface
+    (``status``/``headers``/``body``) and the httpx-ish surface the helpers +
+    ``PluginClient._raise`` rely on."""
+
+    def __init__(self, status: int, headers: Dict[str, str], body: bytes):
+        self.status      = status
+        self.status_code = status
+        self.headers     = headers or {}
+        self.body        = body or b''
+        self.content     = self.body
+
+    @property
+    def text(self) -> str:
+        return self.content.decode('utf-8', 'replace')
+
+    @property
+    def is_error(self) -> bool:
+        return self.status_code >= 400
+
+    def json(self) -> Any:
+        return _json.loads(self.content) if self.content else {}
+
+
+class _RuntimeHTTP:
+    """Minimal ``httpx.Client``-shaped adapter bound to ``(runtime, dst)``.
+
+    Installed as a plugin helper's ``self._http`` so every helper's
+    ``self._http.get/post`` (and ``PluginClient._request``) rides
+    ``EndpointRuntime.call`` instead of HTTP — no helper changes.
+    """
+
+    def __init__(self, runtime, dst: str):
+        self._runtime = runtime
+        self._dst     = dst
+
+    def get(self, url: str, *, params=None, headers=None, **kw
+            ) -> RuntimeResponse:
+        return self._do('GET', url, params=params, headers=headers)
+
+    def post(self, url: str, *, json=None, content=None, data=None,
+             params=None, headers=None, **kw) -> RuntimeResponse:
+        return self._do('POST', url, json=json, content=content, data=data,
+                        params=params, headers=headers)
+
+    def request(self, method: str, url: str, *, json=None, content=None,
+                data=None, params=None, headers=None, **kw) -> RuntimeResponse:
+        return self._do(method, url, json=json, content=content, data=data,
+                        params=params, headers=headers)
+
+    def _do(self, method, url, json=None, content=None, data=None,
+            params=None, headers=None) -> RuntimeResponse:
+        path = url if not params else f"{url}?{urlencode(params)}"
+        hdrs: Dict[str, str] = dict(headers or {})
+        body: bytes = b''
+        if json is not None:
+            body = _json.dumps(json).encode('utf-8')
+            hdrs.setdefault('content-type', 'application/json')
+        elif content is not None:
+            body = content if isinstance(content, (bytes, bytearray)) \
+                           else str(content).encode('utf-8')
+        elif data is not None:
+            body = urlencode(data).encode('utf-8')
+            hdrs.setdefault('content-type', 'application/x-www-form-urlencoded')
+        return self._runtime.call(self._dst, method, path,
+                                  body=bytes(body), headers=hdrs)
+
+
+class RuntimePluginClient(PluginClient):
+    """Transport seam for the plugin ``client_class`` helpers over a runtime.
+
+    A concrete helper class is mixed on top of this by
+    ``EndpointRuntime.get_plugin``; this base overrides only the
+    transport-touching surface: the ``self._http`` object is a
+    :class:`_RuntimeHTTP` adapter (installed at construction), and notification
+    registration rides the runtime's callback registry instead of a
+    ``BridgeClient`` + SSE.
+    """
+
+    _runtime = None
+
+    def register_notification_callback(self, callback: Callable,
+                                       topic: Optional[str] = None) -> None:
+        if self._runtime is None:
+            raise RuntimeError("no runtime bound to this plugin client")
+        self._runtime.register_callback(
+            endpoint_id=self._endpoint_id, plugin_name=self._plugin_name,
+            topic=topic, callback=callback)
+
+    def unregister_notification_callback(self, callback: Callable,
+                                         topic: Optional[str] = None) -> None:
+        if self._runtime is None:
+            raise RuntimeError("no runtime bound to this plugin client")
+        self._runtime.unregister_callback(
+            endpoint_id=self._endpoint_id, plugin_name=self._plugin_name,
+            topic=topic, callback=callback)

--- a/src/radical/orbit/runtime_support.py
+++ b/src/radical/orbit/runtime_support.py
@@ -1,0 +1,134 @@
+"""Cross-loop plumbing for the endpoint participant runtime.
+
+Two small, test-covered building blocks factored out of ``runtime.py`` so the
+runtime module stays focused on protocol/dispatch logic:
+
+* :class:`Handoff` — the M0-validated coalesced cross-loop queue.  A producer
+  thread pushes items; **at most one** ``call_soon_threadsafe`` wakeup is
+  outstanding per burst (re-armed only after a drain), which is what yields the
+  ~2.2 M msgs/s handoff M0 measured.  The buffer is *soft*-bounded with an
+  overflow counter and never blocks the producer — the transport loop must
+  never block (M0 lesson 5); the strict request backpressure (503 fast-fail)
+  is applied at dispatch time, not here.
+
+* :class:`CallbackDispatcher` — runs user callbacks on a **dedicated** thread
+  fed by a bounded, drop-oldest queue.  A slow user callback must never stall
+  the work loop (it is user code and can never be "disciplined"), so it is
+  structurally isolated the same way the transport is.  Drops bump a counter so
+  loss is observable.
+"""
+
+import logging
+import threading
+
+from collections import deque
+from typing      import Any, Callable, List, Optional
+
+
+log = logging.getLogger("radical.orbit.runtime")
+
+
+class Handoff:
+    """Coalesced, thread-safe cross-loop queue (one direction).
+
+    *drain* is a sync callable ``(items: list) -> None`` executed **on the
+    consumer loop** with every item accumulated since the last drain.  The
+    consumer loop is bound after its thread is up via :meth:`bind`.
+    """
+
+    def __init__(self, drain: Callable[[List[Any]], None],
+                 soft_max: int = 100000):
+        self._drain    = drain
+        self._soft_max = soft_max
+        self._buf      : deque = deque()
+        self._lock     = threading.Lock()
+        self._armed    = False
+        self._loop     = None            # asyncio loop of the consumer thread
+        self.overflow  = 0
+
+    def bind(self, loop) -> None:
+        """Bind the consumer event loop (called once its thread is running)."""
+        with self._lock:
+            self._loop = loop
+            # A producer may already have pushed before the loop existed;
+            # arm a wakeup now so nothing is stranded.
+            if self._buf and not self._armed:
+                self._armed = True
+                loop.call_soon_threadsafe(self._run_drain)
+
+    def push(self, item: Any) -> None:
+        """Enqueue *item* from the producer thread; arm one wakeup per burst."""
+        with self._lock:
+            if len(self._buf) >= self._soft_max:
+                # Soft bound: count the pressure but never block the producer.
+                self.overflow += 1
+            self._buf.append(item)
+            if not self._armed and self._loop is not None:
+                self._armed = True
+                self._loop.call_soon_threadsafe(self._run_drain)
+
+    def _run_drain(self) -> None:
+        with self._lock:
+            items = list(self._buf)
+            self._buf.clear()
+            self._armed = False
+        if items:
+            self._drain(items)
+
+
+class CallbackDispatcher:
+    """Dedicated-thread runner for user callbacks (bounded, drop-oldest).
+
+    ``submit(fn, *args)`` is called from the work loop; ``fn`` runs later on
+    the dispatcher thread.  When the queue is full the *oldest* pending entry
+    is evicted and :attr:`dropped` is bumped, so a wedged callback can never
+    stall the caller or grow memory without bound.
+    """
+
+    def __init__(self, maxlen: int = 1024, name: str = 'orbit-callbacks'):
+        self._buf     : deque = deque(maxlen=maxlen)
+        self._cv      = threading.Condition()
+        self._stop    = False
+        self.dropped  = 0
+        self._thread  = threading.Thread(target=self._run, name=name,
+                                         daemon=True)
+
+    @property
+    def thread(self) -> threading.Thread:
+        """The dispatcher thread (tests assert callbacks run *here*)."""
+        return self._thread
+
+    @property
+    def ident(self) -> Optional[int]:
+        return self._thread.ident
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def submit(self, fn: Callable, *args: Any) -> None:
+        with self._cv:
+            if self._buf.maxlen is not None and len(self._buf) == self._buf.maxlen:
+                # deque drops the oldest on append once full.
+                self.dropped += 1
+            self._buf.append((fn, args))
+            self._cv.notify()
+
+    def _run(self) -> None:
+        while True:
+            with self._cv:
+                while not self._buf and not self._stop:
+                    self._cv.wait()
+                if self._stop and not self._buf:
+                    return
+                fn, args = self._buf.popleft()
+            try:
+                fn(*args)
+            except Exception as e:
+                log.error("[Runtime] user callback failed: %r", e, exc_info=e)
+
+    def stop(self) -> None:
+        with self._cv:
+            self._stop = True
+            self._cv.notify()
+        if self._thread.is_alive():
+            self._thread.join(timeout=2.0)

--- a/src/radical/orbit/service.py
+++ b/src/radical/orbit/service.py
@@ -31,49 +31,12 @@ from radical.orbit.models import (
 )
 from radical.orbit.ui_schema import ui_config_to_dict
 
+# ``RequestShim`` + ``match_route`` live in ``dispatch.py`` now (shared by the
+# WS endpoint and the broker-hosted plugin host).  Re-export ``RequestShim``
+# here so external imports (``bridge_plugin_host``, tests) keep working.
+from radical.orbit.dispatch import RequestShim, match_route  # noqa: F401
+
 log = logging.getLogger("radical.orbit.endpoint")
-
-
-# ---------------------------------------------------------------------------
-# RequestShim — lightweight stand-in for starlette.requests.Request
-# ---------------------------------------------------------------------------
-
-class RequestShim:
-    """Lightweight adapter for starlette ``Request``.
-
-    Provides the three interfaces that every plugin handler uses:
-    ``path_params``, ``query_params``, and ``await .json()`` / ``await .body()``.
-    Encoding-agnostic: stores raw bytes, decodes lazily based on content_type.
-    """
-
-    def __init__(self, path_params : dict,
-                       query_params: dict,
-                       body_bytes  : bytes,
-                       content_type: str = 'application/json'):
-        self.path_params  = path_params
-        self.query_params = query_params
-        self.content_type = content_type
-        self._body        = body_bytes
-        self._decoded     = None
-
-    async def body(self) -> bytes:
-        """Raw body bytes (matches ``Request.body()``)."""
-        return self._body
-
-    async def json(self) -> dict:
-        """Parse body into a Python dict (matches ``Request.json()``).
-
-        Content-type-aware: JSON or msgpack based on Content-Type header.
-        """
-        if self._decoded is not None:
-            return self._decoded
-
-        ct = self.content_type or 'application/json'
-        if 'msgpack' in ct:
-            self._decoded = msgpack.unpackb(self._body, raw=False)
-        else:
-            self._decoded = json.loads(self._body) if self._body else {}
-        return self._decoded
 
 
 # Re-export for backward compatibility (bridge_plugin_host.py, tests, etc.)
@@ -201,14 +164,11 @@ class EndpointService(PluginHostBase):
     def _match_route(self, method: str, path: str):
         """Match *method* + *path* against the direct-dispatch route table.
 
-        Returns ``(handler, path_params)`` or ``(None, None)``.
+        Thin wrapper over :func:`radical.orbit.dispatch.match_route` bound to
+        this endpoint's live route table.  Returns ``(handler, path_params)``
+        or ``(None, None)``.
         """
-        for rt_method, pattern, param_names, handler in self._direct_routes:
-            if rt_method == method:
-                m = pattern.match(path)
-                if m:
-                    return handler, dict(zip(param_names, m.groups()))
-        return None, None
+        return match_route(self._direct_routes, method, path)
 
     @staticmethod
     def _error_response(req_id: str, exc: Exception) -> ResponseMessage:

--- a/tests/unittests/test_runtime.py
+++ b/tests/unittests/test_runtime.py
@@ -1,0 +1,481 @@
+"""Tests for :class:`radical.orbit.runtime.EndpointRuntime` (M4).
+
+The suite drives a **real** :class:`~radical.orbit.broker.Broker` under uvicorn
+on an ephemeral port and connects **real** ``EndpointRuntime`` participants over
+real WebSockets — the most faithful reproduction of production wiring.  Where a
+building block is better exercised in isolation (the callback-dispatcher
+drop-oldest counter, the dispatch.py move) it is unit-tested directly.
+
+No test sleeps for more than ~2.5 s; liveness/backoff knobs are injected tiny.
+"""
+
+import asyncio
+import subprocess
+import threading
+import time
+
+import pytest
+
+from radical.orbit               import PluginSession
+from radical.orbit.plugin_base   import Plugin
+from radical.orbit.client        import PluginClient
+
+
+# ---------------------------------------------------------------------------
+# TLS material (the broker requires a loadable cert/key even for plain-ws runs)
+# ---------------------------------------------------------------------------
+
+def _have_openssl() -> bool:
+    try:
+        subprocess.run(['openssl', 'version'], check=True, capture_output=True)
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+@pytest.fixture
+def self_signed(tmp_path):
+    if not _have_openssl():
+        pytest.skip("openssl not available")
+    import os
+    cert = tmp_path / 'cert.pem'
+    key  = tmp_path / 'key.pem'
+    subprocess.run(
+        ['openssl', 'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+         '-keyout', str(key), '-out', str(cert),
+         '-days', '1', '-subj', '/CN=localhost'],
+        check=True, capture_output=True)
+    os.chmod(key, 0o600)
+    return cert, key
+
+
+# ---------------------------------------------------------------------------
+# A tiny served plugin: ping (session-less), echo (session), notify, block
+# ---------------------------------------------------------------------------
+
+class _EchoSession(PluginSession):
+    async def echo(self, msg):
+        return {'echo': msg}
+
+
+class _EchoClient(PluginClient):
+    def ping(self):
+        resp = self._http.get(self._url('ping'))
+        self._raise(resp, 'ping')
+        return resp.json()
+
+    def echo(self, msg):
+        self._require_session()
+        resp = self._http.post(self._url(f'echo/{self.sid}'),
+                               json={'msg': msg})
+        self._raise(resp, 'echo')
+        return resp.json()
+
+
+class _EchoPlugin(Plugin):
+    plugin_name   = 'echo_rt'
+    session_class = _EchoSession
+    client_class  = _EchoClient
+    version       = '0.0.1'
+
+    def __init__(self, app):
+        super().__init__(app, 'echo_rt')
+        self.add_route_get('ping',        self._ping)
+        self.add_route_post('echo/{sid}', self._echo)
+        self.add_route_get('notify',      self._notify)
+        self.add_route_get('slow/{ms}',   self._slow)
+        self.add_route_get('block/{ms}',  self._block)
+
+    async def _ping(self, request):
+        return {'pong': True}
+
+    async def _echo(self, request):
+        sid  = request.path_params['sid']
+        data = await request.json()
+        return await self._forward(sid, _EchoSession.echo, data.get('msg'))
+
+    async def _notify(self, request):
+        await self.send_notification('demo', {'hello': 'world'})
+        return {'sent': True}
+
+    async def _slow(self, request):
+        # An async sleep holds the concurrency slot WITHOUT stalling the work
+        # loop — so admission of further requests still runs (503 fast-fail).
+        await asyncio.sleep(int(request.path_params['ms']) / 1000.0)
+        return {'slow': True}
+
+    async def _block(self, request):
+        # A synchronous sleep pins the WORK loop — the transport thread must
+        # keep answering keepalive regardless (transport isolation).
+        time.sleep(int(request.path_params['ms']) / 1000.0)
+        return {'blocked': True}
+
+
+# ---------------------------------------------------------------------------
+# Broker-under-uvicorn harness + runtime factory
+# ---------------------------------------------------------------------------
+
+class _RunningBroker:
+    def __init__(self, broker, ws_ping_interval, ws_ping_timeout):
+        import uvicorn
+        self.broker = broker
+        config = uvicorn.Config(
+            broker.app, host='127.0.0.1', port=0, log_level='error',
+            ws_ping_interval=ws_ping_interval,
+            ws_ping_timeout=ws_ping_timeout)
+        self._server = uvicorn.Server(config)
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
+
+    def start(self):
+        self._thread.start()
+        deadline = time.time() + 10.0
+        while time.time() < deadline:
+            if self._server.started and self._server.servers:
+                socks = self._server.servers[0].sockets
+                if socks:
+                    self.port = socks[0].getsockname()[1]
+                    return self
+            time.sleep(0.02)
+        raise RuntimeError("broker server did not start")
+
+    @property
+    def url(self):
+        return 'http://127.0.0.1:%d' % self.port
+
+    def stop(self):
+        self._server.should_exit = True
+        self._thread.join(timeout=10.0)
+
+
+@pytest.fixture
+def harness(self_signed, tmp_path, monkeypatch):
+    """Factory yielding (make_broker, make_runtime); tears everything down."""
+    from radical.orbit import utils
+    monkeypatch.setattr(utils, 'URL_FILE',   tmp_path / 'bridge.url')
+    monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'bridge.token')
+    monkeypatch.delenv('RADICAL_ORBIT_BRIDGE_TOKEN', raising=False)
+    monkeypatch.delenv('RADICAL_ORBIT_BRIDGE_URL',   raising=False)
+    cert, key = self_signed
+
+    servers = []
+    runtimes = []
+
+    def make_broker(ws_ping_interval=20.0, ws_ping_timeout=20.0, **kw):
+        from radical.orbit.broker import Broker
+        defaults = dict(cert=str(cert), key=str(key), no_auth=True, grace=2.0)
+        defaults.update(kw)
+        broker = Broker(**defaults)
+        srv = _RunningBroker(broker, ws_ping_interval, ws_ping_timeout).start()
+        servers.append(srv)
+        return srv
+
+    def make_runtime(url, wait=True, **kw):
+        from radical.orbit.runtime import EndpointRuntime
+        defaults = dict(broker_url=url, token=None, ping_interval=1.0,
+                        ping_timeout=3.0, backoff_start=0.05, backoff_max=0.2)
+        defaults.update(kw)
+        rt = EndpointRuntime(**defaults)
+        runtimes.append(rt)
+        rt.start(wait=wait, timeout=10.0)
+        return rt
+
+    yield make_broker, make_runtime
+
+    for rt in runtimes:
+        try:    rt.stop()
+        except Exception:
+            pass
+    for srv in servers:
+        try:    srv.stop()
+        except Exception:
+            pass
+
+
+def _wait(cond, timeout=5.0, interval=0.02):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if cond():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def _wait_topology(rt, name, plugin=None, timeout=5.0):
+    def _ok():
+        topo = rt.topology()
+        if name not in topo:
+            return False
+        if plugin is None:
+            return True
+        return plugin in (topo[name].get('plugins') or {})
+    return _wait(_ok, timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# register + ack + auto-name consumer
+# ---------------------------------------------------------------------------
+
+def test_register_ack_and_auto_named_consumer(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+
+    rt = make_runtime(srv.url)                      # no name, no plugins
+    assert rt.wait_registered(timeout=5.0)
+    assert rt.name.startswith('consumer.')
+    assert rt.resume_key                            # minted, non-empty
+    assert rt._role() == 'consumer'
+    assert _wait(lambda: rt.name in srv.broker.registry)
+
+
+# ---------------------------------------------------------------------------
+# name-in-use retry/backoff, then the name frees and the retry wins
+# ---------------------------------------------------------------------------
+
+def test_name_in_use_retries_until_name_frees(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+
+    a = make_runtime(srv.url, name='dup')
+    assert a.wait_registered(timeout=5.0)
+
+    b = make_runtime(srv.url, name='dup', wait=False)
+    # b keeps hitting name-in-use while a holds the name.
+    assert b.wait_registered(timeout=1.0) is False
+
+    a.stop()                                        # clean close frees 'dup'
+    assert b.wait_registered(timeout=5.0)
+    assert _wait(lambda: 'dup' in srv.broker.registry)
+
+
+# ---------------------------------------------------------------------------
+# resume-key reconnect replaces a live socket
+# ---------------------------------------------------------------------------
+
+def test_resume_key_replaces_live_socket(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+
+    a = make_runtime(srv.url, name='r1', backoff_start=30.0, backoff_max=30.0)
+    assert a.wait_registered(timeout=5.0)
+    key = a.resume_key
+
+    # A second participant with the same name + the resume key replaces A.
+    b = make_runtime(srv.url, name='r1', resume_key=key)
+    assert b.wait_registered(timeout=5.0)
+    assert b.resume_key == key                      # broker returns same key
+    assert _wait(lambda: 'r1' in srv.broker.registry)
+    # A's socket is closed by the broker; with a 30 s backoff it does not
+    # ping-pong back within the test window.
+
+
+# ---------------------------------------------------------------------------
+# serve a plugin end-to-end: A serves echo, B calls it via get_plugin()
+# ---------------------------------------------------------------------------
+
+def test_serve_and_call_plugin_end_to_end(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+
+    a = make_runtime(srv.url, name='epA', plugins=['echo_rt'])
+    assert a.wait_registered(timeout=5.0)
+    assert a._role() == 'endpoint'
+
+    b = make_runtime(srv.url, name='epB')
+    assert _wait_topology(b, 'epA', 'echo_rt', timeout=5.0)
+
+    echo = b.get_plugin('epA', 'echo_rt')
+    assert echo.ping() == {'pong': True}
+    assert echo.echo('hi') == {'echo': 'hi'}
+
+    # Also exercise the raw consumer call surface.
+    resp = b.call('epA', 'GET', '/echo_rt/ping')
+    assert resp.status_code == 200
+    assert resp.json() == {'pong': True}
+
+
+# ---------------------------------------------------------------------------
+# pending-table timeout (and no leak: a later call still works)
+# ---------------------------------------------------------------------------
+
+def test_call_timeout_and_recovery(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+
+    a = make_runtime(srv.url, name='epA', plugins=['echo_rt'])
+    b = make_runtime(srv.url, name='epB')
+    assert _wait_topology(b, 'epA', 'echo_rt', timeout=5.0)
+
+    with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+        b.call('epA', 'GET', '/echo_rt/slow/600', timeout=0.2)
+
+    time.sleep(0.8)                                 # let the handler drain
+    resp = b.call('epA', 'GET', '/echo_rt/ping')
+    assert resp.status_code == 200                  # pending table not leaked
+
+
+# ---------------------------------------------------------------------------
+# 503 fast-fail at the request-concurrency cap (+ Retry-After)
+# ---------------------------------------------------------------------------
+
+def test_503_fast_fail_at_concurrency_cap(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+
+    a = make_runtime(srv.url, name='epA', plugins=['echo_rt'],
+                     request_concurrency=1, accept_queue=0)
+    b = make_runtime(srv.url, name='epB')
+    assert _wait_topology(b, 'epA', 'echo_rt', timeout=5.0)
+
+    # Occupy the single slot with a blocking request.
+    def _occupy():
+        b.call('epA', 'GET', '/echo_rt/slow/800', timeout=5.0)
+
+    t = threading.Thread(target=_occupy, daemon=True)
+    t.start()
+    assert _wait(lambda: a._req_inflight >= 1, timeout=2.0)
+
+    resp = b.call('epA', 'GET', '/echo_rt/ping', timeout=2.0)
+    assert resp.status_code == 503
+    assert 'retry-after' in {k.lower(): v for k, v in resp.headers.items()}
+    t.join(timeout=5.0)
+
+
+# ---------------------------------------------------------------------------
+# event round-trip with auto-subscribe; callback fires on the callback thread
+# ---------------------------------------------------------------------------
+
+def test_event_roundtrip_on_callback_thread(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+
+    a = make_runtime(srv.url, name='epA', plugins=['echo_rt'])
+    b = make_runtime(srv.url, name='epB')
+    assert _wait_topology(b, 'epA', 'echo_rt', timeout=5.0)
+
+    seen = []
+    lock = threading.Lock()
+
+    def _cb(endpoint, plugin, topic, data):
+        with lock:
+            seen.append((endpoint, plugin, topic, data,
+                         threading.get_ident()))
+
+    b.register_callback(endpoint_id='epA', plugin_name='echo_rt',
+                        topic='demo', callback=_cb)
+    time.sleep(0.2)                                 # let the subscribe land
+
+    b.call('epA', 'GET', '/echo_rt/notify')
+    assert _wait(lambda: len(seen) >= 1, timeout=5.0)
+
+    endpoint, plugin, topic, data, ident = seen[0]
+    assert (endpoint, plugin, topic) == ('epA', 'echo_rt', 'demo')
+    assert data == {'hello': 'world'}
+    # The user callback ran on the dedicated dispatcher thread — NOT the work
+    # loop or the transport loop.
+    assert ident == b._cb.ident
+    assert ident != b._work_ident
+    assert ident != b._transport_ident
+
+
+# ---------------------------------------------------------------------------
+# topology callback on connect + disconnect
+# ---------------------------------------------------------------------------
+
+def test_topology_callback_connect_and_disconnect(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+
+    b = make_runtime(srv.url, name='epB')
+    snaps = []
+    lock  = threading.Lock()
+
+    def _topo(participants):
+        with lock:
+            snaps.append(set(participants.keys()))
+
+    b.register_topology_callback(_topo)
+
+    a = make_runtime(srv.url, name='epA', plugins=['echo_rt'])
+    assert _wait(lambda: any('epA' in s for s in snaps), timeout=5.0)
+
+    a.stop()
+    assert _wait(lambda: snaps and 'epA' not in snaps[-1], timeout=5.0)
+
+
+# ---------------------------------------------------------------------------
+# RuntimePluginClient satisfies a real plugin helper (sysinfo)
+# ---------------------------------------------------------------------------
+
+def test_runtime_plugin_client_satisfies_sysinfo(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+
+    a = make_runtime(srv.url, name='epA', plugins=['sysinfo'])
+    b = make_runtime(srv.url, name='epB')
+    assert _wait_topology(b, 'epA', 'sysinfo', timeout=5.0)
+
+    sysinfo = b.get_plugin('epA', 'sysinfo')
+    assert isinstance(sysinfo.homedir(), str)       # session-less helper
+    metrics = sysinfo.get_metrics()                 # session helper
+    assert 'system' in metrics
+
+
+# ---------------------------------------------------------------------------
+# transport isolation: a blocked work loop keeps the endpoint present
+# ---------------------------------------------------------------------------
+
+def test_transport_isolation_blocked_work_loop_stays_present(harness):
+    make_broker, make_runtime = harness
+    # Aggressive broker keepalive: a client that failed to answer would be
+    # dropped in well under a second.
+    srv = make_broker(ws_ping_interval=0.2, ws_ping_timeout=0.5)
+
+    a = make_runtime(srv.url, name='epA', plugins=['echo_rt'],
+                     ping_interval=0.2, ping_timeout=0.5)
+    b = make_runtime(srv.url, name='epB',
+                     ping_interval=0.2, ping_timeout=0.5)
+    assert _wait_topology(b, 'epA', 'echo_rt', timeout=5.0)
+
+    # Block A's work loop for ~2.5 s.
+    def _block():
+        b.call('epA', 'GET', '/echo_rt/block/2500', timeout=5.0)
+
+    t = threading.Thread(target=_block, daemon=True)
+    t.start()
+    assert _wait(lambda: a._req_inflight >= 1, timeout=2.0)
+
+    # Mid-block, A must still be present (transport thread answered pings).
+    time.sleep(1.2)
+    assert 'epA' in srv.broker.registry
+    assert srv.broker._liveness.get('epA') == 'present'
+    t.join(timeout=5.0)
+
+
+# ---------------------------------------------------------------------------
+# callback-queue drop-oldest counter (unit)
+# ---------------------------------------------------------------------------
+
+def test_callback_dispatcher_drop_oldest_counter():
+    from radical.orbit.runtime_support import CallbackDispatcher
+    cb = CallbackDispatcher(maxlen=2)               # not started → nothing drains
+    for _ in range(5):
+        cb.submit(lambda: None)
+    assert cb.dropped == 3                           # 5 submitted, 2 retained
+
+
+# ---------------------------------------------------------------------------
+# dispatch.py move: service.py re-export + shared function
+# ---------------------------------------------------------------------------
+
+def test_dispatch_move_reexport():
+    from radical.orbit import dispatch
+    from radical.orbit import service
+    from radical.orbit import bridge_plugin_host
+    assert service.RequestShim is dispatch.RequestShim
+    assert bridge_plugin_host.RequestShim is dispatch.RequestShim
+    assert callable(dispatch.match_route)
+    # A route table the shared matcher understands.
+    import re
+    routes = [('GET', re.compile(r'^/p/ping$'), (), 'H')]
+    handler, params = dispatch.match_route(routes, 'GET', '/p/ping')
+    assert handler == 'H' and params == {}


### PR DESCRIPTION
Fourth milestone of `plans/broker_architecture_plan.md` (M4 — endpoint/participant runtime), stacked on #66. New modules alongside the old stack; `bin/` defaults unchanged; old suite green bit-for-bit.

## What

**`EndpointRuntime`** (`runtime.py`) — one participant node type that serves plugins, consumes them, or both, over a single outbound WS:

- **Transport thread** (own asyncio loop): connect with the service.py URL/TLS/cert + tunnel (`forward`/`reverse`) handling, `register` handshake gated on `register_ack`, resume-key reconnect (replace path), `name-in-use` retry with capped backoff (a crashed predecessor's name frees within seconds under the fast keepalive), websockets keepalive, raw frame send/recv **only**.
- **Work loop**: pack/parse + all dispatch. Served requests go through the moved `dispatch.py` machinery against plugins mounted exactly as `service.py` mounts them; **bounded request concurrency with immediate 503 + `Retry-After`** at the cap (never a silent drop). Consumer calls resolve a per-runtime pending table (`corr_id` namespaced by name).
- **M0 coalesced handoff** both directions (`runtime_support.py`): bounded deque + one `call_soon_threadsafe` per burst; inbound is soft-bounded with an overflow counter — the transport loop can never be blocked by work (transport-isolation smoke test: work loop blocked 2.5 s under 0.2/0.5 keepalive, endpoint stays `present`).
- **User callbacks on a dedicated dispatcher thread** (bounded queue, drop-oldest + counter); registering a callback auto-emits `subscribe` (filter-at-edge semantics preserved from `BridgeClient`).
- **Consumer facade keeps call-site shape**: `get_plugin(target, ...).method()`, `register_session(...)`, sync over `run_coroutine_threadsafe`. Zero-plugin consumers auto-name `consumer.<uuid8>` (session reattach needs a stable client-supplied name — documented).
- **`RuntimePluginClient`** (`runtime_client.py`): rides a new single transport seam in `PluginClient` (`_request` + swappable `_http`), so **all 11 plugin `client_class` helpers work over the runtime unchanged** (verified against the real sysinfo helper in-process).

**Old-stack touches (all minimal, suite bit-for-bit green):**
- `dispatch.py`: pure move of `RequestShim`/`match_route` out of `service.py` (re-exported there; `bridge_plugin_host` imports the shared code).
- `client.py`: the `_request` seam; two call sites rerouted, helpers untouched.
- `plugin_rhapsody.py`: Dragon `rh.Session` construction offloaded via `asyncio.to_thread` — the M0-gated fix (gate passed; ~2.8 ms GIL hold measured, so this is work-loop hygiene, liveness never depended on it).

## Testing

12 new tests, all in-process against a **real Broker under uvicorn + real runtimes over real sockets**: register/auto-name, name-in-use retry, resume replace, serve+call end-to-end via `get_plugin().method()`, pending timeout without leaks, 503+Retry-After at cap, event round-trip with callback-thread identity asserted, drop-oldest counter, topology callbacks, RuntimePluginClient×sysinfo helper, transport-isolation smoke, dispatch re-export compat.

Full suite: **885 passed, 2 skipped**; `flake8 src/ bin/` clean.

## Notes

- Plugin namespaces are endpoint-relative in the star model (`/{instance}`, routing is by `dst`) — the M5 gateway maps the bridge-era URL shape (`/{endpoint}/{ns}/...`) onto this.
- `register_ack` is the one frame parsed on the transport loop (the handshake gates everything); documented deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)