### PR TITLE
M5: gateway module — HTTP/SSE/Explorer compat tier on the broker seam

### DIFF
--- a/src/radical/orbit/broker.py
+++ b/src/radical/orbit/broker.py
@@ -179,7 +179,8 @@ Bridge`.  The tunable liveness/backpressure knobs — ``ping_interval`` and
                  event_queue:       int   = 1024,
                  frame_cap:         int   = protocol.FRAME_CAP,
                  clock:             Callable[[], float] = time.monotonic,
-                 watchdog_interval: float = 1.0):
+                 watchdog_interval: float = 1.0,
+                 gateway:           bool  = True):
 
         # ── TLS config ───────────────────────────────────────────────
         cert_path, _ = utils.resolve_bridge_cert(cli=cert)
@@ -210,6 +211,7 @@ Bridge`.  The tunable liveness/backpressure knobs — ``ping_interval`` and
         self._clock             = clock
         self._watchdog_interval = watchdog_interval
         self._plugins_spec: str = plugins or ''
+        self._gateway_enabled   = gateway
 
         # ── Routing state (all touched only on the routing loop) ──────
         self.registry:       Dict[str, Any]         = {}   # name -> transport ws
@@ -217,6 +219,12 @@ Bridge`.  The tunable liveness/backpressure knobs — ``ping_interval`` and
         self._liveness:      Dict[str, str]         = {}   # name -> present/...
         self._resume_keys:   Dict[str, str]         = {}   # name -> resume_key
         self._grace_timers:  Dict[str, Any]         = {}   # name -> TimerHandle
+
+        # Topology-change listeners (the one minimal seam the M5 gateway needs
+        # beyond tap/pending/caller: topology changes do not flow through the
+        # raw event tap).  Fired synchronously on the routing loop from
+        # ``_broadcast_topology``.
+        self._topology_listeners: List[Callable[[], None]] = []
 
         # Correlation: one broker-side pending table (src='broker') plus a
         # lightweight inflight forwarding table for grace-bounded fast-fail.
@@ -258,6 +266,16 @@ Bridge`.  The tunable liveness/backpressure knobs — ``ping_interval`` and
         self._setup_middleware()
         self._register_routes()
 
+        # ── Gateway module ──────────────────────────────────────────
+        # On by default: build/attach the compat-tier HTTP/SSE/UI ingress onto
+        # this same app (single port, single uvicorn server).  ``gateway=False``
+        # is a headless broker (only the token-gated WS ``/register``).  Imported
+        # lazily so a broker import never hard-depends on the gateway module.
+        self._gateway = None
+        if self._gateway_enabled:
+            from .gateway import Gateway
+            self._gateway = Gateway(self)
+
     # ── public API / gateway seam ─────────────────────────────────────
 
     @property
@@ -289,6 +307,23 @@ Bridge`.  The tunable liveness/backpressure knobs — ``ping_interval`` and
         callable.
         """
         return self._events.tap(callback)
+
+    def add_topology_listener(self, callback: Callable[[], None]
+                              ) -> Callable[[], None]:
+        """Register an in-process topology-change listener (gateway seam).
+
+        Called (with no arguments) on the **routing loop** whenever the topology
+        is (re)broadcast — a participant connecting, disconnecting, going
+        ``suspect``/``lost``, or a hosted-plugin change.  The listener reads
+        :meth:`topology_snapshot` itself.  Returns an unsubscribe callable.
+        """
+        self._topology_listeners.append(callback)
+
+        def _remove() -> None:
+            try:    self._topology_listeners.remove(callback)
+            except ValueError:
+                pass
+        return _remove
 
     def topology_snapshot(self) -> Dict[str, Dict[str, Any]]:
         """The current rich topology dict (gateway seam).
@@ -427,7 +462,11 @@ Bridge`.  The tunable liveness/backpressure knobs — ``ping_interval`` and
     # ── middleware (token gate only — no CORS, that is the gateway's) ──
 
     def _setup_middleware(self) -> None:
-        if self._auth_enabled:
+        # When the gateway is attached it installs the fuller HTTP auth gate
+        # (with the Explorer's ``/`` + ``/plugins/*`` exemptions); the core's
+        # OPTIONS-only gate is only needed for a headless broker.  The WS
+        # ``/register`` gate is separate (inside the handler) regardless.
+        if self._auth_enabled and not self._gateway_enabled:
             self._app.add_middleware(BaseHTTPMiddleware,
                                      dispatch=self._auth_dispatch)
 
@@ -897,6 +936,11 @@ Bridge`.  The tunable liveness/backpressure knobs — ``ping_interval`` and
         packed = self._build_topology_msg()
         for name, ws in list(self.registry.items()):
             await self._send(ws, packed)
+        # Notify in-process topology listeners (the gateway's SSE fan-out).
+        for cb in list(self._topology_listeners):
+            try:    cb()
+            except Exception as e:
+                log.error("[Broker] topology listener failed: %r", e, exc_info=e)
 
     # ── low-level helpers ─────────────────────────────────────────────
 

--- a/src/radical/orbit/gateway.py
+++ b/src/radical/orbit/gateway.py
@@ -1,0 +1,567 @@
+"""ORBIT Gateway — the broker's compat-tier HTTP/SSE/UI ingress.
+
+The gateway is a broker **module**, explicitly *not* a :class:`Plugin`: it is
+the single non-participant ingress onto the participant star.  Where a
+:class:`~radical.orbit.plugin_base.Plugin` is handed a narrow app+session
+surface and speaks the participant protocol, the gateway needs an interface far
+wider than ``Plugin``'s — the shared pending table, the raw event tap, the
+topology snapshot, the uvicorn app, CORS, and the ingress token gate — and it
+serves clients that never speak the wire protocol at all (browsers, ``curl``,
+the legacy HTTP client).  Making it an honest module with a constructor-declared
+seam is the point.
+
+**The seam (why it is wider than a plugin's).**  :class:`Gateway` consumes the
+following members of the :class:`~radical.orbit.broker.Broker` it is handed:
+
+* :attr:`Broker.app`               — mount the HTTP routes + middleware here
+                                     (single port, single uvicorn server).
+* :attr:`Broker.caller`            — the HTTP catch-all proxies every request
+                                     through this handle over the **shared**
+                                     broker pending table.
+* :meth:`Broker.tap`               — the ``/events`` SSE fan-out subscribes to
+                                     the raw event stream (plugin notifications).
+* :meth:`Broker.add_topology_listener` — the ``/events`` topology fan-out (the
+                                     one minimal hook M5 adds to the broker, as
+                                     topology changes do not flow through the
+                                     tap).
+* :meth:`Broker.topology_snapshot` — the source of the discovery response and
+                                     the SSE topology payload.
+* :attr:`Broker.token` / :attr:`Broker.auth_enabled` — the ingress token gate
+                                     and the ``/auth`` cookie.
+* :attr:`Broker.url`               — advertised in the discovery response.
+* :attr:`Broker.registry`          — the unknown-endpoint / disconnect check.
+* :meth:`Broker._disconnect` / :meth:`Broker._handle_control` — the admin
+                                     control path (protected members, used by
+                                     the disconnect/terminate routes).
+
+**Loops.**  Gateway HTTP/SSE handlers run on the **routing loop** (uvicorn's
+loop): they are ``async`` and ``await`` the caller — no blocking work in a
+handler.  The topology listener also fires on the routing loop, so it reads
+``topology_snapshot()`` (routing-loop-owned state) directly.  The raw event tap,
+however, fires on the **plugin-host loop**; its callback hands the formatted SSE
+frame to the routing loop via ``call_soon_threadsafe`` before touching any
+per-client queue.
+
+**Backpressure contract.**  Each SSE client owns a *bounded, drop-oldest* queue
+with a dropped counter (mirroring the broker's per-subscriber delivery queues):
+a stalled browser can never grow broker memory — the oldest frame is dropped and
+the loss is countable, never propagated back into the routing loop.
+
+**Sessions.**  Gateway-originated sessions carry **no participant identity** —
+they are capability-style within the token trust domain.  Only TTL/persistent
+sessions are meaningful for such callers; owner-checked reattach (403) is an M6
+concern.
+
+The gateway preserves the **exact** bridge-era HTTP surface (paths, response
+shapes, SSE message envelopes) so the Explorer UI keeps working unchanged; it is
+the compat tier the broker-native runtime does not need.
+"""
+
+# pylint: disable=protected-access
+
+import asyncio
+import json
+import logging
+import os
+import posixpath
+import re
+
+from collections import deque
+from typing      import Any, Dict, Optional, Set
+
+from fastapi                    import Request, Response, HTTPException
+from fastapi.responses          import JSONResponse, FileResponse
+from fastapi.middleware.cors    import CORSMiddleware
+from starlette.middleware.base  import BaseHTTPMiddleware
+from starlette.responses        import StreamingResponse
+
+from . import utils
+
+
+log = logging.getLogger("radical.orbit.gateway")
+
+# Per proxied request: the gateway forwards an HTTP request to the endpoint over
+# the shared broker pending table and waits this many seconds for the response
+# before returning 504.  Carried over verbatim from the bridge (``bridge.py``
+# ``REQUEST_TIMEOUT``): a submit batch of thousands of tasks (whose dragon-side
+# ProcessGroup creation takes seconds per task) genuinely takes this long.
+REQUEST_TIMEOUT = 600
+
+# The name the broker reserves for its own hosted-plugin participant.  Kept in
+# sync with :data:`radical.orbit.broker.BROKER_NAME`; duplicated here to avoid a
+# module import cycle (broker imports gateway).
+BROKER_NAME = 'broker'
+
+# Allowed CORS origins — carried over from ``Bridge._setup_middleware``.  LUCID
+# needs credentials; browsers reject credentials + wildcard origin, so the
+# allow-list is explicit.
+CORS_ORIGINS = [
+    "http://localhost",
+    "http://localhost:8080",
+    "https://localhost",
+    "https://localhost:8080",
+    "https://dev-1.bv-brc.org",
+]
+
+# Hop-by-hop headers plus the bridge credential, stripped before a request is
+# forwarded to an endpoint (so the shared token never rides on to plugins).
+_HOP_BY_HOP = {"connection", "keep-alive", "proxy-authenticate",
+               "proxy-authorization", "te", "trailers",
+               "transfer-encoding", "upgrade", "authorization"}
+
+
+# ---------------------------------------------------------------------------
+# Per-SSE-client bounded delivery queue
+# ---------------------------------------------------------------------------
+
+class _SSEQueue:
+    """A per-SSE-client bounded, drop-oldest delivery queue.
+
+    Overflow drops the *oldest* frame and bumps :attr:`dropped` — a stalled
+    browser is disciplined at its own queue and can never backpressure the
+    routing loop or grow broker memory.  The ``deque(maxlen=...)`` does the
+    oldest-eviction; ``dropped`` makes the loss observable.
+    """
+
+    __slots__ = ('buf', 'dropped', 'wake')
+
+    def __init__(self, maxlen: int):
+        self.buf     : deque         = deque(maxlen=maxlen)
+        self.dropped : int           = 0
+        self.wake    : asyncio.Event = asyncio.Event()
+
+    def push(self, item: str) -> None:
+        if len(self.buf) == self.buf.maxlen:
+            self.dropped += 1                  # deque evicts the oldest here
+        self.buf.append(item)
+        self.wake.set()
+
+
+# ---------------------------------------------------------------------------
+# Gateway
+# ---------------------------------------------------------------------------
+
+class Gateway:
+    """The compat-tier HTTP/SSE/UI ingress attached onto :attr:`Broker.app`.
+
+    Args:
+      broker:          the :class:`~radical.orbit.broker.Broker` whose seam this
+                       gateway consumes (see the module docstring).
+      request_timeout: the proxy 504 deadline in seconds (default
+                       :data:`REQUEST_TIMEOUT`).
+      sse_queue:       per-SSE-client delivery queue depth (drop-oldest).
+    """
+
+    def __init__(self, broker,
+                 request_timeout: int = REQUEST_TIMEOUT,
+                 sse_queue:       int = 1024):
+        self._broker          = broker
+        self._app             = broker.app
+        self._request_timeout = request_timeout
+        self._sse_depth       = sse_queue
+
+        # SSE fan-out state.  Clients live on the routing loop; the tap callback
+        # (plugin-host loop) hands frames over via ``_routing_loop``.
+        self._sse_clients:  Set[_SSEQueue]                        = set()
+        self._routing_loop: Optional[asyncio.AbstractEventLoop]   = None
+        self._untap         = None
+        self._untopo        = None
+
+        self._setup_middleware()
+        self._register_routes()
+        self._subscribe_events()
+
+    # ── token config passthrough ──────────────────────────────────────
+
+    @property
+    def _token(self) -> Optional[str]:
+        return self._broker.token
+
+    @property
+    def _auth_enabled(self) -> bool:
+        return self._broker.auth_enabled
+
+    # ── middleware (auth gate + CORS) ─────────────────────────────────
+
+    def _setup_middleware(self) -> None:
+        """Attach the ingress token gate + the CORS allow-list.
+
+        Ported from ``Bridge._setup_middleware``: auth is added *before* CORS so
+        CORS ends up outermost (Starlette applies the most-recently-added
+        middleware first), which means a 401 still carries CORS headers and the
+        browser can read it.  The broker suppresses its own HTTP auth middleware
+        while the gateway is attached (the ``/register`` WS gate is separate).
+        """
+        if self._auth_enabled:
+            self._app.add_middleware(BaseHTTPMiddleware,
+                                     dispatch=self._auth_dispatch)
+        self._app.add_middleware(
+            CORSMiddleware,
+            allow_credentials=True,
+            allow_origins=CORS_ORIGINS,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+    @staticmethod
+    def _request_token(request: Request) -> Optional[str]:
+        """Bearer header first, else the ``orbit_bridge_token`` cookie (the
+        browser/SSE path minted by ``POST /auth``)."""
+        auth = request.headers.get('authorization', '')
+        if auth.lower().startswith('bearer '):
+            return auth[7:].strip()
+        return request.cookies.get(utils.AUTH_COOKIE)
+
+    async def _auth_dispatch(self, request: Request, call_next):
+        """Require the shared token on every capability-bearing HTTP route.
+
+        Exempt (ported verbatim from the bridge): CORS preflight (``OPTIONS``),
+        the UI shell (``/``), and the static plugin JS (``/plugins/...``) —
+        these carry no capability and must load so the Explorer can prompt for
+        the token.  ``POST /auth`` is *not* exempt: it is reached only with a
+        valid bearer header and then mints the cookie.  The path is normalized
+        first so a traversal-style path cannot slip a gated route past the gate
+        (normalizing can only ever *under*-exempt).
+        """
+        path = posixpath.normpath(request.url.path)
+        if request.method == 'OPTIONS' \
+                or path == '/' \
+                or path.startswith('/plugins/'):
+            return await call_next(request)
+        if not utils.tokens_match(self._request_token(request), self._token):
+            return JSONResponse(
+                status_code=401,
+                content={"error": True, "status_code": 401,
+                         "detail": "missing or invalid bridge token"})
+        return await call_next(request)
+
+    # ── event subscriptions (SSE fan-out) ─────────────────────────────
+
+    def _subscribe_events(self) -> None:
+        self._untap  = self._broker.tap(self._on_event)
+        self._untopo = self._broker.add_topology_listener(self._on_topology)
+
+    def detach(self) -> None:
+        """Unsubscribe the tap + topology listener (mainly for tests)."""
+        if self._untap:
+            self._untap()
+            self._untap = None
+        if self._untopo:
+            self._untopo()
+            self._untopo = None
+
+    @staticmethod
+    def _sse_frame(topic: str, data: Any) -> str:
+        """Format one SSE frame exactly as the bridge wrote it on the wire:
+        ``data: {"topic": <topic>, "data": <data>}\\n\\n`` (no keepalive
+        comments — the bridge emitted none)."""
+        return "data: %s\n\n" % json.dumps({"topic": topic, "data": data})
+
+    def _on_event(self, event: Dict[str, Any]) -> None:
+        """Raw event tap callback — runs on the **plugin-host loop**.
+
+        Renders the legacy notification envelope
+        ``{topic: 'notification', data: {endpoint, plugin, topic, data}}`` and
+        hands it to the routing loop, which owns the per-client queues.
+        """
+        if not self._sse_clients:
+            return
+        loop = self._routing_loop
+        if loop is None:
+            return
+        frame = self._sse_frame('notification', {
+            "endpoint": event.get('src'),
+            "plugin":   event.get('plugin'),
+            "topic":    event.get('topic'),
+            "data":     event.get('data') or {},
+        })
+        loop.call_soon_threadsafe(self._push_all, frame)
+
+    def _on_topology(self) -> None:
+        """Topology-change listener — runs on the **routing loop**.
+
+        Emits the legacy topology envelope with the same ``{bridge, endpoints}``
+        payload the discovery route returns (the exact shape the bridge sent).
+        """
+        if not self._sse_clients:
+            return
+        self._push_all(self._sse_frame('topology', self._discovery_snapshot()))
+
+    def _push_all(self, frame: str) -> None:
+        """Enqueue one frame onto every SSE client (routing loop only)."""
+        for q in list(self._sse_clients):
+            q.push(frame)
+
+    # ── discovery snapshot (bridge-era shape) ─────────────────────────
+
+    @staticmethod
+    def _full_namespace(name: str, ns: str) -> str:
+        """Present a star-model namespace the way the old API did.
+
+        Endpoint plugins advertise **endpoint-relative** namespaces
+        (``/{instance}``); the bridge-era clients + Explorer consume the *full*
+        ``/{endpoint}/{instance}`` prefix.  Prefix the endpoint name unless the
+        namespace is already rooted at it (the broker's own hosted-plugin
+        participant advertises the full ``/broker/{instance}`` form).
+        """
+        prefix = '/' + name
+        if ns == prefix or ns.startswith(prefix + '/'):
+            return ns
+        if not ns.startswith('/'):
+            ns = '/' + ns
+        return prefix + ns
+
+    def _discovery_snapshot(self) -> Dict[str, Any]:
+        """Build the bridge-era discovery structure from the topology snapshot.
+
+        Shape (unchanged from the bridge)::
+
+            {"bridge":    {"url": <broker url>},
+             "endpoints": {<name>: {"endpoint": {...},
+                                    "plugins":  {<pname>: {namespace, ...}}}}}
+
+        Namespaces are normalized to the full ``/{endpoint}/{instance}`` form.
+        """
+        endpoints: Dict[str, Any] = {}
+        for name, info in self._broker.topology_snapshot().items():
+            plugins: Dict[str, Any] = {}
+            for pname, pinfo in (info.get('plugins') or {}).items():
+                pdata = dict(pinfo)
+                pdata['namespace'] = self._full_namespace(
+                    name, pdata.get('namespace') or '')
+                plugins[pname] = pdata
+            endpoints[name] = {
+                "endpoint": {"role":     info.get('role'),
+                             "liveness": info.get('liveness')},
+                "plugins":  plugins,
+            }
+        return {"bridge":    {"url": self._broker.url},
+                "endpoints": endpoints}
+
+    # ── header hygiene (ported from Bridge._strip_headers) ────────────
+
+    @staticmethod
+    def _strip_headers(request: Request) -> Dict[str, str]:
+        """Drop hop-by-hop headers + the bridge credential before forwarding.
+
+        The ``authorization`` header and the ``orbit_bridge_token`` cookie are
+        removed so the shared token is never forwarded to endpoint plugins; any
+        other cookies are preserved.
+        """
+        headers: Dict[str, str] = {}
+        for k, v in request.headers.items():
+            k_lower = k.lower()
+            if k_lower in _HOP_BY_HOP:
+                continue
+            if k_lower == "cookie":
+                kept = [c.strip() for c in v.split(";")
+                        if c.strip()
+                        and not c.strip().startswith(f"{utils.AUTH_COOKIE}=")]
+                if kept:
+                    headers[k] = "; ".join(kept)
+            else:
+                headers[k] = v
+        return headers
+
+    # ── routes ─────────────────────────────────────────────────────────
+
+    def _register_routes(self) -> None:
+        """Attach every gateway route.  The catch-all proxy is registered LAST
+        so the specific routes (auth/discovery/admin/UI) win the match."""
+        self_ = self
+        app   = self._app
+
+        # ── /auth (mint the browser/SSE cookie) ──────────────────────
+        # Reaching this handler means the auth middleware already validated a
+        # bearer header (or an existing cookie); we then set the HttpOnly,
+        # SameSite=Strict cookie the browser's EventSource rides.  No-op (still
+        # 200) when auth is disabled.
+        @app.post("/auth", tags=["Auth"])
+        async def auth(request: Request):
+            resp = JSONResponse({"ok": True})
+            if self_._auth_enabled and self_._token:
+                resp.set_cookie(key=utils.AUTH_COOKIE, value=self_._token,
+                                httponly=True,
+                                secure=request.url.scheme == "https",
+                                samesite="strict", path="/")
+            return resp
+
+        # ── discovery ────────────────────────────────────────────────
+        @app.post("/endpoint/list", tags=["Discovery"])
+        async def endpoint_list(request: Request):
+            return JSONResponse({"data": self_._discovery_snapshot()})
+
+        @app.get("/endpoints", tags=["Discovery"])
+        async def get_endpoints():
+            out = []
+            for name, info in self_._broker.topology_snapshot().items():
+                plugins = list((info.get('plugins') or {}).keys())
+                out.append({
+                    "name":         name,
+                    "plugins":      plugins,
+                    "connected":    info.get('liveness') == 'present',
+                    "plugin_count": len(plugins),
+                })
+            return JSONResponse({"endpoints": out, "total": len(out)})
+
+        # ── /events (SSE) ────────────────────────────────────────────
+        @app.get("/events", tags=["Events"])
+        async def sse_events(request: Request):
+            self_._routing_loop = asyncio.get_running_loop()
+            q = _SSEQueue(self_._sse_depth)
+            self_._sse_clients.add(q)
+            # The bridge sends the current topology as the first SSE frame.
+            q.push(self_._sse_frame('topology', self_._discovery_snapshot()))
+
+            async def event_generator():
+                try:
+                    while True:
+                        if await request.is_disconnected():
+                            break
+                        try:
+                            await asyncio.wait_for(q.wake.wait(), timeout=1.0)
+                        except asyncio.TimeoutError:
+                            continue
+                        q.wake.clear()
+                        while q.buf:
+                            yield q.buf.popleft()
+                except asyncio.CancelledError:
+                    log.debug("[Gateway] SSE client cancelled")
+                except Exception as e:
+                    log.exception("[Gateway] SSE client error: %s", e)
+                finally:
+                    self_._sse_clients.discard(q)
+
+            return StreamingResponse(event_generator(),
+                                     media_type="text/event-stream")
+
+        # ── admin ────────────────────────────────────────────────────
+        @app.post("/endpoint/disconnect/{endpoint_name}", tags=["Management"])
+        async def disconnect_endpoint(endpoint_name: str):
+            if endpoint_name == BROKER_NAME:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Cannot disconnect the broker host")
+            if endpoint_name not in self_._broker.registry:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Endpoint '{endpoint_name}' not connected")
+            await self_._broker._disconnect(endpoint_name)
+            return JSONResponse({"status":   "shutdown",
+                                 "endpoint": endpoint_name})
+
+        async def _terminate():
+            # Route both terminate paths through the broker's self-SIGTERM floor
+            # (``_handle_control`` schedules the delayed ``os.kill``).
+            await self_._broker._handle_control('gateway', {'op': 'terminate'})
+            return JSONResponse({
+                "status":  "terminating",
+                "message": "Broker will terminate shortly. "
+                           "Endpoints will not be shut down."})
+
+        # Exact old path — the Explorer JS calls it; ``/broker/terminate`` is the
+        # forward-looking alias the rename PR keeps once the old one retires.
+        @app.post("/bridge/terminate", tags=["Management"])
+        async def terminate_bridge():
+            return await _terminate()
+
+        @app.post("/broker/terminate", tags=["Management"])
+        async def terminate_broker():
+            return await _terminate()
+
+        # ── UI: index + plugin JS modules ────────────────────────────
+        @app.get("/", tags=["UI"], include_in_schema=False)
+        async def root():
+            html_path = self_._resource_path('orbit_explorer.html')
+            if html_path:
+                return FileResponse(html_path, headers=self_._no_cache())
+            return Response(content="orbit_explorer.html not found",
+                            status_code=404)
+
+        @app.get("/plugins/{filename}", tags=["UI"], include_in_schema=False)
+        async def serve_plugin(filename: str):
+            if not re.match(r'^[a-z_][a-z0-9_.]*\.js$', filename):
+                raise HTTPException(status_code=404,
+                                    detail="Invalid plugin filename")
+            plugin_path = self_._resource_path('plugins/%s' % filename)
+            if plugin_path:
+                return FileResponse(plugin_path,
+                                    media_type="application/javascript",
+                                    headers=self_._no_cache())
+            raise HTTPException(status_code=404,
+                                detail=f"Plugin '{filename}' not found")
+
+        # ── catch-all proxy (must register LAST) ─────────────────────
+        @app.api_route(
+            "/{endpoint_name}/{path:path}",
+            methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
+            tags=["Proxy"],
+            summary="Proxy requests to endpoint plugins")
+        async def proxy(endpoint_name: str, path: str, request: Request):
+            # Map the bridge-era URL ``/{endpoint}/{plugin_ns}/...`` onto the
+            # star model: dst = endpoint, path = the endpoint-relative remainder.
+            forward_path = '/' + path
+            if request.url.query:
+                forward_path += '?' + str(request.url.query)
+
+            body    = await request.body()
+            headers = self_._strip_headers(request)
+
+            try:
+                resp = await self_._broker.caller.call(
+                    endpoint_name, request.method, forward_path,
+                    body=body, headers=headers,
+                    timeout=self_._request_timeout)
+            except asyncio.TimeoutError as exc:
+                raise HTTPException(
+                    status_code=504,
+                    detail="Upstream (endpoint) timeout") from exc
+            except RuntimeError as exc:
+                # Unroutable dst (unknown endpoint) mirrors the bridge's 404;
+                # a full pending table is a 503.
+                if 'unknown' in str(exc):
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"Endpoint '{endpoint_name}' unknown") from exc
+                raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+            status  = int(resp.get('status', 502))
+            rheaders = resp.get('headers') or {}
+            rbody   = resp.get('body') or b''
+            if isinstance(rbody, str):
+                rbody = rbody.encode()
+            return Response(content=rbody, status_code=status,
+                            headers=dict(rheaders))
+
+    # ── static-asset helpers (ported from the bridge) ─────────────────
+
+    @staticmethod
+    def _no_cache() -> Dict[str, str]:
+        return {"Cache-Control": "no-cache, no-store, must-revalidate",
+                "Pragma":        "no-cache",
+                "Expires":       "0"}
+
+    @staticmethod
+    def _resource_path(rel: str) -> Optional[str]:
+        """Resolve a packaged ``data/<rel>`` file path (importlib.resources with
+        a pkg_resources fallback), or ``None`` if it does not exist."""
+        try:
+            from importlib.resources import files
+            candidate = files('radical.orbit').joinpath('data').joinpath(rel)
+            path = (os.fspath(candidate)                    # type: ignore[arg-type]
+                    if hasattr(candidate, '__fspath__') else str(candidate))
+            if os.path.exists(path):
+                return path
+        except Exception as e:
+            log.debug("[Gateway] importlib.resources lookup failed: %s", e)
+
+        try:
+            import pkg_resources                            # type: ignore[import]
+            path = pkg_resources.resource_filename(
+                'radical.orbit', 'data/%s' % rel)
+            if os.path.exists(path):
+                return path
+        except Exception as e:
+            log.debug("[Gateway] pkg_resources lookup failed: %s", e)
+
+        return None

--- a/tests/unittests/test_gateway.py
+++ b/tests/unittests/test_gateway.py
@@ -1,0 +1,526 @@
+"""Tests for :class:`radical.orbit.gateway.Gateway` (M5 compat tier).
+
+Following the :mod:`test_runtime` pattern, the suite drives a **real**
+:class:`~radical.orbit.broker.Broker` (with its default-on gateway) under
+uvicorn on an ephemeral port and connects **real** ``EndpointRuntime``
+participants that serve a test plugin — the most faithful reproduction of
+production wiring.  HTTP ingress is exercised over ``httpx``; SSE over a
+streaming ``requests`` reader.  The bounded per-client SSE queue is unit-tested
+in isolation.
+
+No test sleeps for more than ~1 s; liveness/backoff knobs are injected tiny.
+"""
+
+import json
+import subprocess
+import threading
+import time
+
+import httpx
+import pytest
+import requests
+
+from starlette.responses     import Response as StarletteResponse
+from starlette.responses     import JSONResponse
+
+from radical.orbit.plugin_base import Plugin
+
+
+# ---------------------------------------------------------------------------
+# TLS material (the broker resolves a cert/key even when the test server runs
+# plain-HTTP under uvicorn)
+# ---------------------------------------------------------------------------
+
+def _have_openssl() -> bool:
+    try:
+        subprocess.run(['openssl', 'version'], check=True, capture_output=True)
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+@pytest.fixture
+def self_signed(tmp_path):
+    if not _have_openssl():
+        pytest.skip("openssl not available")
+    import os
+    cert = tmp_path / 'cert.pem'
+    key  = tmp_path / 'key.pem'
+    subprocess.run(
+        ['openssl', 'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+         '-keyout', str(key), '-out', str(cert),
+         '-days', '1', '-subj', '/CN=localhost'],
+        check=True, capture_output=True)
+    os.chmod(key, 0o600)
+    return cert, key
+
+
+# ---------------------------------------------------------------------------
+# A tiny served plugin: ping, echo (verbatim body), teapot (status+headers),
+# notify (event)
+# ---------------------------------------------------------------------------
+
+class _GwPlugin(Plugin):
+    plugin_name = 'gw_test'
+    version     = '0.0.1'
+
+    def __init__(self, app):
+        super().__init__(app, 'gw_test')
+        self.add_route_get('ping',   self._ping)
+        self.add_route_post('echo',  self._echo)
+        self.add_route_get('teapot', self._teapot)
+        self.add_route_get('notify', self._notify)
+
+    async def _ping(self, request):
+        return {'pong': True}
+
+    async def _echo(self, request):
+        body = await request.body()
+        # Return the request body verbatim (JSON + binary round-trip) with a
+        # custom content-type + header to exercise passthrough.
+        return StarletteResponse(
+            content=body, status_code=200,
+            headers={'content-type': 'application/octet-stream',
+                     'x-echo': 'yes'})
+
+    async def _teapot(self, request):
+        return JSONResponse({'brew': 'coffee'}, status_code=418,
+                            headers={'x-custom': 'v'})
+
+    async def _notify(self, request):
+        await self.send_notification('demo', {'hello': 'world'})
+        return {'sent': True}
+
+
+# ---------------------------------------------------------------------------
+# Broker-under-uvicorn harness + runtime factory
+# ---------------------------------------------------------------------------
+
+class _RunningBroker:
+    def __init__(self, broker):
+        import uvicorn
+        self.broker = broker
+        config = uvicorn.Config(
+            broker.app, host='127.0.0.1', port=0, log_level='error',
+            ws_ping_interval=20.0, ws_ping_timeout=20.0)
+        self._server = uvicorn.Server(config)
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
+
+    def start(self):
+        self._thread.start()
+        deadline = time.time() + 10.0
+        while time.time() < deadline:
+            if self._server.started and self._server.servers:
+                socks = self._server.servers[0].sockets
+                if socks:
+                    self.port = socks[0].getsockname()[1]
+                    return self
+            time.sleep(0.02)
+        raise RuntimeError("broker server did not start")
+
+    @property
+    def url(self):
+        return 'http://127.0.0.1:%d' % self.port
+
+    def stop(self):
+        self._server.should_exit = True
+        self._thread.join(timeout=10.0)
+
+
+@pytest.fixture
+def harness(self_signed, tmp_path, monkeypatch):
+    """Factory yielding (make_broker, make_runtime); tears everything down."""
+    from radical.orbit import utils
+    monkeypatch.setattr(utils, 'URL_FILE',   tmp_path / 'bridge.url')
+    monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'bridge.token')
+    monkeypatch.delenv('RADICAL_ORBIT_BRIDGE_TOKEN', raising=False)
+    monkeypatch.delenv('RADICAL_ORBIT_BRIDGE_URL',   raising=False)
+    cert, key = self_signed
+
+    servers  = []
+    runtimes = []
+
+    def make_broker(**kw):
+        from radical.orbit.broker import Broker
+        defaults = dict(cert=str(cert), key=str(key), no_auth=True, grace=2.0)
+        defaults.update(kw)
+        broker = Broker(**defaults)
+        srv = _RunningBroker(broker).start()
+        servers.append(srv)
+        return srv
+
+    def make_runtime(url, wait=True, token=None, **kw):
+        from radical.orbit.runtime import EndpointRuntime
+        defaults = dict(broker_url=url, token=token, ping_interval=1.0,
+                        ping_timeout=3.0, backoff_start=0.05, backoff_max=0.2)
+        defaults.update(kw)
+        rt = EndpointRuntime(**defaults)
+        runtimes.append(rt)
+        rt.start(wait=wait, timeout=10.0)
+        return rt
+
+    yield make_broker, make_runtime
+
+    for rt in runtimes:
+        try:    rt.stop()
+        except Exception:
+            pass
+    for srv in servers:
+        try:    srv.stop()
+        except Exception:
+            pass
+
+
+def _wait(cond, timeout=5.0, interval=0.02):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if cond():
+            return True
+        time.sleep(interval)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# SSE reader (background thread, streaming)
+# ---------------------------------------------------------------------------
+
+class _SSEReader:
+    """Open an SSE stream and collect parsed ``{topic, data}`` frames."""
+
+    def __init__(self, url, cookies=None):
+        self.frames = []
+        self.lock   = threading.Lock()
+        self._stop  = False
+        self._resp  = requests.get(url, stream=True, timeout=10.0,
+                                   cookies=cookies or {})
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self):
+        try:
+            for line in self._resp.iter_lines(decode_unicode=True):
+                if self._stop:
+                    break
+                if line and line.startswith('data: '):
+                    try:
+                        frame = json.loads(line[6:])
+                    except Exception:
+                        continue
+                    with self.lock:
+                        self.frames.append(frame)
+        except Exception:
+            pass
+
+    def by_topic(self, topic):
+        with self.lock:
+            return [f for f in self.frames if f.get('topic') == topic]
+
+    def close(self):
+        self._stop = True
+        try:    self._resp.close()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Auth middleware
+# ---------------------------------------------------------------------------
+
+def test_auth_gate_401_without_token_and_cookie_flow(harness):
+    make_broker, _ = harness
+    srv = make_broker(no_auth=False, token='sekret')
+
+    # No token -> 401 on a capability route.
+    r = httpx.post(srv.url + '/endpoint/list')
+    assert r.status_code == 401
+    assert r.json()['detail'] == 'missing or invalid bridge token'
+
+    # Bearer token passes.
+    r = httpx.post(srv.url + '/endpoint/list',
+                   headers={'authorization': 'Bearer sekret'})
+    assert r.status_code == 200
+
+    # /auth mints the cookie (reached with a valid bearer header).
+    r = httpx.post(srv.url + '/auth',
+                   headers={'authorization': 'Bearer sekret'})
+    assert r.status_code == 200
+    assert r.cookies.get('orbit_bridge_token') == 'sekret'
+
+    # The cookie alone then passes.
+    r = httpx.post(srv.url + '/endpoint/list',
+                   cookies={'orbit_bridge_token': 'sekret'})
+    assert r.status_code == 200
+
+
+def test_auth_exempt_paths(harness):
+    make_broker, _ = harness
+    srv = make_broker(no_auth=False, token='sekret')
+
+    # UI shell + static plugin JS load without a token (Explorer must prompt).
+    assert httpx.get(srv.url + '/').status_code in (200, 404)  # served or absent
+    # A plugin JS request is exempt from the gate (404 only if the file is
+    # absent — never 401).
+    assert httpx.get(srv.url + '/plugins/does_not_exist.js').status_code == 404
+
+
+def test_auth_disabled_passthrough(harness):
+    make_broker, _ = harness
+    srv = make_broker(no_auth=True)
+    r = httpx.post(srv.url + '/endpoint/list')
+    assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Explorer served at /
+# ---------------------------------------------------------------------------
+
+def test_explorer_served_at_root(harness):
+    make_broker, _ = harness
+    srv = make_broker()
+    r = httpx.get(srv.url + '/')
+    assert r.status_code == 200
+    assert 'html' in r.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Discovery: /endpoint/list bridge-era shape (namespaces present)
+# ---------------------------------------------------------------------------
+
+def test_endpoint_list_shape_with_live_endpoint(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+
+    a = make_runtime(srv.url, name='epA', plugins=['gw_test'])
+    assert a.wait_registered(timeout=5.0)
+    assert _wait(lambda: 'epA' in srv.broker.registry)
+
+    r = httpx.post(srv.url + '/endpoint/list')
+    assert r.status_code == 200
+    data = r.json()['data']
+
+    # Bridge-era envelope: {bridge:{url}, endpoints:{...}}.
+    assert 'url' in data['bridge']
+    endpoints = data['endpoints']
+    assert 'epA'    in endpoints
+    assert 'broker' in endpoints                          # broker is a participant
+
+    plugins = endpoints['epA']['plugins']
+    assert 'gw_test' in plugins
+    # Endpoint-relative /{instance} presented as the full /{endpoint}/{instance}.
+    assert plugins['gw_test']['namespace'] == '/epA/gw_test'
+
+
+def test_endpoints_summary_list(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+    a = make_runtime(srv.url, name='epA', plugins=['gw_test'])
+    assert a.wait_registered(timeout=5.0)
+    assert _wait(lambda: 'epA' in srv.broker.registry)
+
+    r = httpx.get(srv.url + '/endpoints')
+    assert r.status_code == 200
+    body = r.json()
+    names = {e['name']: e for e in body['endpoints']}
+    assert 'epA' in names
+    assert names['epA']['connected'] is True
+    assert names['epA']['plugin_count'] == 1
+    assert body['total'] == len(body['endpoints'])
+
+
+# ---------------------------------------------------------------------------
+# Catch-all proxy end-to-end
+# ---------------------------------------------------------------------------
+
+def test_proxy_json_roundtrip(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+    make_runtime(srv.url, name='epA', plugins=['gw_test'])
+    assert _wait(lambda: 'epA' in srv.broker.registry)
+
+    r = httpx.get(srv.url + '/epA/gw_test/ping')
+    assert r.status_code == 200
+    assert r.json() == {'pong': True}
+
+
+def test_proxy_binary_roundtrip_and_header_passthrough(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+    make_runtime(srv.url, name='epA', plugins=['gw_test'])
+    assert _wait(lambda: 'epA' in srv.broker.registry)
+
+    payload = bytes(range(256))                           # non-UTF-8 bytes
+    r = httpx.post(srv.url + '/epA/gw_test/echo', content=payload)
+    assert r.status_code == 200
+    assert r.content == payload                           # verbatim round-trip
+    assert r.headers['x-echo'] == 'yes'                   # header passthrough
+    assert r.headers['content-type'] == 'application/octet-stream'
+
+
+def test_proxy_status_and_custom_header_passthrough(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+    make_runtime(srv.url, name='epA', plugins=['gw_test'])
+    assert _wait(lambda: 'epA' in srv.broker.registry)
+
+    r = httpx.get(srv.url + '/epA/gw_test/teapot')
+    assert r.status_code == 418                           # status passthrough
+    assert r.headers['x-custom'] == 'v'
+    assert r.json() == {'brew': 'coffee'}
+
+
+def test_proxy_unknown_endpoint_is_404(harness):
+    make_broker, _ = harness
+    srv = make_broker()
+    r = httpx.get(srv.url + '/ghost/gw_test/ping')
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Long 504 deadline carried over (config value; not waited on)
+# ---------------------------------------------------------------------------
+
+def test_long_request_deadline_config(harness):
+    from radical.orbit import gateway
+    make_broker, _ = harness
+    srv = make_broker()
+    assert gateway.REQUEST_TIMEOUT == 600
+    assert srv.broker._gateway._request_timeout == 600
+
+
+# ---------------------------------------------------------------------------
+# SSE: notification (legacy shape) + topology (connect/disconnect)
+# ---------------------------------------------------------------------------
+
+def test_sse_notification_legacy_shape(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+    make_runtime(srv.url, name='epA', plugins=['gw_test'])
+    assert _wait(lambda: 'epA' in srv.broker.registry)
+
+    sse = _SSEReader(srv.url + '/events')
+    try:
+        time.sleep(0.3)                                   # let the stream open
+        httpx.get(srv.url + '/epA/gw_test/notify')
+        assert _wait(lambda: len(sse.by_topic('notification')) >= 1, timeout=5.0)
+        frame = sse.by_topic('notification')[0]
+        # Exact legacy envelope: {topic:'notification', data:{endpoint,plugin,
+        # topic,data}}.
+        d = frame['data']
+        assert d['endpoint'] == 'epA'
+        assert d['plugin']   == 'gw_test'
+        assert d['topic']    == 'demo'
+        assert d['data']     == {'hello': 'world'}
+    finally:
+        sse.close()
+
+
+def test_sse_topology_on_connect_and_disconnect(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+
+    sse = _SSEReader(srv.url + '/events')
+    try:
+        time.sleep(0.3)
+        # Initial topology frame is sent on connect.
+        assert _wait(lambda: len(sse.by_topic('topology')) >= 1, timeout=5.0)
+
+        a = make_runtime(srv.url, name='epA', plugins=['gw_test'])
+        assert _wait(
+            lambda: any('epA' in f['data'].get('endpoints', {})
+                        for f in sse.by_topic('topology')),
+            timeout=5.0)
+
+        a.stop()                                          # clean close
+        assert _wait(
+            lambda: 'epA' not in sse.by_topic('topology')[-1]['data']
+                    .get('endpoints', {}),
+            timeout=5.0)
+    finally:
+        sse.close()
+
+
+def test_sse_queue_drop_oldest_counter():
+    from radical.orbit.gateway import _SSEQueue
+    q = _SSEQueue(2)
+    for i in range(5):
+        q.push('f%d' % i)
+    assert q.dropped == 3                                 # 5 pushed, 2 retained
+    assert list(q.buf) == ['f3', 'f4']                    # oldest evicted
+
+
+# ---------------------------------------------------------------------------
+# Admin: disconnect + terminate (+ alias)
+# ---------------------------------------------------------------------------
+
+def test_endpoint_disconnect(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+    make_runtime(srv.url, name='epA', plugins=['gw_test'],
+                 backoff_start=30.0, backoff_max=30.0)
+    assert _wait(lambda: 'epA' in srv.broker.registry)
+
+    r = httpx.post(srv.url + '/endpoint/disconnect/epA')
+    assert r.status_code == 200
+    assert r.json()['endpoint'] == 'epA'
+    assert _wait(lambda: 'epA' not in srv.broker.registry, timeout=5.0)
+
+    # Unknown endpoint -> 404.
+    assert httpx.post(srv.url + '/endpoint/disconnect/ghost').status_code == 404
+
+
+def test_terminate_and_alias_self_sigterm(harness, monkeypatch):
+    import radical.orbit.broker as bmod
+    make_broker, _ = harness
+    srv = make_broker()
+
+    killed = {}
+    monkeypatch.setattr(bmod.os, 'kill',
+                        lambda pid, sig: killed.setdefault('sig', sig))
+
+    r = httpx.post(srv.url + '/bridge/terminate')
+    assert r.status_code == 200
+    assert r.json()['status'] == 'terminating'
+    assert _wait(lambda: killed.get('sig') == bmod.signal.SIGTERM, timeout=2.0)
+
+    killed.clear()
+    r = httpx.post(srv.url + '/broker/terminate')          # alias
+    assert r.status_code == 200
+    assert _wait(lambda: killed.get('sig') == bmod.signal.SIGTERM, timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# gateway=False leaves the app without gateway routes
+# ---------------------------------------------------------------------------
+
+def test_headless_broker_has_no_gateway_routes(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker(gateway=False)
+
+    paths = {getattr(r, 'path', None) for r in srv.broker.app.routes}
+    assert '/register' in paths                            # core WS gate present
+    assert '/endpoint/list' not in paths
+    assert '/events' not in paths
+    assert srv.broker._gateway is None
+
+    # The HTTP surface is simply not there.
+    assert httpx.post(srv.url + '/endpoint/list').status_code == 404
+
+    # But the WS /register still works (a runtime can connect).
+    a = make_runtime(srv.url, name='epA', plugins=['gw_test'])
+    assert a.wait_registered(timeout=5.0)
+
+
+# ---------------------------------------------------------------------------
+# CORS preflight
+# ---------------------------------------------------------------------------
+
+def test_cors_preflight_headers(harness):
+    make_broker, _ = harness
+    srv = make_broker()
+    r = httpx.request(
+        'OPTIONS', srv.url + '/endpoint/list',
+        headers={'Origin': 'http://localhost:8080',
+                 'Access-Control-Request-Method': 'POST'})
+    assert r.status_code in (200, 204)
+    assert r.headers.get('access-control-allow-origin') == 'http://localhost:8080'
+    assert r.headers.get('access-control-allow-credentials') == 'true'


### PR DESCRIPTION
Fifth milestone of `plans/broker_architecture_plan.md` (M5 — gateway), stacked on #67. `gateway.py` + tests; the only other change is the minimal broker attach hook. Old stack untouched.

## What

`Gateway` — the sole non-participant ingress, an explicit broker **module** (not a `Plugin`): it consumes the constructor-declared seam (`app`, `caller`/pending, `tap()`, `add_topology_listener()`, token config) — an interface deliberately wider than `Plugin`'s, which is the plan's honest-modularity argument. Attached by default; `gateway=False` gives a headless broker (WS `/register` only). Single port, single uvicorn server.

- **Auth**: `_auth_dispatch` semantics ported — bearer → `/auth` → HttpOnly cookie, Explorer `/` + `/plugins/*` + OPTIONS exempt, auth-disabled passthrough. Core keeps its own WS `/register` gate; the headless broker keeps its OPTIONS-only HTTP gate (no double-gating).
- **Proxy**: `/{endpoint}/{path:path}` → `Broker.caller.call()` over the shared pending table; 600 s deadline carried from bridge.py; native-bytes bodies (JSON + full 0–255 binary round-trip tested); status/headers passthrough; hop-by-hop + auth headers stripped; unknown endpoint → 404, pending-cap → 503, timeout → 504.
- **SSE `/events`**: subscriber of the raw tap (+ the new topology listener); per-client bounded drop-oldest queues with dropped counters (a stalled browser never grows broker memory); **legacy message shapes preserved field-for-field**.
- **Discovery/admin, exact paths**: `/endpoint/list`, `/endpoints` (bridge-era shape; star-model endpoint-relative namespaces normalized back to `/{endpoint}/{instance}` for consumers), `/endpoint/disconnect/{name}`, `/bridge/terminate` + `/broker/terminate` alias. Dead 501 stubs not ported.
- **broker.py** (+46/−2, flagged): `gateway` flag + lazy attach; `add_topology_listener()` — the one genuine seam addition (topology doesn't flow through the event tap); headless-only OPTIONS gate.

## Pre-flip follow-ups recorded (not M5 blockers)

1. **Broker-hosted plugins aren't HTTP-proxied** — `caller.call` routes via the registry only. Irrelevant while the default broker hosts no plugins, but `iri_connect`/dispatcher access through the gateway needs this before the final flip (natural home: M7, which reworks the host anyway).
2. **Dynamic `ui_module` JS cache not ported** — `/plugins/*` serves packaged static JS only; dynamically-registered plugin UI (`iri.<endpoint>`) needs it pre-flip.

## Testing

18 new tests — real broker+gateway under uvicorn with a real `EndpointRuntime` serving a test plugin: auth matrix, Explorer, discovery shapes, proxy JSON/binary/status/headers/404, SSE notification + topology with exact legacy shapes, drop-oldest counter, disconnect, terminate + alias, headless mode, CORS preflight.

Full suite: **903 passed, 2 skipped**; `flake8 src/ bin/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)