### PR TITLE
M6: session liveness — owner-checked reattach, reclaim-drain, lost plumbing

### DIFF
--- a/src/radical/orbit/dispatch.py
+++ b/src/radical/orbit/dispatch.py
@@ -32,18 +32,26 @@ import msgpack
 class RequestShim:
     """Lightweight adapter for starlette ``Request``.
 
-    Provides the three interfaces that every plugin handler uses:
-    ``path_params``, ``query_params``, and ``await .json()`` / ``await .body()``.
+    Provides the interfaces that every plugin handler uses: ``path_params``,
+    ``query_params``, ``headers``, and ``await .json()`` / ``await .body()``.
     Encoding-agnostic: stores raw bytes, decodes lazily based on content_type.
+
+    ``headers`` is a plain dict.  The serving runtime injects the trusted
+    ``x-orbit-src`` owner header here (see ``runtime._dispatch_served``); the
+    old-stack ``service.py`` and the broker gateway pass no such header, so
+    ``headers.get('x-orbit-src')`` is ``None`` there (owner-less,
+    capability-style within the token trust domain).
     """
 
     def __init__(self, path_params : dict,
                        query_params: dict,
                        body_bytes  : bytes,
-                       content_type: str = 'application/json'):
+                       content_type: str  = 'application/json',
+                       headers     : dict = None):
         self.path_params  = path_params
         self.query_params = query_params
         self.content_type = content_type
+        self.headers      = headers if headers is not None else {}
         self._body        = body_bytes
         self._decoded     = None
 

--- a/src/radical/orbit/plugin_base.py
+++ b/src/radical/orbit/plugin_base.py
@@ -47,7 +47,21 @@ class Plugin(object):
         client_class: The local helper class for the application-side client.
         version: The version string for the plugin.
         session_ttl: Session timeout in seconds (default: 3600 = 1 hour, 0 = no timeout)
+        reclaim_drain: Grace, in seconds, between an owner being declared
+            ``lost`` and its owner-bound ephemeral sessions being reclaimed
+            (default: 300).  Injectable per instance for tests.
         ui_config: UI configuration dict for portal rendering (see ui_schema.py)
+
+    Session ownership
+    -----------------
+    The serving runtime injects the broker-stamped participant identity as the
+    trusted ``x-orbit-src`` request header.  ``register_session`` records it as
+    the session ``owner`` at create.  Reattach to an existing session from a
+    *different* owner is rejected (HTTP 403); recovery goes through
+    re-registering the same participant name.  Requests arriving through the
+    old stack or the broker gateway carry no participant identity — their
+    sessions are owner-less (``None``) and stay capability-style within the
+    token trust domain (only ttl/idle policy expires them, never owner loss).
 
     Notifications
     -------------
@@ -93,18 +107,24 @@ class Plugin(object):
 
     Topology Updates
     ----------------
-    Plugins can receive notifications when endpoints connect or disconnect by
-    overriding the `on_topology_change` method:
+    The serving runtime delivers the rich topology (``name -> {role, plugins,
+    liveness}``) to served plugins on every change.  The base
+    ``on_topology_change`` drives owner-bound ephemeral-session reclaim; a
+    plugin can override it to also react to connect/disconnect/liveness:
 
-        async def on_topology_change(self, endpoints: dict):
-            '''Called when endpoints connect/disconnect.
+        async def on_topology_change(self, participants: dict):
+            '''Called on a topology / liveness change.
 
             Args:
-                endpoints: Dict mapping endpoint names to their plugin info.
-                       Example: {"endpoint1": {"plugins": ["sysinfo", "psij"]}}
+                participants: Dict mapping participant names to their rich
+                    info. Example:
+                    {"endpoint1": {"role": "endpoint",
+                                   "plugins": {"sysinfo": {...}},
+                                   "liveness": "present"}}
             '''
-            for endpoint_name, info in endpoints.items():
-                print(f"Endpoint {endpoint_name} has plugins: {info.get('plugins', [])}")
+            for name, info in participants.items():
+                print(f"{name}: {info.get('liveness')}")
+            await super().on_topology_change(participants)  # keep reclaim-drain
     """
 
     _registry: Dict[str, Type["Plugin"]] = {}
@@ -112,6 +132,7 @@ class Plugin(object):
     client_class: Optional[Type] = None
     version: str = '0.0.1'
     session_ttl: int = 3600  # Default: 1 hour session timeout
+    reclaim_drain: float = 300  # 'lost' owner -> ephemeral-session reclaim grace
     ui_config: Union[Dict, UIConfig, None] = None  # UI configuration for portal
     ui_module: Optional[str] = None  # Absolute path to JS plugin module, or None
 
@@ -162,6 +183,11 @@ class Plugin(object):
         self._default_lock = asyncio.Lock()
         self._main_loop: Optional[asyncio.AbstractEventLoop] = None
         self._cleanup_task: Optional[asyncio.Task] = None
+        # Per-owner reclaim-drain timers: owner-identity -> pending Task.  Armed
+        # when an owner is declared 'lost' (if it owns ephemeral sessions),
+        # cancelled when it returns 'present'.  Touched only on the work loop
+        # (register_session + on_topology_change both run there).
+        self._drain_timers: Dict[str, asyncio.Task] = {}
 
         # Shared direct-dispatch route table (one list across all plugins).
         # We also track the entries this particular plugin instance owns,
@@ -332,17 +358,27 @@ class Plugin(object):
         - ``sid`` names no session           -> a session is created under
           exactly that ID.
 
-        Each session records ``{lifetime, ttl, last_access, owner}`` (``owner``
-        is reserved for owner-checked reattach and is ``None`` for now):
+        Each session records ``{lifetime, ttl, last_access, owner}``.  The
+        ``owner`` is the trusted ``x-orbit-src`` header the serving runtime
+        injects from the broker-stamped envelope src (``None`` for old-stack /
+        gateway requests, which carry no participant identity):
 
-        - ``ephemeral`` (default): liveness-driven expiry is a documented stub
-          — until it lands, an ephemeral session retains the plugin idle-timeout
-          behavior (``session_ttl``) so idle sessions are not leaked.
+        - ``ephemeral`` (default): an owner-bound ephemeral session is
+          reclaimed on a reclaim-drain grace after its owner is declared
+          ``lost`` (see :meth:`on_topology_change`); an owner-less one falls
+          back to the plugin idle-timeout (``session_ttl``) so it is not
+          leaked.
         - ``ttl``: expires once ``now - last_access`` exceeds ``ttl`` seconds
           (time-driven, enforced by the cleanup pass); requires ``ttl > 0``.
+          Never touched by owner loss.
         - ``persistent``: never expires; its resources are reclaimed only by
           explicit operator action (e.g. ``unregister_session`` / ``cancel_all``)
           — there is no liveness reclaim.
+
+        Reattach is owner-checked: reconnecting to an existing ``sid`` whose
+        recorded owner is not ``None`` and differs from the caller's identity
+        is rejected (403).  The reserved ``default`` session is shared per
+        plugin instance and always records owner ``None``.
 
         The session registry is per plugin *instance*, so the reserved
         ``default`` session (always ``persistent``, auto-created on demand) is
@@ -350,6 +386,8 @@ class Plugin(object):
         sessions.
 
         Raises:
+            HTTPException 403: a reattach to an existing session from a
+                different owner than the one recorded at create.
             HTTPException 409: an incoherent lifetime/ttl pair, an unknown
                 lifetime value, or a reconnect whose policy conflicts with the
                 existing session.
@@ -362,9 +400,29 @@ class Plugin(object):
         if not isinstance(data, dict):
             data = {}
 
+        owner              = self._request_owner(request)
         sid, lifetime, ttl = self._normalize_session_policy(data)
-        sid = await self._open_session(sid, lifetime, ttl)
+        sid = await self._open_session(sid, lifetime, ttl, owner)
         return {"sid": sid}
+
+    @staticmethod
+    def _request_owner(request) -> Optional[str]:
+        """Extract the trusted owner identity from the request headers.
+
+        The serving runtime injects the broker-stamped envelope src as the
+        ``x-orbit-src`` header (overwriting any client-supplied copy).  Old-
+        stack and gateway requests carry no such header — owner ``None``.
+        Robust to header containers that are not plain mappings (e.g. test
+        mocks): a non-string value resolves to ``None``.
+        """
+        headers = getattr(request, 'headers', None)
+        if headers is None:
+            return None
+        try:
+            owner = headers.get('x-orbit-src')
+        except Exception:
+            return None
+        return owner if isinstance(owner, str) and owner else None
 
     def _normalize_session_policy(self, data: Dict[str, Any]) -> tuple:
         """Validate the session-policy fields of a register_session body.
@@ -415,12 +473,14 @@ class Plugin(object):
         return sid, lifetime, ttl
 
     async def _open_session(self, sid: Optional[str], lifetime: str,
-                            ttl: Optional[float]) -> str:
+                            ttl: Optional[float],
+                            owner: Optional[str] = None) -> str:
         """Create-or-reconnect a session under the given policy.
 
-        ``sid=None`` mints a fresh ID; an existing ``sid`` reconnects (after a
-        policy-conflict check); the reserved ``default`` is created on demand
-        under a lock.  Returns the resolved session ID.
+        ``sid=None`` mints a fresh ID; an existing ``sid`` reconnects (after an
+        owner check then a policy-conflict check); the reserved ``default`` is
+        created on demand under a lock and is shared (owner ``None``).  Returns
+        the resolved session ID.
         """
         if sid == DEFAULT_SID:
             await self._ensure_default_session()
@@ -433,28 +493,50 @@ class Plugin(object):
                 sid = f"session.{uuid.uuid4().hex[:8]}"
 
         if sid in self._sessions:
+            self._check_owner(sid, owner)
             self._check_policy_conflict(sid, lifetime, ttl)
             self._session_last_access[sid] = time.time()
             log.info("[%s] Reconnected session %s", self.instance_name, sid)
             return sid
 
-        self._record_session(sid, self._create_session(sid), lifetime, ttl)
-        log.info("[%s] Registered session %s", self.instance_name, sid)
+        self._record_session(sid, self._create_session(sid), lifetime, ttl,
+                             owner)
+        log.info("[%s] Registered session %s (owner=%s)",
+                 self.instance_name, sid, owner)
         return sid
 
     def _record_session(self, sid: str, session: PluginSession,
-                        lifetime: str, ttl: Optional[float]) -> None:
+                        lifetime: str, ttl: Optional[float],
+                        owner: Optional[str] = None) -> None:
         """Store a session together with its lifetime record.
 
-        The record is ``{lifetime, ttl, owner}`` (``owner`` reserved for
-        owner-checked reattach, ``None`` for now); the mutable ``last_access``
-        field lives in ``self._session_last_access``.
+        The record is ``{lifetime, ttl, owner}``; the mutable ``last_access``
+        field lives in ``self._session_last_access``.  ``owner`` is the trusted
+        participant identity (``None`` for old-stack / gateway sessions and for
+        the shared ``default`` session).
         """
         self._sessions[sid]            = session
         self._session_policy[sid]      = {'lifetime': lifetime,
                                           'ttl':      ttl,
-                                          'owner':    None}
+                                          'owner':    owner}
         self._session_last_access[sid] = time.time()
+
+    def _check_owner(self, sid: str, owner: Optional[str]) -> None:
+        """Reject a reattach from a different owner than recorded at create.
+
+        A session created with a non-``None`` owner may only be reattached by
+        that same identity — session recovery goes through re-registering the
+        same participant name.  Owner-less sessions (``None`` recorded — old
+        stack / gateway) accept any reattach; there is no identity to guard.
+        """
+        record = self._session_policy.get(sid)
+        if record is None:
+            return
+        recorded = record.get('owner')
+        if recorded is not None and recorded != owner:
+            raise HTTPException(
+                status_code=403,
+                detail=f"session {sid} is owned by another participant")
 
     def _check_policy_conflict(self, sid: str, lifetime: str,
                                ttl: Optional[float]) -> None:
@@ -572,17 +654,93 @@ class Plugin(object):
         else:
             log.warning("[%s] Cannot send notification: endpoint_service unlinked", self.instance_name)
 
-    async def on_topology_change(self, endpoints: dict):
-        """
-        Called when the bridge topology changes (endpoint connect/disconnect).
+    async def on_topology_change(self, participants: dict):
+        """React to a topology / liveness change from the serving runtime.
 
-        Subclasses can override this to react to topology changes.
-        Default implementation does nothing.
+        The serving runtime delivers the rich topology (``name -> {role,
+        plugins, liveness}``) on every change, synthesizing a ``liveness ==
+        'lost'`` entry for a participant that vanishes after the broker's
+        grace (the wire carries no tombstone).
+
+        The default implementation drives owner-bound ephemeral-session
+        liveness expiry: an owner declared ``lost`` arms its reclaim-drain
+        timer; an owner seen ``present`` again cancels it.  A ``suspect``
+        owner does **not** arm the drain — a transient blip reaches
+        ``suspect`` at most and must never reclaim.
+
+        Subclasses may override to react to topology changes; overriders that
+        also want the reclaim-drain behavior call ``super()``.
 
         Args:
-            endpoints: Dict mapping endpoint names to their plugin info.
+            participants: Dict mapping participant names to their rich info
+                (``{role, plugins, liveness}``).
         """
-        pass
+        for name, info in (participants or {}).items():
+            liveness = (info or {}).get('liveness')
+            if   liveness == 'lost':    self._arm_reclaim_drain(name)
+            elif liveness == 'present': self._cancel_reclaim_drain(name)
+
+    # ── owner-bound ephemeral session reclaim (liveness-driven expiry) ──
+
+    def _owner_has_ephemeral(self, owner: Optional[str]) -> bool:
+        """True when *owner* owns at least one reclaimable ephemeral session."""
+        if owner is None:
+            return False
+        return any(rec.get('owner') == owner
+                   and rec.get('lifetime') == 'ephemeral'
+                   for rec in self._session_policy.values())
+
+    def _arm_reclaim_drain(self, owner: Optional[str]) -> None:
+        """Arm the reclaim-drain timer for an owner declared ``lost``.
+
+        A no-op unless *owner* is a real identity that owns ephemeral sessions
+        — nothing else is reclaimed by owner loss, so no idle timer is spawned
+        for owner-less / ttl-only / persistent-only owners.  Idempotent under
+        repeated ``lost`` frames (a running timer is replaced).
+        """
+        if not self._owner_has_ephemeral(owner):
+            return
+        self._cancel_reclaim_drain(owner)
+        self._drain_timers[owner] = asyncio.ensure_future(
+            self._reclaim_drain(owner))
+
+    def _cancel_reclaim_drain(self, owner: Optional[str]) -> None:
+        """Cancel a pending reclaim-drain (owner returned before it fired)."""
+        timer = self._drain_timers.pop(owner, None)
+        if timer is not None:
+            timer.cancel()
+
+    async def _reclaim_drain(self, owner: str) -> None:
+        """Wait out the reclaim-drain window, then reclaim *owner*'s ephemeral
+        sessions.  Cancelled cleanly if the owner returns first."""
+        try:
+            await asyncio.sleep(self.reclaim_drain)
+        except asyncio.CancelledError:
+            return
+        self._drain_timers.pop(owner, None)
+        await self._reclaim_owner_sessions(owner)
+
+    async def _reclaim_owner_sessions(self, owner: str) -> int:
+        """Close and drop every ephemeral session owned by *owner*.
+
+        ttl / persistent sessions are never touched by owner loss.  Returns the
+        number of sessions reclaimed.
+        """
+        victims = [sid for sid, rec in list(self._session_policy.items())
+                   if rec.get('owner') == owner
+                   and rec.get('lifetime') == 'ephemeral']
+        for sid in victims:
+            session = self._sessions.pop(sid, None)
+            self._session_last_access.pop(sid, None)
+            self._session_policy.pop(sid, None)
+            if session:
+                try:    await session.close()
+                except Exception as e:
+                    log.warning("[%s] Error closing reclaimed session %s: %s",
+                                self.instance_name, sid, e)
+            log.info("[%s] Reclaimed ephemeral session %s (owner %s lost)",
+                     self.instance_name, sid, owner)
+        return len(victims)
 
     async def _forward(self, sid: str, func: Callable, *args: Any, **kwargs: Any) -> dict:
         """
@@ -637,9 +795,11 @@ class Plugin(object):
 
         - ``persistent`` never expires.
         - ``ttl`` expires once ``now - last_access`` exceeds its ``ttl``.
-        - ``ephemeral`` (and any session with no recorded policy) falls back to
-          the plugin idle timeout (``session_ttl``) — the documented stub that
-          stands in for liveness-driven expiry until it lands.
+        - ``ephemeral``: an *owner-less* one (old-stack / gateway session, or a
+          record-less session) falls back to the plugin idle timeout
+          (``session_ttl``).  An *owner-bound* one is governed by liveness —
+          reclaimed on the owner's ``lost`` via the reclaim-drain, never
+          idle-expired here.
         """
         last = self._session_last_access.get(sid)
         if last is None:
@@ -655,7 +815,11 @@ class Plugin(object):
             ttl = record['ttl']
             return ttl is not None and (now - last) > ttl
 
-        # 'ephemeral' stub — idle timeout until liveness-driven expiry lands.
+        # 'ephemeral': owner-bound sessions expire by liveness (reclaim-drain),
+        # not idle; owner-less ones fall back to the plugin idle timeout.
+        owner = record.get('owner') if record else None
+        if owner is not None:
+            return False
         return self.session_ttl > 0 and (now - last) > self.session_ttl
 
     async def _cleanup_expired_sessions(self) -> int:

--- a/src/radical/orbit/runtime.py
+++ b/src/radical/orbit/runtime.py
@@ -643,7 +643,16 @@ class EndpointRuntime(PluginHostBase):
                                  }).encode())
         content_type = (req.headers or {}).get('content-type',
                                                'application/json')
-        shim = RequestShim(path_params, query, req.body, content_type)
+        # Trusted owner channel.  ``req.src`` is broker-stamped (the broker
+        # overwrote the envelope src from the registered identity on every
+        # forwarded request), so it — not any client-supplied copy — is the
+        # authoritative participant identity.  Inject it as ``x-orbit-src``,
+        # dropping any inbound header of that name (never trust the client's
+        # copy); plugin_base reads it as the session owner.
+        headers = {k: v for k, v in (req.headers or {}).items()
+                   if k.lower() != 'x-orbit-src'}
+        headers['x-orbit-src'] = req.src
+        shim = RequestShim(path_params, query, req.body, content_type, headers)
         try:
             result = await handler(shim)
         except HTTPException as e:
@@ -800,13 +809,51 @@ class EndpointRuntime(PluginHostBase):
             self._cb.submit(cb, endpoint, plugin, topic, data)
 
     def _on_topology(self, msg: protocol.Topology) -> None:
-        self._topology = {name: info.model_dump()
-                          for name, info in msg.participants.items()}
+        new_topo = {name: info.model_dump()
+                    for name, info in msg.participants.items()}
+        prev = self._topology
+        self._topology = new_topo
         with self._cb_lock:
             cbs = list(self._topology_callbacks)
-        snapshot = dict(self._topology)
+        snapshot = dict(new_topo)
         for cb in cbs:
             self._cb.submit(cb, snapshot)
+        # Served plugins react to the rich topology (owner-liveness → session
+        # reclaim-drain in plugin_base).  Consumers have no served plugins.
+        if self._plugins:
+            self._dispatch_topology_to_plugins(prev, new_topo)
+
+    def _dispatch_topology_to_plugins(self,
+                                      prev: Dict[str, Dict[str, Any]],
+                                      curr: Dict[str, Dict[str, Any]]) -> None:
+        """Deliver the rich topology to served plugins, synthesizing a
+        ``lost`` entry for a participant that has vanished after being seen.
+
+        The wire carries no tombstone: the broker broadcasts ``suspect`` on a
+        socket drop and, once the grace elapses, simply drops the participant
+        from the topology.  A participant absent from *curr* that was
+        ``present``/``suspect`` in *prev* is therefore the post-grace
+        ``lost`` — synthesized here (as a copy carrying ``liveness='lost'``)
+        so served plugins observe the loss exactly once."""
+        participants = dict(curr)
+        for name, info in prev.items():
+            if name in curr:
+                continue
+            if (info or {}).get('liveness') in ('present', 'suspect'):
+                lost = dict(info)
+                lost['liveness'] = 'lost'
+                participants[name] = lost
+        for plugin in list(self._plugins.values()):
+            self._work_loop.create_task(
+                self._invoke_topology(plugin, participants))
+
+    async def _invoke_topology(self, plugin, participants: Dict[str, Any]
+                               ) -> None:
+        try:
+            await plugin.on_topology_change(participants)
+        except Exception as e:                             # pragma: no cover
+            log.error("[Runtime] %s.on_topology_change failed: %s",
+                      plugin.instance_name, e)
 
     def _on_control(self, msg: protocol.Control) -> None:
         if msg.op in ('shutdown', 'terminate'):

--- a/tests/unittests/test_plugin_base.py
+++ b/tests/unittests/test_plugin_base.py
@@ -16,6 +16,7 @@ from fastapi import FastAPI, HTTPException
 from starlette.routing import Route
 from starlette.requests import Request
 from unittest.mock import Mock
+import asyncio
 import uuid
 import time
 import pytest
@@ -563,6 +564,176 @@ def test_plugin_ui_config_default():
 
     # Default should be None
     assert plugin.ui_config is None
+
+
+# ---------------------------------------------------------------------------
+# Session ownership + owner-checked reattach (M6)
+# ---------------------------------------------------------------------------
+
+def _owned_request(payload, owner=None):
+    '''Request mock whose headers carry the trusted x-orbit-src owner
+    (the header the serving runtime injects from the broker-stamped src).'''
+    async def _json():
+        return payload
+    request = Mock(spec=Request)
+    request.json    = _json
+    request.headers = {} if owner is None else {'x-orbit-src': owner}
+    return request
+
+
+def _fresh_plugin():
+    app    = FastAPI()
+    plugin = Plugin(app, "test_plugin")
+    plugin.session_class = PluginSession
+    return plugin
+
+
+@pytest.mark.asyncio
+async def test_session_owner_recorded_from_header():
+    '''register_session records owner from the x-orbit-src header at create.'''
+    plugin = _fresh_plugin()
+    data = await plugin.register_session(_owned_request({"sid": "s1"}, "epB"))
+    assert data['sid'] == "s1"
+    assert plugin._session_policy["s1"]["owner"] == "epB"
+
+
+@pytest.mark.asyncio
+async def test_session_owner_none_without_header():
+    '''No x-orbit-src header (old stack / gateway) -> owner None.'''
+    plugin = _fresh_plugin()
+    await plugin.register_session(_owned_request({"sid": "s1"}))
+    assert plugin._session_policy["s1"]["owner"] is None
+
+
+@pytest.mark.asyncio
+async def test_session_same_owner_reattach_ok():
+    '''Reattach by the same owner re-states policy and succeeds.'''
+    plugin = _fresh_plugin()
+    await plugin.register_session(_owned_request({"sid": "s1"}, "epB"))
+    data = await plugin.register_session(_owned_request({"sid": "s1"}, "epB"))
+    assert data['sid'] == "s1"
+
+
+@pytest.mark.asyncio
+async def test_session_different_owner_reattach_403():
+    '''Reattach by a different owner (or none) to a bound session -> 403.'''
+    plugin = _fresh_plugin()
+    await plugin.register_session(_owned_request({"sid": "s1"}, "epB"))
+
+    with pytest.raises(HTTPException) as exc:
+        await plugin.register_session(_owned_request({"sid": "s1"}, "attacker"))
+    assert exc.value.status_code == 403
+
+    with pytest.raises(HTTPException) as exc:
+        await plugin.register_session(_owned_request({"sid": "s1"}))  # no owner
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_session_ownerless_reattach_unaffected():
+    '''An owner-less session accepts any reattach and stays owner-less.'''
+    plugin = _fresh_plugin()
+    await plugin.register_session(_owned_request({"sid": "s1"}))          # None
+    data = await plugin.register_session(_owned_request({"sid": "s1"}, "x"))
+    assert data['sid'] == "s1"
+    assert plugin._session_policy["s1"]["owner"] is None
+
+
+@pytest.mark.asyncio
+async def test_default_session_owner_none_even_with_header():
+    '''The shared reserved default session always records owner None.'''
+    plugin = _fresh_plugin()
+    await plugin.register_session(_owned_request({"sid": "default"}, "epB"))
+    assert plugin._session_policy["default"]["owner"] is None
+
+
+# ---------------------------------------------------------------------------
+# Owner-liveness driven ephemeral reclaim (M6): suspect never reclaims,
+# lost arms the drain, owner return cancels, ttl/persistent survive
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_suspect_does_not_arm_drain():
+    '''A blip reaching 'suspect' must NOT arm the reclaim drain.'''
+    plugin = _fresh_plugin()
+    plugin.reclaim_drain = 0.05
+    await plugin.register_session(_owned_request({"sid": "s1"}, "epB"))
+    await plugin.on_topology_change({"epB": {"liveness": "suspect"}})
+    assert not plugin._drain_timers                    # nothing armed
+    await asyncio.sleep(0.12)
+    assert "s1" in plugin._sessions                    # session survives
+
+
+@pytest.mark.asyncio
+async def test_lost_arms_drain_and_reclaims_ephemeral():
+    '''An owner declared 'lost' reclaims its ephemeral sessions after the
+    drain; a persistent session of the same owner survives.'''
+    plugin = _fresh_plugin()
+    plugin.reclaim_drain = 0.05
+    await plugin.register_session(_owned_request({"sid": "s1"}, "epB"))
+    await plugin.register_session(
+        _owned_request({"sid": "p1", "lifetime": "persistent"}, "epB"))
+
+    await plugin.on_topology_change({"epB": {"liveness": "lost"}})
+    assert "epB" in plugin._drain_timers
+    await asyncio.sleep(0.15)
+
+    assert "s1" not in plugin._sessions
+    assert "s1" not in plugin._session_policy
+    assert "p1" in plugin._sessions                    # persistent survives
+
+
+@pytest.mark.asyncio
+async def test_owner_return_cancels_drain():
+    '''An owner seen 'present' again before the drain fires cancels it.'''
+    plugin = _fresh_plugin()
+    plugin.reclaim_drain = 0.1
+    await plugin.register_session(_owned_request({"sid": "s1"}, "epB"))
+
+    await plugin.on_topology_change({"epB": {"liveness": "lost"}})
+    assert "epB" in plugin._drain_timers
+    await plugin.on_topology_change({"epB": {"liveness": "present"}})
+    assert "epB" not in plugin._drain_timers
+
+    await asyncio.sleep(0.2)
+    assert "s1" in plugin._sessions                    # not reclaimed
+
+
+@pytest.mark.asyncio
+async def test_owner_bound_ephemeral_not_idle_expired():
+    '''An owner-bound ephemeral session is governed by liveness, not the idle
+    timeout; an owner-less one still idle-expires (old-stack behavior).'''
+    plugin = _fresh_plugin()
+    plugin.session_ttl = 1                             # tiny idle timeout
+
+    await plugin.register_session(_owned_request({"sid": "bound"}, "epB"))
+    await plugin.register_session(_owned_request({"sid": "free"}))   # owner None
+
+    # Backdate both well past the idle timeout.
+    plugin._session_last_access["bound"] = time.time() - 100
+    plugin._session_last_access["free"]  = time.time() - 100
+
+    cleaned = await plugin._cleanup_expired_sessions()
+    assert cleaned == 1
+    assert "bound" in plugin._sessions                 # liveness-governed
+    assert "free" not in plugin._sessions              # idle-expired
+
+
+@pytest.mark.asyncio
+async def test_ttl_and_persistent_never_armed_by_owner_loss():
+    '''An owner with only ttl/persistent sessions arms no drain on loss.'''
+    plugin = _fresh_plugin()
+    plugin.reclaim_drain = 0.05
+    await plugin.register_session(
+        _owned_request({"sid": "t1", "lifetime": "ttl", "ttl": 100}, "epB"))
+    await plugin.register_session(
+        _owned_request({"sid": "p1", "lifetime": "persistent"}, "epB"))
+
+    await plugin.on_topology_change({"epB": {"liveness": "lost"}})
+    assert not plugin._drain_timers
+    await asyncio.sleep(0.1)
+    assert "t1" in plugin._sessions
+    assert "p1" in plugin._sessions
 
 
 if __name__ == '__main__':

--- a/tests/unittests/test_runtime.py
+++ b/tests/unittests/test_runtime.py
@@ -111,6 +111,23 @@ class _EchoPlugin(Plugin):
         return {'blocked': True}
 
 
+class _LivenessPlugin(Plugin):
+    '''Records the (name, liveness) pairs its on_topology_change observes and
+    still drives the base reclaim-drain behavior (calls super()).'''
+    plugin_name   = 'liveness_rt'
+    session_class = PluginSession
+    version       = '0.0.1'
+
+    def __init__(self, app):
+        super().__init__(app, 'liveness_rt')
+        self.observed = []
+
+    async def on_topology_change(self, participants):
+        for name, info in participants.items():
+            self.observed.append((name, (info or {}).get('liveness')))
+        await super().on_topology_change(participants)
+
+
 # ---------------------------------------------------------------------------
 # Broker-under-uvicorn harness + runtime factory
 # ---------------------------------------------------------------------------
@@ -400,6 +417,77 @@ def test_topology_callback_connect_and_disconnect(harness):
 
     a.stop()
     assert _wait(lambda: snaps and 'epA' not in snaps[-1], timeout=5.0)
+
+
+# ---------------------------------------------------------------------------
+# owner channel: broker-stamped src wins over a forged x-orbit-src header
+# ---------------------------------------------------------------------------
+
+def test_owner_channel_broker_stamped_not_spoofable(harness):
+    make_broker, make_runtime = harness
+    srv = make_broker()
+
+    a = make_runtime(srv.url, name='epA', plugins=['echo_rt'])
+    b = make_runtime(srv.url, name='epB')
+    assert _wait_topology(b, 'epA', 'echo_rt', timeout=5.0)
+
+    # B forges x-orbit-src; the serving runtime overwrites it with the
+    # broker-stamped identity 'epB' before the plugin records the owner.
+    resp = b.call('epA', 'POST', '/echo_rt/register_session',
+                  headers={'x-orbit-src': 'attacker'}, body=b'{}')
+    assert resp.status_code == 200
+    sid = resp.json()['sid']
+
+    plugin = a._plugins['echo_rt']
+    assert _wait(lambda: sid in plugin._session_policy, timeout=2.0)
+    assert plugin._session_policy[sid]['owner'] == 'epB'    # not 'attacker'
+
+
+# ---------------------------------------------------------------------------
+# runtime wires on_topology_change to served plugins incl. synthesized 'lost';
+# an owner-bound ephemeral session is reclaimed after the drain
+# ---------------------------------------------------------------------------
+
+def test_served_plugin_observes_lost_and_reclaims(harness):
+    make_broker, make_runtime = harness
+    # Aggressive broker keepalive + tiny grace so a hard-dropped consumer
+    # reaches suspect then lost within the test window.
+    srv = make_broker(ws_ping_interval=0.2, ws_ping_timeout=0.5, grace=0.5)
+
+    a = make_runtime(srv.url, name='epA', plugins=['liveness_rt'],
+                     ping_interval=0.2, ping_timeout=0.5)
+    b = make_runtime(srv.url, name='epB',
+                     ping_interval=0.2, ping_timeout=0.5)
+    assert _wait_topology(b, 'epA', 'liveness_rt', timeout=5.0)
+
+    plugin = a._plugins['liveness_rt']
+    plugin.reclaim_drain = 0.2
+
+    # B registers an owner-bound ephemeral session on epA's plugin.
+    resp = b.call('epA', 'POST', '/liveness_rt/register_session', body=b'{}')
+    sid = resp.json()['sid']
+    assert _wait(lambda: sid in plugin._sessions, timeout=2.0)
+    assert plugin._session_policy[sid]['owner'] == 'epB'
+    assert _wait(lambda: ('epB', 'present') in plugin.observed, timeout=5.0)
+
+    # Hard-drop B: abort the WS transport (TCP RST, no close frame) so the
+    # broker sees a NON-clean drop -> suspect -> (grace) -> lost.  Mark B
+    # stopping first so its transport loop does not reconnect.
+    b._stopping = True
+
+    def _abort():
+        try:    b._ws.transport.abort()
+        except Exception:
+            pass
+    b._transport_loop.call_soon_threadsafe(_abort)
+
+    # epA's plugin observes suspect, then the runtime-synthesized 'lost'
+    # (the wire carries no tombstone — the participant simply vanishes).
+    assert _wait(lambda: ('epB', 'suspect') in plugin.observed, timeout=5.0)
+    assert _wait(lambda: ('epB', 'lost')    in plugin.observed, timeout=5.0)
+
+    # The owner-bound ephemeral session is reclaimed after the drain.
+    assert _wait(lambda: sid not in plugin._sessions, timeout=5.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Sixth milestone of `plans/broker_architecture_plan.md` (M6 — session liveness integration), stacked on #68.

## What

- **Trusted owner channel**: the serving runtime injects the broker-stamped envelope `src` as `x-orbit-src` into plugin dispatch headers, dropping any inbound copy first (case-insensitive). Spoof-proof by construction — the broker overwrites envelope `src` from the registered identity on every forwarded request. In-process test: a consumer sending a forged header is seen by the plugin under its real broker-stamped name.
- **Owner-checked reattach**: `register_session` records the owner at create; reattach to an owner-bound sid from a different — or missing — identity → **403** (an owner-less caller can't hijack a bound sid). Recovery goes through re-registering the same participant name, which the runtime's name-in-use retry (M4) makes automatic. Old-stack/gateway sessions have owner `None` and stay capability-style within the token trust domain (documented). Reserved `default` is always owner-`None` (shared per plugin instance by design).
- **Reclaim-drain (ephemeral × liveness)**: plugin-level `reclaim_drain` (default 300 s, injectable class attribute). Owner `lost` → arm (only if that owner actually owns ephemeral sessions); owner `present` again → cancel; **`suspect` does neither** — a blip must not reclaim (plan verification requirement). On fire, only that owner's *ephemeral* sessions close; ttl/persistent survive owner loss. Owner-bound ephemerals are no longer idle-reaped (idle fallback now applies to owner-less sessions only — the faithful reading of the plan).
- **Lost plumbing**: the runtime now drives served plugins' `on_topology_change(participants)` with the rich topology, synthesizing a one-shot `liveness='lost'` entry when a previously present/suspect participant vanishes from a broadcast (the wire carries no tombstones). `xgfabric`'s override checked: signature and dict-shape compatible, opts out of drain by not calling super() — unaffected, suite green.
- `RequestShim` gains a `headers` dict (default `{}`) — old-stack callers unchanged.

## Testing

13 new tests: owner recorded from header; spoofed header defeated end-to-end; same-owner reattach OK; cross-owner and identity-less reattach 403; suspect ≠ drain; lost → drain → only ephemeral reclaimed; owner return cancels; ttl/persistent survive; default owner-None; runtime→plugin topology wiring incl. synthesized lost (real sockets, present→suspect→lost via TCP RST).

Full suite: **916 passed, 2 skipped**; `flake8 src/ bin/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)