### PR TITLE
M7: task dispatcher onto strict per-session pools + in-process caller

### DIFF
--- a/src/radical/orbit/bridge_plugin_host.py
+++ b/src/radical/orbit/bridge_plugin_host.py
@@ -27,7 +27,9 @@ class BridgePluginHost(PluginHostBase):
                        broadcast_fn        : Callable,
                        endpoint_name           : str      = 'bridge',
                        on_topology_changed : Optional[Callable] = None,
-                       bridge_url          : str      = ''):
+                       bridge_url          : str      = '',
+                       broker_caller       : Any      = None,
+                       broker_tap          : Optional[Callable] = None):
 
         self._name                : str      = endpoint_name
         self._broadcast_fn        : Callable = broadcast_fn
@@ -43,6 +45,11 @@ class BridgePluginHost(PluginHostBase):
         self._app.state.endpoint_name    = endpoint_name
         self._app.state.bridge_url   = bridge_url
         self._app.state.is_bridge    = True
+        # Broker seam for broker-hosted plugins (task_dispatcher): the in-process
+        # caller handle and the raw event tap.  Absent (None) under the old
+        # ``bridge.py`` construction — a broker-only plugin must refuse cleanly.
+        self._app.state.broker_caller = broker_caller
+        self._app.state.broker_tap    = broker_tap
 
         self._load_plugins_from_filter(plugin_names)
 

--- a/src/radical/orbit/broker.py
+++ b/src/radical/orbit/broker.py
@@ -226,6 +226,13 @@ Bridge`.  The tunable liveness/backpressure knobs — ``ping_interval`` and
         # ``_broadcast_topology``.
         self._topology_listeners: List[Callable[[], None]] = []
 
+        # Last rich topology delivered to the hosted-plugin host, so a
+        # participant that vanishes (post-grace ``lost``) can be re-synthesized
+        # with ``liveness='lost'`` for hosted plugins (the wire carries no
+        # tombstone; the broker simply drops a lost participant).  Touched only
+        # on the routing loop.
+        self._host_topology_prev: Dict[str, Dict[str, Any]] = {}
+
         # Correlation: one broker-side pending table (src='broker') plus a
         # lightweight inflight forwarding table for grace-bounded fast-fail.
         self.pending:  Dict[str, asyncio.Future]        = {}   # corr_id -> future
@@ -397,7 +404,8 @@ Bridge`.  The tunable liveness/backpressure knobs — ``ping_interval`` and
             try:
                 host = BridgePluginHost(
                     names, self._host_broadcast, BROKER_NAME,
-                    on_topology_changed=None, bridge_url=self._url)
+                    on_topology_changed=None, bridge_url=self._url,
+                    broker_caller=self.caller, broker_tap=self.tap)
                 fut.set_result(host)
             except Exception as e:                         # pragma: no cover
                 fut.set_exception(e)
@@ -702,44 +710,58 @@ Bridge`.  The tunable liveness/backpressure knobs — ``ping_interval`` and
 
     async def _dispatch_to_host(self, src_name: str, raw: dict) -> None:
         """Route a ``dst='broker'`` request into the host and reply."""
-        status  = 502
-        headers : Dict[str, str] = {}
-        body    : bytes          = b''
-        if self._host is None:
-            body = json.dumps({"error": True, "detail": "no broker host"}).encode()
-            status = 503
-        else:
-            try:
-                query = ''
-                path  = raw.get('path', '/')
-                if '?' in path:
-                    path, query = path.split('?', 1)
-                cfut = asyncio.run_coroutine_threadsafe(
-                    self._host.handle_request(
-                        method       = raw.get('method', 'GET'),
-                        path         = path,
-                        headers      = raw.get('headers', {}),
-                        body_bytes   = self._as_bytes(raw.get('body', b'')),
-                        query_string = query),
-                    self._host_loop)
-                resp    = await asyncio.wrap_future(cfut)
-                status  = resp.status_code
-                headers = dict(resp.headers)
-                body    = bytes(resp.body)
-            except HTTPException as e:
-                status = e.status_code
-                body   = json.dumps({"error": True, "detail": e.detail}).encode()
-            except Exception as e:
-                log.exception("[Broker] host dispatch failed: %s", e)
-                status = 500
-                body   = json.dumps({"error": True, "detail": str(e)}).encode()
-
-        out = protocol.Response(src=BROKER_NAME, dst=src_name, status=status,
-                                headers={k: v for k, v in headers.items()},
-                                body=body, corr_id=raw.get('corr_id'))
+        resp = await self.call_host(
+            raw.get('method', 'GET'), raw.get('path', '/'),
+            headers=raw.get('headers', {}), body=raw.get('body', b''))
+        out = protocol.Response(
+            src=BROKER_NAME, dst=src_name, status=int(resp['status']),
+            headers={k: v for k, v in (resp['headers'] or {}).items()},
+            body=resp['body'], corr_id=raw.get('corr_id'))
         target = self.registry.get(src_name)
         if target is not None:
             await self._send(target, protocol.pack_message(out, cap=self._frame_cap))
+
+    async def call_host(self, method: str, path: str, *,
+                        headers: Optional[Dict[str, str]] = None,
+                        body: Any = b'') -> Dict[str, Any]:
+        """Invoke a broker-hosted plugin route across the thread boundary.
+
+        Gateway seam (pre-flip item 1): the HTTP catch-all proxies a
+        ``dst=='broker'`` request here instead of 404-ing on the routing-loop
+        registry.  Returns a ``{status, headers, body}`` dict (body is bytes),
+        the same passthrough shape :meth:`_dispatch_to_host` wraps into a wire
+        ``response``."""
+        if self._host is None:
+            return {'status': 503, 'headers': {},
+                    'body': json.dumps({"error": True,
+                                        "detail": "no broker host"}).encode()}
+        query = ''
+        if '?' in path:
+            path, query = path.split('?', 1)
+        try:
+            cfut = asyncio.run_coroutine_threadsafe(
+                self._host.handle_request(
+                    method       = method,
+                    path         = path,
+                    headers      = headers or {},
+                    body_bytes   = self._as_bytes(body),
+                    query_string = query),
+                self._host_loop)
+            resp = await asyncio.wrap_future(cfut)
+            return {'status':  resp.status_code,
+                    'headers': dict(resp.headers),
+                    'body':    bytes(resp.body)}
+        except HTTPException as e:
+            return {'status': e.status_code,
+                    'headers': {'content-type': 'application/json'},
+                    'body': json.dumps({"error": True,
+                                        "detail": e.detail}).encode()}
+        except Exception as e:
+            log.exception("[Broker] host dispatch failed: %s", e)
+            return {'status': 500,
+                    'headers': {'content-type': 'application/json'},
+                    'body': json.dumps({"error": True,
+                                        "detail": str(e)}).encode()}
 
     def _host_broadcast(self, topic: str, data: dict):
         """``broadcast_fn`` handed to :class:`BridgePluginHost`.
@@ -936,11 +958,41 @@ Bridge`.  The tunable liveness/backpressure knobs — ``ping_interval`` and
         packed = self._build_topology_msg()
         for name, ws in list(self.registry.items()):
             await self._send(ws, packed)
+        # Deliver the rich topology to the hosted-plugin host (task_dispatcher
+        # consumes it for pilot-child liveness + owner-session reclaim-drain).
+        self._deliver_topology_to_host()
         # Notify in-process topology listeners (the gateway's SSE fan-out).
         for cb in list(self._topology_listeners):
             try:    cb()
             except Exception as e:
                 log.error("[Broker] topology listener failed: %r", e, exc_info=e)
+
+    def _deliver_topology_to_host(self) -> None:
+        """Hand the rich topology to hosted plugins on the host loop.
+
+        Synthesizes a ``liveness='lost'`` entry for a participant that was
+        ``present``/``suspect`` in the previous delivery but is now gone (the
+        post-grace ``lost`` the wire never carries), mirroring the runtime's
+        served-plugin delivery.  A fresh broker starts with an empty ``prev``,
+        so a not-yet-reconnected child is never synthesized ``lost`` (it was
+        never ``present`` in this broker's view)."""
+        if self._host is None or self._host_loop is None:
+            return
+        curr = self.topology_snapshot()
+        participants = dict(curr)
+        for name, info in self._host_topology_prev.items():
+            if name in curr:
+                continue
+            if (info or {}).get('liveness') in ('present', 'suspect'):
+                lost = dict(info)
+                lost['liveness'] = 'lost'
+                participants[name] = lost
+        self._host_topology_prev = curr
+        try:
+            asyncio.run_coroutine_threadsafe(
+                self._host.on_topology_change(participants), self._host_loop)
+        except Exception as e:
+            log.debug("[Broker] host topology delivery failed: %s", e)
 
     # ── low-level helpers ─────────────────────────────────────────────
 

--- a/src/radical/orbit/gateway.py
+++ b/src/radical/orbit/gateway.py
@@ -507,6 +507,21 @@ class Gateway:
             body    = await request.body()
             headers = self_._strip_headers(request)
 
+            # dst == the broker's own hosted-plugin participant: route into the
+            # plugin host (the same host-loop crossing ``_dispatch_to_host``
+            # uses) instead of the routing-loop registry, which 404s for
+            # ``dst=='broker'`` (pre-flip item 1: HTTP reach to hosted plugins).
+            if endpoint_name == BROKER_NAME:
+                resp = await self_._broker.call_host(
+                    request.method, forward_path, headers=headers, body=body)
+                status  = int(resp.get('status', 502))
+                rheaders = resp.get('headers') or {}
+                rbody   = resp.get('body') or b''
+                if isinstance(rbody, str):
+                    rbody = rbody.encode()
+                return Response(content=rbody, status_code=status,
+                                headers=dict(rheaders))
+
             try:
                 resp = await self_._broker.caller.call(
                     endpoint_name, request.method, forward_path,

--- a/src/radical/orbit/plugin_task_dispatcher.py
+++ b/src/radical/orbit/plugin_task_dispatcher.py
@@ -8,13 +8,21 @@ Hosts one :class:`PoolState` per pool declared in ``pools.json``.  Each
 - a shared-FS scratch area
 - an arrivals ring buffer and pilot-lag history
 
-Pilots are submitted via ``plugin_psij.submit_tunneled`` on the same endpoint
-(routed through the bridge — see design doc §4.3).  When the child endpoint
-registers with the bridge, its appearance in the topology event is the
-dispatcher's signal that the pilot is ACTIVE — capacity is taken from
-the pool's pilot-size config.  Tasks then flow via
-``rhapsody.submit_tasks`` on the child endpoint; completion is observed via
-the bridge SSE stream.
+The dispatcher is a **broker-hosted plugin**: it runs on the broker's
+plugin-host loop and reaches endpoints through the in-process broker caller
+(``BrokerCaller.call_threadsafe``, awaited via ``asyncio.wrap_future`` on the
+host loop) — never a loopback HTTP client.  Pilots are submitted via
+``plugin_psij.submit_tunneled`` on a login-node endpoint.  When the pilot's
+child endpoint registers with the broker, its appearance in the rich topology
+(``on_topology_change``) is the dispatcher's signal that the pilot is ACTIVE —
+capacity is taken from the pool's pilot-size config.  Tasks then flow via
+``rhapsody.submit_tasks`` on the child endpoint; completion arrives as broker
+``event`` frames on the raw event tap.
+
+Pools are strictly per-session: keyed ``(owning_sid, pool_name)``, pool names
+are session-local, and there is no cross-session attach.  A pool's pilots
+follow the owning session's lifetime — session close (owner ``lost`` +
+reclaim-drain, ttl expiry, or explicit ``cancel_all``) tears the pools down.
 
 See:
 - ``plans/task_dispatcher_design.md`` for the architecture
@@ -25,10 +33,10 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import logging
 import os
 import shutil
-import threading
 import time
 import uuid
 
@@ -36,13 +44,15 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
+import msgpack
+
 from fastapi import FastAPI, HTTPException, Request
 
-from .client                            import BridgeClient, PluginClient
+from .client                            import PluginClient
 from .plugin_base                       import Plugin
 from .plugin_session_base               import PluginSession
 from .task_dispatcher_config            import (
-    DEFAULT_POOL_NAME, PoolConfig, PilotSize, PoolConfigError,
+    PoolConfig, PilotSize, PoolConfigError,
     default_pool_config, parse_pools,
 )
 from .task_dispatcher_state             import (
@@ -101,6 +111,81 @@ _HANDSHAKE_TIMEOUT_SEC = 300.0  # 5 min, adjusted per observed lag history
 #   RUNNING/QUEUED    → attach to existing wait (wrapper reconnect)
 
 
+# Rhapsody child-session readiness poll (mirrors RhapsodyClient._poll_session_ready)
+_RH_READY_TIMEOUT_SEC = 120.0
+_RH_READY_POLL_SEC    = 1.0
+
+
+# ---------------------------------------------------------------------------
+# Remote plugin proxies — async calls to child endpoints over the broker caller
+# ---------------------------------------------------------------------------
+
+class _RemoteError(Exception):
+    '''A non-2xx ``response`` from a child endpoint's plugin route.'''
+
+    def __init__(self, status: int, detail: Any) -> None:
+        self.status = status
+        self.detail = detail
+        super().__init__(f'remote error {status}: {detail}')
+
+
+class _RemotePlugin:
+    '''Async facade for one child-endpoint plugin session.
+
+    All child-endpoint traffic rides the in-process broker caller
+    (``call_threadsafe`` → ``asyncio.wrap_future`` on the host loop) — there is
+    no loopback HTTP client and no worker-thread offload.  Bound to a resolved
+    ``(dst, sid)`` so the concrete proxies below just format paths.
+    '''
+
+    def __init__(self, plugin: 'PluginTaskDispatcher', dst: str,
+                 sid: str) -> None:
+        self._plugin = plugin
+        self._dst    = dst
+        self.sid     = sid
+
+    async def _get(self, path: str) -> Any:
+        return await self._plugin._call_json(self._dst, 'GET', path)
+
+    async def _post(self, path: str, payload: dict | None = None) -> Any:
+        return await self._plugin._call_json(self._dst, 'POST', path, payload)
+
+
+class _PsijProxy(_RemotePlugin):
+    '''The three psij operations the dispatcher drives on a login endpoint.'''
+
+    async def submit_tunneled(self, job_spec: dict, executor: str,
+                              tunnel: str) -> dict:
+        return await self._post(
+            f'/psij/submit_tunneled/{self.sid}',
+            {'job_spec': job_spec, 'executor': executor, 'tunnel': tunnel})
+
+    async def cancel_job(self, job_id: str) -> dict:
+        return await self._post(f'/psij/cancel/{self.sid}/{job_id}')
+
+    async def get_job_status(self, job_id: str) -> dict:
+        return await self._get(f'/psij/status/{self.sid}/{job_id}')
+
+
+class _RhapsodyProxy(_RemotePlugin):
+    '''The three rhapsody operations the dispatcher drives on a child pilot.'''
+
+    async def submit_tasks(self, task_dicts: list[dict]) -> list[dict]:
+        # msgpack ``{"tasks": [...]}`` body — the shape RhapsodyClient's
+        # single-batch submit sends on the wire.
+        body = msgpack.packb({'tasks': task_dicts}, use_bin_type=True)
+        resp = await self._plugin._call(
+            self._dst, 'POST', f'/rhapsody/submit/{self.sid}',
+            body=body, headers={'content-type': 'application/msgpack'})
+        return self._plugin._decode_json(resp)
+
+    async def get_task(self, uid: str) -> dict:
+        return await self._get(f'/rhapsody/task/{self.sid}/{uid}')
+
+    async def cancel_task(self, uid: str) -> dict:
+        return await self._post(f'/rhapsody/cancel/{self.sid}/{uid}')
+
+
 # ---------------------------------------------------------------------------
 # PoolState — per-pool runtime state
 # ---------------------------------------------------------------------------
@@ -119,10 +204,12 @@ class PoolState:
 
     def __init__(self, config: PoolConfig, state_dir: Path,
                  scratch_base: Path,
-                 plugin: 'PluginTaskDispatcher') -> None:
+                 plugin: 'PluginTaskDispatcher',
+                 owning_sid: str = '') -> None:
         self.config       = config
         self.state_dir    = state_dir
         self.scratch_base = scratch_base
+        self.owning_sid   = owning_sid
         self._plugin      = plugin
 
         state_dir.mkdir(parents=True, exist_ok=True)
@@ -200,6 +287,7 @@ class PoolState:
         record = PilotRecord(
             pid              = pid,
             pool             = self.config.name,
+            owning_sid       = self.owning_sid,
             size_key         = size_key,
             rhapsody_backend = size.rhapsody_backend,
             state            = PILOT_PENDING,
@@ -281,13 +369,20 @@ class PoolState:
 # ---------------------------------------------------------------------------
 
 class TaskDispatcherSession(PluginSession):
-    '''Thin session — dispatcher state is plugin-level, not session-level.
+    '''Session handle — owns this session's pools by lifetime.
 
-    The session exists to fit the radical.orbit ``Plugin`` framework (sid
-    tracking, TTL cleanup) but all pool state lives on
-    :class:`PluginTaskDispatcher`.
+    Pool/pilot state lives on :class:`PluginTaskDispatcher`, keyed by
+    ``(owning_sid, pool_name)``.  The session is the owner: closing it (owner
+    ``lost`` + reclaim-drain, ttl expiry, ``unregister_session``, or
+    ``cancel_all``) tears down *this session's* pools — cancelling their pilots
+    and marking the durable store — so a pool's pilots follow the session
+    lifetime policy.
     '''
-    pass
+
+    async def close(self) -> dict:
+        if self._plugin is not None:
+            await self._plugin._teardown_session_pools(self._sid)
+        return await super().close()
 
 
 # ---------------------------------------------------------------------------
@@ -374,6 +469,17 @@ class TaskDispatcherClient(PluginClient):
         self._raise(resp, f'cancel task {task_id!r}')
         return resp.json()
 
+    def cancel_all(self) -> dict:
+        '''Tear down this session's pools: cancel their pilots, drop the pools.
+
+        The explicit reclaim path for ``persistent``/``default`` pools, which
+        have no liveness-driven expiry.
+        '''
+        self._require_session()
+        resp = self._http.post(self._url(f'cancel_all/{self.sid}'))
+        self._raise(resp, 'cancel_all')
+        return resp.json()
+
     def stage_in(self, pool: str, task_id: str, filename: str,
                  content: bytes, overwrite: bool = False) -> dict:
         '''Upload one file into a task's scratch dir.  Returns ``{cwd, size}``.
@@ -446,29 +552,30 @@ class PluginTaskDispatcher(Plugin):
         self._state_root   = Path(state_root   or _DEFAULT_STATE_ROOT)
         self._scratch_root = Path(scratch_root or _DEFAULT_SCRATCH_ROOT)
 
-        # Map of endpoint_name → set of loaded plugin names, updated on
-        # every bridge topology event.  Used to (a) auto-resolve a
-        # pool's endpoint_name when it's None, and (b) validate the target
-        # of an endpoint-mode task submission.
+        # Broker seam (the dispatcher is broker-hosted only): the in-process
+        # caller handle and the raw event tap, injected by BridgePluginHost.
+        # Under the old ``bridge.py`` construction these are absent (None) and
+        # the dispatcher refuses any endpoint call cleanly (see _call).
+        self._broker_caller = getattr(app.state, 'broker_caller', None)
+        self._broker_tap    = getattr(app.state, 'broker_tap', None)
+        self._untap         = None
+
+        # Cached child-endpoint plugin sessions: (dst, plugin, backend) → sid.
+        # Invalidated for a dst when it goes ``lost``.
+        self._child_sessions: dict[tuple, str] = {}
+
+        # Map of endpoint_name → set of loaded plugin names, refreshed on
+        # every topology change.  Used to (a) auto-resolve a pool's
+        # endpoint_name when it's None, and (b) validate the target of an
+        # endpoint-mode task submission.
         self._connected_endpoints: dict[str, set[str]] = {}
 
-        # Child endpoints we've actually observed connected during this
-        # process's lifetime.  A live pilot is only demoted on
-        # disconnect if we previously saw its child here — otherwise a
-        # replayed-ACTIVE pilot whose child hasn't reconnected yet (just
-        # after a bridge restart) would be wrongly torn down before the
-        # child gets a chance to reappear.  See on_topology_change (C2).
-        self._seen_child_endpoints: set[str] = set()
-
         # Endpoint-mode task tracking: task_id → target_endpoint_name.  Endpoint
-        # mode bypasses pool state — the dispatcher is a transparent
-        # proxy to the target endpoint's rhapsody.  This dict lets get/
-        # cancel routes know which endpoint to forward to.  Entries are
-        # cleared when the task reaches a terminal state (via the SSE
-        # callback).  Backed by a small on-disk lendpointr (C4) so an
-        # in-flight endpoint-mode task survives a bridge restart; terminal
-        # records are filtered out on replay so only live entries seed
-        # the dict.
+        # mode bypasses pool state — the dispatcher is a transparent proxy to
+        # the target endpoint's rhapsody (plugin-global, session-less).  Backed
+        # by a small on-disk ledger (C4) so an in-flight endpoint-mode task
+        # survives a broker restart; terminal records are filtered out on
+        # replay so only live entries seed the dict.
         self._endpoint_mode_log = StateLog(
             self._state_root / 'endpoint_mode.log', EndpointModeRecord, 'task_id')
         self._endpoint_mode_tasks: dict[str, str] = {
@@ -477,14 +584,9 @@ class PluginTaskDispatcher(Plugin):
             if not rec.is_terminal()
         }
 
-        # BridgeClient lazily created when we need to reach other endpoints
-        # or subscribe to SSE.  Lifetime managed by _ensure_started.
-        self._bc: BridgeClient | None = None
-        self._bc_lock                  = threading.Lock()
-
-        # Map rhapsody-task-uid → (pool_name, task_id) so SSE callbacks
-        # can find the right TaskRecord when a pilot reports completion.
-        self._uid_to_task: dict[str, tuple[str, str]] = {}
+        # Map rhapsody-task-uid → (owning_sid, pool_name, task_id) so the event
+        # tap can find the right TaskRecord when a pilot reports completion.
+        self._uid_to_task: dict[str, tuple[str, str, str]] = {}
 
         # Background loops (tick, handshake-timeout sweeper, state
         # prune).  Loops don't actually run until _ensure_started is
@@ -494,11 +596,14 @@ class PluginTaskDispatcher(Plugin):
         self._loops_tasks: list[asyncio.Task] = []
         self._main_loop: asyncio.AbstractEventLoop | None = None
 
-        # Pool state, keyed by pool name.  Empty at startup; sessions
-        # declare pools via :meth:`register_session` (per-workflow
-        # config, not operator-managed).  See
-        # memory/project_bridge_dispatcher.md (Phase 5).
-        self._pool_states: dict[str, PoolState] = {}
+        # Pool state, keyed strictly per session: {owning_sid: {pool_name:
+        # PoolState}}.  Pool names are session-local; there is no cross-session
+        # attach.  Sessions declare pools via :meth:`register_session`.
+        self._pool_states: dict[str, dict[str, PoolState]] = {}
+
+        # Restart-time replay: rebuild pool/pilot/task bookkeeping for ALL
+        # sessions from the sid-scoped durable store (built here, not lazy).
+        self._replay_state()
 
         # Routes
         self.add_route_get  ('pools',                         self._route_pools)
@@ -507,25 +612,47 @@ class PluginTaskDispatcher(Plugin):
         self.add_route_post ('submit/{sid}',                  self._route_submit)
         self.add_route_get  ('task/{sid}/{task_id}',          self._route_get_task)
         self.add_route_post ('cancel/{sid}/{task_id}',        self._route_cancel_task)
+        self.add_route_post ('cancel_all/{sid}',              self._route_cancel_all)
         self.add_route_post ('stage_in/{sid}/{task_id}',      self._route_stage_in)
         self.add_route_get  ('stage_out/{sid}/{task_id}/{filename}',
                              self._route_stage_out)
 
+    # -- pool bookkeeping helpers ---------------------------------------
+
+    def _pools_for(self, sid: str) -> dict[str, 'PoolState']:
+        '''This session's pools (created lazily; empty for a fresh sid).'''
+        return self._pool_states.setdefault(sid, {})
+
+    def _all_pools(self):
+        '''Iterate every pool across every session.'''
+        for pools in list(self._pool_states.values()):
+            for ps in list(pools.values()):
+                yield ps
+
+    def _find_pool(self, sid: str, name: str) -> 'PoolState | None':
+        '''This session's pool by name, or ``None`` (strictly session-local).'''
+        return self._pool_states.get(sid, {}).get(name)
+
     # -- materialisation ------------------------------------------------
 
-    def _materialise_pool(self, cfg: PoolConfig) -> 'PoolState':
-        '''Create a :class:`PoolState` from *cfg* and register it.
+    def _pool_dir(self, sid: str, cfg: PoolConfig) -> Path:
+        '''Sid-scoped, endpoint-tagged on-disk state directory for a pool.'''
+        endpoint_tag = cfg.endpoint_name or 'unbound'
+        return self._state_root / sid / f'{cfg.name}__{endpoint_tag}'
 
-        - Resolves ``endpoint_name=None`` via :meth:`_pick_endpoint_name` against
-          the current topology snapshot.  Stores the resolved name back
-          onto *cfg*; if no endpoint is available, leaves it None and lets
-          the pilot-submit path bail later.
-        - If a pool with the same ``name`` already exists, validates
-          that the configs match (see :meth:`_pool_configs_compatible`)
-          and returns the existing :class:`PoolState`.  Mismatch raises
-          :class:`HTTPException` 409.
-        - If the dispatcher's tick-loop machinery is already running,
-          starts a tick loop for the new pool.
+    def _scratch_for(self, cfg: PoolConfig) -> Path:
+        return (Path(cfg.scratch_base).expanduser()
+                if cfg.scratch_base
+                else self._scratch_root / cfg.name)
+
+    def _materialise_pool(self, sid: str, cfg: PoolConfig) -> 'PoolState':
+        '''Create (or return) this session's pool named ``cfg.name``.
+
+        Pools are strictly per-session (keyed ``(sid, cfg.name)``): a
+        same-named pool in another session is a *distinct* pool.  Re-declaring
+        a pool already present under this session returns the existing
+        :class:`PoolState` (idempotent reconnect) — there is no cross-session
+        attach and no config-compatibility check.
         '''
         if cfg.endpoint_name is None:
             picked = self._pick_endpoint_name()
@@ -534,66 +661,89 @@ class PluginTaskDispatcher(Plugin):
                 log.info('[%s] pool %r: endpoint_name auto-resolved to %r',
                          self.instance_name, cfg.name, picked)
 
-        existing = self._pool_states.get(cfg.name)
+        pools    = self._pools_for(sid)
+        existing = pools.get(cfg.name)
         if existing is not None:
-            if not self._pool_configs_compatible(existing.config, cfg):
-                raise HTTPException(
-                    status_code=409,
-                    detail=(f'pool {cfg.name!r} already exists with a '
-                            f'different config; declare with a unique '
-                            f'name or align with the existing pool'))
             return existing
 
-        # Encode (name, endpoint) in the state-dir path so renames are safe
-        # and pools across endpoints (future) don't collide on disk.
-        endpoint_tag     = cfg.endpoint_name or 'unbound'
-        state_dir    = self._state_root / f'{cfg.name}__{endpoint_tag}'
-        scratch_base = (Path(cfg.scratch_base).expanduser()
-                        if cfg.scratch_base
-                        else self._scratch_root / cfg.name)
-        ps = PoolState(cfg, state_dir, scratch_base, self)
-        self._pool_states[cfg.name] = ps
+        state_dir    = self._pool_dir(sid, cfg)
+        scratch_base = self._scratch_for(cfg)
+        ps = PoolState(cfg, state_dir, scratch_base, self, owning_sid=sid)
+        pools[cfg.name] = ps
 
-        # Restart recovery (C4): the uid→task map is in-memory only, but
-        # fully derivable from the replayed task log.  Repopulate it so a
-        # terminal SSE event for a task that was RUNNING before the
+        # Persist the config so restart-time replay can rebuild this pool
+        # (the append-only logs hold pilots/tasks, not the pool declaration).
+        self._write_pool_config(state_dir, sid, cfg)
+
+        # Restart recovery (C4): rebuild the uid→task map from the replayed
+        # task log so a terminal event for a task that was RUNNING before the
         # restart can still be correlated and advanced.
         for rec in ps.tasks.values():
             if rec.state == TASK_RUNNING and rec.rhapsody_uid:
-                self._uid_to_task[rec.rhapsody_uid] = (cfg.name, rec.task_id)
+                self._uid_to_task[rec.rhapsody_uid] = (sid, cfg.name, rec.task_id)
 
-        log.info('[%s] materialised pool %r → endpoint %r '
+        log.info('[%s] materialised pool %r (sid=%s) → endpoint %r '
                  '(strategy=%s, sizes=%s)',
-                 self.instance_name, cfg.name, cfg.endpoint_name,
+                 self.instance_name, cfg.name, sid, cfg.endpoint_name,
                  cfg.strategy, sorted(cfg.pilot_sizes))
 
         # If the dispatcher is already running, kick off this pool's
         # tick loop right away (otherwise _ensure_started will catch it).
-        if self._loops_started and self._main_loop:
-            self._loops_tasks.append(
-                self._main_loop.create_task(self._tick_loop(ps)))
+        if self._loops_started and self._main_loop \
+                and not self._main_loop.is_closed():
+            try:
+                self._loops_tasks.append(
+                    self._main_loop.create_task(self._tick_loop(ps)))
+            except RuntimeError:
+                pass   # loop not running (e.g. cross-request in TestClient)
         return ps
 
-    def _pool_configs_compatible(self, a: PoolConfig,
-                                 b: PoolConfig) -> bool:
-        '''Two configs are compatible if all structural fields match.
+    @staticmethod
+    def _write_pool_config(state_dir: Path, sid: str,
+                           cfg: PoolConfig) -> None:
+        '''Persist a pool's declaration next to its logs (``pool.json``).'''
+        try:
+            state_dir.mkdir(parents=True, exist_ok=True)
+            payload = {'owning_sid': sid, 'pool': asdict(cfg)}
+            (state_dir / 'pool.json').write_text(json.dumps(payload))
+        except OSError as e:
+            log.warning('task_dispatcher: could not persist pool config '
+                        'for %s: %s', cfg.name, e)
 
-        Conflict policy is strict reject (see
-        memory/project_bridge_dispatcher.md).  Any difference in name,
-        endpoint_name, queue, account, sizes, strategy, or min/max pilots
-        counts as a conflict.
+    def _replay_state(self) -> None:
+        '''Rebuild pools for ALL sessions from the sid-scoped durable store.
+
+        Restart-time replay (built here, not lazy): scan
+        ``<state_root>/<sid>/<pool>__<endpoint>/pool.json``, reload each pool's
+        config, and re-materialise its :class:`PoolState` (which replays the
+        pilot/task logs).  Owner reconnection then reconciles naturally (M1
+        create-or-reconnect + M6 owner check); a pool whose owner never returns
+        is drained by the reclaim-drain / ttl path.
         '''
-        return (a.name            == b.name
-            and a.endpoint_name       == b.endpoint_name
-            and a.queue           == b.queue
-            and a.account         == b.account
-            and a.pilot_sizes     == b.pilot_sizes
-            and a.default_size    == b.default_size
-            and a.min_pilots      == b.min_pilots
-            and a.max_pilots      == b.max_pilots
-            and a.strategy        == b.strategy
-            and a.strategy_config == b.strategy_config
-            and a.scratch_base    == b.scratch_base)
+        if not self._state_root.exists():
+            return
+        for sid_dir in sorted(self._state_root.iterdir()):
+            if not sid_dir.is_dir():
+                continue
+            sid = sid_dir.name
+            for pool_dir in sorted(sid_dir.iterdir()):
+                cfg_path = pool_dir / 'pool.json'
+                if not (pool_dir.is_dir() and cfg_path.is_file()):
+                    continue
+                try:
+                    payload = json.loads(cfg_path.read_text())
+                    cfg = self._pool_config_from_dict(payload.get('pool', {}))
+                except (OSError, ValueError, KeyError, PoolConfigError) as e:
+                    log.warning('task_dispatcher: skipping unreadable pool '
+                                'config %s: %s', cfg_path, e)
+                    continue
+                self._materialise_pool(sid, cfg)
+
+    @staticmethod
+    def _pool_config_from_dict(d: dict) -> PoolConfig:
+        '''Reconstruct a :class:`PoolConfig` from a persisted ``asdict``.'''
+        parsed = parse_pools({'pools': [d]}, source='replay')
+        return next(iter(parsed.values()))
 
     def _pick_endpoint_name(self) -> str | None:
         '''Auto-pick an endpoint_name when a pool was declared without one.
@@ -610,7 +760,7 @@ class PluginTaskDispatcher(Plugin):
     # -- lifecycle ------------------------------------------------------
 
     def _ensure_started(self) -> None:
-        '''Idempotent: start tick loops and bridge subscription.'''
+        '''Idempotent: start tick loops and the broker event-tap subscription.'''
         if self._loops_started:
             return
         self._loops_started = True
@@ -622,7 +772,7 @@ class PluginTaskDispatcher(Plugin):
             return
 
         self._main_loop = loop
-        for pool_state in self._pool_states.values():
+        for pool_state in self._all_pools():
             self._loops_tasks.append(loop.create_task(
                 self._tick_loop(pool_state)))
         self._loops_tasks.append(loop.create_task(
@@ -632,36 +782,61 @@ class PluginTaskDispatcher(Plugin):
         self._loops_tasks.append(loop.create_task(
             self._compaction_sweeper()))
 
-        # Spin up the bridge client + SSE subscription in a worker thread
-        # — BridgeClient uses blocking httpx under the hood.
-        threading.Thread(target=self._start_bridge_client,
-                         daemon=True,
-                         name='task-dispatcher-bc').start()
+        # Subscribe to the broker's raw event tap for child-pilot task events
+        # (the old stack read these off the bridge SSE stream).  The tap fires
+        # on the plugin-host loop — the dispatcher's own loop — so terminal
+        # handling runs inline with no cross-thread marshalling.
+        if self._broker_tap is not None and self._untap is None:
+            self._untap = self._broker_tap(self._on_event)
 
-    def _start_bridge_client(self) -> None:
-        '''Create the internal BridgeClient and register an SSE callback.
+    # ── transport: async calls to child endpoints over the broker caller ──
 
-        Runs once, in a background thread.  ``BridgeClient`` itself
-        spawns another thread for the SSE listener, so this is a
-        fire-and-forget wire-up.
+    async def _call(self, dst: str, method: str, path: str, *,
+                    body: bytes = b'', headers: dict | None = None,
+                    timeout: float | None = None) -> dict:
+        '''Send one ``request`` to *dst* and await its ``response`` dict.
+
+        The dispatcher is broker-hosted: every endpoint call rides the
+        in-process ``BrokerCaller`` (``call_threadsafe`` schedules onto the
+        routing loop; ``asyncio.wrap_future`` awaits it on the host loop
+        without blocking).  Refuses cleanly when no caller is wired (the old
+        ``bridge.py`` host, where the dispatcher is not meant to run).
         '''
-        try:
-            bridge_url  = getattr(self._app.state, 'bridge_url', None)
-            bridge_cert = os.environ.get('RADICAL_ORBIT_BRIDGE_CERT')
-            if not bridge_url:
-                log.warning('[%s] bridge_url missing; SSE disabled',
-                            self.instance_name)
-                return
-            bc = BridgeClient(url=bridge_url, cert=bridge_cert)
-            bc.register_callback(topic='task_status',
-                                 callback=self._on_rhapsody_task_status)
-            with self._bc_lock:
-                self._bc = bc
-            log.info('[%s] bridge client ready at %s',
-                     self.instance_name, bridge_url)
-        except Exception as e:
-            log.error('[%s] failed to start bridge client: %s',
-                      self.instance_name, e)
+        caller = self._broker_caller
+        if caller is None:
+            raise RuntimeError(
+                'task_dispatcher is broker-hosted only: no broker caller '
+                'available (this plugin cannot reach endpoints on this host)')
+        fut = caller.call_threadsafe(dst, method, path,
+                                     body=body, headers=headers or {},
+                                     timeout=timeout)
+        return await asyncio.wrap_future(fut)
+
+    @staticmethod
+    def _decode_json(resp: dict) -> Any:
+        '''Decode a broker ``response`` dict, raising on a non-2xx status.'''
+        status = int(resp.get('status', 502))
+        rbody  = resp.get('body') or b''
+        if isinstance(rbody, str):
+            rbody = rbody.encode()
+        data = json.loads(rbody) if rbody else {}
+        if status >= 400:
+            detail = data.get('detail', data) if isinstance(data, dict) else data
+            raise _RemoteError(status, detail)
+        return data
+
+    async def _call_json(self, dst: str, method: str, path: str,
+                         payload: dict | None = None,
+                         timeout: float | None = None) -> Any:
+        '''JSON-in / JSON-out convenience over :meth:`_call`.'''
+        body    = b''
+        headers = None
+        if payload is not None:
+            body    = json.dumps(payload).encode()
+            headers = {'content-type': 'application/json'}
+        resp = await self._call(dst, method, path, body=body,
+                                headers=headers, timeout=timeout)
+        return self._decode_json(resp)
 
     async def _tick_loop(self, pool_state: PoolState) -> None:
         '''Periodic ``strategy.on_tick`` driver, per pool.'''
@@ -691,7 +866,7 @@ class PluginTaskDispatcher(Plugin):
             try:
                 await asyncio.sleep(_TICK_INTERVAL_SEC)
                 now = time.time()
-                for pool_state in self._pool_states.values():
+                for pool_state in self._all_pools():
                     for pilot in list(pool_state.pilots.values()):
                         if pilot.state not in (PILOT_PENDING, PILOT_STARTING):
                             continue
@@ -749,7 +924,7 @@ class PluginTaskDispatcher(Plugin):
         while True:
             try:
                 await asyncio.sleep(_COMPACT_INTERVAL_SEC)
-                for pool_state in self._pool_states.values():
+                for pool_state in self._all_pools():
                     pool_state.compact_logs()
                 if self._endpoint_mode_log.needs_compaction(
                         max_appends=_COMPACT_MAX_APPENDS,
@@ -769,44 +944,42 @@ class PluginTaskDispatcher(Plugin):
     def _prune_stale_state_dirs(self) -> None:
         '''Synchronous worker for :meth:`_state_sweeper`.
 
-        A directory is pruned iff:
-        1. it isn't backing an active pool (not in
-           ``self._pool_states``), AND
-        2. its most-recently-touched file is older than
-           ``_STATE_PRUNE_DAYS`` days.
-
-        Active pools' state-dir names follow the
-        ``<pool>__<endpoint_or_'unbound'>`` scheme from
-        :meth:`_materialise_pool`.  Pools that don't fit that scheme
-        (e.g. older state from previous versions) are simply
-        candidates for pruning by virtue of not being in the active
-        set — that's the intended garbage-collection.
+        The store is sid-scoped: ``<state_root>/<sid>/<pool>__<endpoint>/``.
+        A pool directory is pruned iff it isn't backing an active pool AND its
+        newest file is older than ``_STATE_PRUNE_DAYS`` days; an emptied sid
+        directory is then removed too.  A live pool's state dir is identified
+        by its own :attr:`PoolState.state_dir`, so renames and endpoint changes
+        never collide.
         '''
         if not self._state_root.exists():
             return
         cutoff = time.time() - _STATE_PRUNE_DAYS * 86400
-        active = {
-            f'{ps.config.name}__{ps.config.endpoint_name or "unbound"}'
-            for ps in self._pool_states.values()
-        }
-        for entry in self._state_root.iterdir():
-            if not entry.is_dir() or entry.name in active:
+        active = {str(ps.state_dir) for ps in self._all_pools()}
+        for sid_dir in list(self._state_root.iterdir()):
+            if not sid_dir.is_dir():
                 continue
+            for entry in list(sid_dir.iterdir()):
+                if not entry.is_dir() or str(entry) in active:
+                    continue
+                try:
+                    mtimes = [p.stat().st_mtime for p in entry.iterdir()]
+                except (FileNotFoundError, PermissionError):
+                    continue
+                if not mtimes or max(mtimes) >= cutoff:
+                    continue
+                try:
+                    shutil.rmtree(entry)
+                    log.info('[%s] pruned stale state dir %s',
+                             self.instance_name, entry)
+                except OSError as e:
+                    log.warning('[%s] could not prune %s: %s',
+                                self.instance_name, entry, e)
+            # Drop an emptied sid directory (all its pools pruned / gone).
             try:
-                mtimes = [p.stat().st_mtime for p in entry.iterdir()]
-            except (FileNotFoundError, PermissionError):
-                continue
-            if not mtimes:
-                continue
-            if max(mtimes) >= cutoff:
-                continue
-            try:
-                shutil.rmtree(entry)
-                log.info('[%s] pruned stale state dir %s',
-                         self.instance_name, entry)
-            except OSError as e:
-                log.warning('[%s] could not prune %s: %s',
-                            self.instance_name, entry, e)
+                if sid_dir.is_dir() and not any(sid_dir.iterdir()):
+                    sid_dir.rmdir()
+            except OSError:
+                pass
 
     # -- routes --------------------------------------------------------
 
@@ -820,19 +993,20 @@ class PluginTaskDispatcher(Plugin):
               "pools": [<PoolConfig>, ...]   # same shape as pools.json
             }
 
-        Materialisation semantics:
+        Materialisation semantics (strict per-session isolation):
 
-        - Each declared pool is parsed via the same loader as pools.json.
-        - For each pool, if a pool with the same name already exists,
-          its config is checked against the new declaration:
-            * compatible  → session attaches to the existing pool
-            * incompatible → request rejected with HTTP 409
-        - If no pools are declared AND no pool named ``default`` exists
-          yet, the dispatcher auto-materialises a ``default`` pool
-          (see :func:`task_dispatcher_config.default_pool_config`).
+        - The base allocates/reconnects the session ``sid`` (and records its
+          owner) first; declared pools then materialise under **that** ``sid``.
+        - Pools are keyed ``(owning_sid, pool_name)``: a same-named pool in
+          another session is a *distinct*, isolated pool — there is no
+          cross-session attach and no config-compatibility check.  Re-declaring
+          a pool this session already owns returns the existing one.
+        - With no pools declared and no pool yet owned by this session, the
+          dispatcher auto-materialises this session's own ``default`` pool.
 
-        Pools materialise into ``self._pool_states`` (plugin-level), so
-        they outlive the session.  Sessions never own pilots.
+        Each pool's pilots follow the owning session's lifetime: session close
+        (owner ``lost`` + reclaim-drain, ttl expiry, or ``cancel_all``) tears
+        the pools down.
         '''
         self._ensure_started()
         try:
@@ -844,8 +1018,10 @@ class PluginTaskDispatcher(Plugin):
 
         pools_body = body.get('pools')
 
+        # Validate/parse the declared pools BEFORE minting the session, so a
+        # bad declaration 400s without leaving a dangling session behind.
+        configs: dict = {}
         if pools_body is not None:
-            # Wrap into the loader's expected shape if needed.
             if isinstance(pools_body, list):
                 wrapped = {'pools': pools_body}
             elif isinstance(pools_body, dict) and 'pools' in pools_body:
@@ -858,44 +1034,52 @@ class PluginTaskDispatcher(Plugin):
                 configs = parse_pools(wrapped, source='register_session')
             except PoolConfigError as e:
                 raise HTTPException(status_code=400, detail=str(e)) from e
-            for cfg in configs.values():
-                self._materialise_pool(cfg)
-        elif DEFAULT_POOL_NAME not in self._pool_states:
-            # No pools declared; auto-materialise the default once.
-            self._materialise_pool(default_pool_config())
 
-        # Hand off to the base sid-allocation / cleanup logic.
-        return await super().register_session(request)
+        # Base sid-allocation / owner-check / cleanup logic runs first so pools
+        # can be keyed on the resolved sid.
+        result = await super().register_session(request)
+        sid    = result['sid']
+
+        if configs:
+            for cfg in configs.values():
+                self._materialise_pool(sid, cfg)
+        elif pools_body is None and not self._pools_for(sid):
+            # No pools declared; auto-materialise this session's default once.
+            self._materialise_pool(sid, default_pool_config())
+
+        return result
 
     async def _route_pools(self, request: Request) -> dict:
-        '''List all configured pools.  Session-less.'''
+        '''List all pools across sessions, grouped by owning session id.'''
         self._ensure_started()
         return {
             'pools': {
-                name: self._summarize_pool(ps)
-                for name, ps in self._pool_states.items()
+                sid: {name: self._summarize_pool(ps)
+                      for name, ps in pools.items()}
+                for sid, pools in self._pool_states.items()
             }
         }
 
     async def _route_pool_detail(self, request: Request) -> dict:
-        '''Detailed state for one pool.  Session-less.'''
+        '''Detailed state for one pool by name (first owner found).  Session-less.'''
         self._ensure_started()
         name = request.path_params['name']
-        ps   = self._pool_states.get(name)
-        if not ps:
-            raise HTTPException(status_code=404,
-                                detail=f'unknown pool: {name}')
-        return self._summarize_pool(ps, verbose=True)
+        for pools in self._pool_states.values():
+            ps = pools.get(name)
+            if ps is not None:
+                return self._summarize_pool(ps, verbose=True)
+        raise HTTPException(status_code=404,
+                            detail=f'unknown pool: {name}')
 
     async def _route_fleet(self, request: Request) -> dict:
-        '''Snapshot of the fleet across all pools.  Session-scoped.'''
+        '''Snapshot of this session's fleet.  Session-scoped, strictly isolated.'''
         self._ensure_started()
         sid = request.path_params['sid']
         self._require_known_session(sid)
         return {
             'pools': {
                 name: self._summarize_pool(ps, verbose=True)
-                for name, ps in self._pool_states.items()
+                for name, ps in self._pools_for(sid).items()
             }
         }
 
@@ -927,7 +1111,7 @@ class PluginTaskDispatcher(Plugin):
                 target_endpoint, task_id, cmd, cwd, body)
 
         # ---------- pool mode: dispatcher-managed pilot fleet ------------
-        pool_state = self._pool_states.get(pool_name)
+        pool_state = self._find_pool(sid, pool_name)
         if not pool_state:
             raise HTTPException(
                 status_code=404,
@@ -954,6 +1138,7 @@ class PluginTaskDispatcher(Plugin):
         record = TaskRecord(
             task_id      = task_id,
             pool         = pool_name,
+            owning_sid   = sid,
             cmd          = list(cmd),
             cwd          = str(cwd),
             priority     = priority,
@@ -988,7 +1173,7 @@ class PluginTaskDispatcher(Plugin):
         forwards the task to the target endpoint's rhapsody session and
         records ``task_id -> target_endpoint`` so subsequent get/cancel
         can route back.  The mapping is cleared when the task hits a
-        terminal state (see :meth:`_on_rhapsody_task_status`).
+        terminal state (see :meth:`_on_event`).
 
         The target endpoint's rhapsody plugin owns the backend choice —
         the dispatcher doesn't pass a ``backends`` list so the endpoint's
@@ -1009,7 +1194,7 @@ class PluginTaskDispatcher(Plugin):
                 detail='stage_in/stage_out not supported for '
                        'endpoint-mode tasks (yet)')
 
-        rh = await asyncio.to_thread(self._get_rhapsody_client, target_endpoint)
+        rh = await self._get_rhapsody_client(target_endpoint)
         if rh is None:
             raise HTTPException(
                 status_code=503,
@@ -1023,7 +1208,7 @@ class PluginTaskDispatcher(Plugin):
             'task_backend_specific_kwargs': {'cwd': cwd},
         }
         try:
-            result = await asyncio.to_thread(rh.submit_tasks, [task_dict])
+            result = await rh.submit_tasks([task_dict])
         except Exception as e:
             log.exception('[%s] endpoint-mode submit to %s failed: %s',
                           self.instance_name, target_endpoint, e)
@@ -1033,9 +1218,9 @@ class PluginTaskDispatcher(Plugin):
                        f'{target_endpoint}: {e}') from e
 
         self._endpoint_mode_tasks[task_id] = target_endpoint
-        # Persist the in-flight lendpointr entry (C4) so a bridge restart can
+        # Persist the in-flight ledger entry (C4) so a broker restart can
         # re-correlate this task; rhapsody uid (== task_id here) is what
-        # the SSE callback keys on for terminal cleanup.
+        # the event tap keys on for terminal cleanup.
         self._endpoint_mode_log.append(
             EndpointModeRecord(task_id=task_id, endpoint=target_endpoint,
                            state=TASK_RUNNING))
@@ -1050,20 +1235,20 @@ class PluginTaskDispatcher(Plugin):
 
     async def _route_get_task(self, request: Request) -> dict:
         self._ensure_started()
-        self._require_known_session(request.path_params['sid'])
+        sid = request.path_params['sid']
+        self._require_known_session(sid)
         task_id = request.path_params['task_id']
 
         # Endpoint mode: forward to the target endpoint's rhapsody.
         endpoint_name = self._endpoint_mode_tasks.get(task_id)
         if endpoint_name is not None:
-            rh = await asyncio.to_thread(
-                self._get_rhapsody_client, endpoint_name)
+            rh = await self._get_rhapsody_client(endpoint_name)
             if rh is None:
                 raise HTTPException(
                     status_code=503,
                     detail=f'rhapsody client unavailable on {endpoint_name}')
             try:
-                info = await asyncio.to_thread(rh.get_task, task_id)
+                info = await rh.get_task(task_id)
             except Exception as e:
                 raise HTTPException(
                     status_code=502,
@@ -1071,7 +1256,7 @@ class PluginTaskDispatcher(Plugin):
                            f'{endpoint_name}: {e}') from e
             return {'task_id': task_id, 'endpoint': endpoint_name, 'result': info}
 
-        for ps in self._pool_states.values():
+        for ps in self._pools_for(sid).values():
             rec = ps.tasks.get(task_id)
             if rec is not None:
                 return self._task_dict(rec)
@@ -1080,20 +1265,20 @@ class PluginTaskDispatcher(Plugin):
 
     async def _route_cancel_task(self, request: Request) -> dict:
         self._ensure_started()
-        self._require_known_session(request.path_params['sid'])
+        sid = request.path_params['sid']
+        self._require_known_session(sid)
         task_id = request.path_params['task_id']
 
         # Endpoint mode: forward cancel to the target endpoint's rhapsody.
         endpoint_name = self._endpoint_mode_tasks.get(task_id)
         if endpoint_name is not None:
-            rh = await asyncio.to_thread(
-                self._get_rhapsody_client, endpoint_name)
+            rh = await self._get_rhapsody_client(endpoint_name)
             if rh is None:
                 raise HTTPException(
                     status_code=503,
                     detail=f'rhapsody client unavailable on {endpoint_name}')
             try:
-                info = await asyncio.to_thread(rh.cancel_task, task_id)
+                info = await rh.cancel_task(task_id)
             except Exception as e:
                 raise HTTPException(
                     status_code=502,
@@ -1101,16 +1286,29 @@ class PluginTaskDispatcher(Plugin):
                            f'{endpoint_name}: {e}') from e
             return {'task_id': task_id, 'endpoint': endpoint_name, 'result': info}
 
-        for ps in self._pool_states.values():
+        for ps in self._pools_for(sid).values():
             rec = ps.tasks.get(task_id)
             if rec is not None:
                 return await self._cancel_task(ps, rec)
         raise HTTPException(status_code=404,
                             detail=f'unknown task: {task_id}')
 
+    async def _route_cancel_all(self, request: Request) -> dict:
+        '''Tear down this session's pools (cancel pilots, drop the pools).
+
+        The explicit reclaim path for ``persistent``/``default`` pools, which
+        have no liveness-driven expiry (M1 decision).  Idempotent.
+        '''
+        self._ensure_started()
+        sid = request.path_params['sid']
+        self._require_known_session(sid)
+        n = await self._teardown_session_pools(sid)
+        return {'sid': sid, 'pools_reclaimed': n}
+
     async def _route_stage_in(self, request: Request) -> dict:
         self._ensure_started()
-        self._require_known_session(request.path_params['sid'])
+        sid = request.path_params['sid']
+        self._require_known_session(sid)
         task_id = request.path_params['task_id']
         body    = await request.json()
 
@@ -1130,7 +1328,7 @@ class PluginTaskDispatcher(Plugin):
                 status_code=400,
                 detail="stage_in requires 'pool', 'filename', 'content_b64'")
 
-        pool_state = self._pool_states.get(pool_name)
+        pool_state = self._find_pool(sid, pool_name)
         if not pool_state:
             raise HTTPException(
                 status_code=404,
@@ -1163,7 +1361,8 @@ class PluginTaskDispatcher(Plugin):
 
     async def _route_stage_out(self, request: Request) -> dict:
         self._ensure_started()
-        self._require_known_session(request.path_params['sid'])
+        sid = request.path_params['sid']
+        self._require_known_session(sid)
         task_id  = request.path_params['task_id']
         filename = request.path_params['filename']
 
@@ -1178,8 +1377,8 @@ class PluginTaskDispatcher(Plugin):
                 status_code=400,
                 detail=f'invalid filename for stage_out: {filename!r}')
 
-        # Find the task's scratch dir
-        for ps in self._pool_states.values():
+        # Find the task's scratch dir (within this session's pools)
+        for ps in self._pools_for(sid).values():
             rec = ps.tasks.get(task_id)
             if rec is None:
                 continue
@@ -1199,66 +1398,95 @@ class PluginTaskDispatcher(Plugin):
         raise HTTPException(status_code=404,
                             detail=f'unknown task: {task_id}')
 
-    async def on_topology_change(self, endpoints: dict) -> None:
-        '''Bridge topology hook: bind pilots as their child endpoints come and go.
+    async def on_topology_change(self, participants: dict) -> None:
+        '''Rich-topology hook: bind pilots + honour the owner-session reclaim.
 
-        Replaces the explicit handshake POST.  The dispatcher pre-binds
-        ``record.child_endpoint_name`` at submit time; this hook then tracks
-        that endpoint's presence in the bridge topology:
+        The broker delivers the rich topology
+        (``name -> {role, plugins, liveness}``) on every change, synthesizing a
+        ``liveness == 'lost'`` entry for a participant that vanishes after the
+        grace.  Two concerns share this signal:
 
-        - **appears** → a PENDING/STARTING pilot becomes ACTIVE, with
-          capacity taken from the pool's pilot-size config (good enough
-          for static allocation; runtime capacity discovery would
-          re-introduce a handshake).
-        - **disappears** (after having been seen) → a live pilot is
-          finalised: DONE if its walltime has elapsed (clean batch-job
-          end), else FAILED (premature loss).  Either way its capacity
-          is reclaimed and any unfinished tasks are re-enqueued — without
-          this the pilot would linger ACTIVE forever (a "phantom",
-          inflating the live count and the apparent free capacity).
+        - **Pilot child liveness.**  The dispatcher pre-binds
+          ``record.child_endpoint_name`` at submit time; a child that becomes
+          ``present`` activates a PENDING/STARTING pilot (capacity from the
+          pool's pilot-size config).  ``suspect`` pauses scheduling to that
+          pilot (a transient blip must not tear it down); ``lost`` finalises
+          the pilot — DONE if walltime elapsed, else FAILED — reclaiming its
+          capacity and re-enqueuing unfinished tasks.  Because ``lost`` is only
+          synthesized for a child that was actually ``present`` in this broker's
+          view, a replayed-ACTIVE pilot whose child has not reconnected after a
+          broker restart is never wrongly demoted — no ``_seen`` heuristic
+          needed.
+        - **Owner-session reclaim.**  ``super().on_topology_change`` arms the
+          reclaim-drain for a *session owner* declared ``lost`` (plugin_base,
+          M6); the drain then closes the session, which tears down its pools.
 
-        Also caches each connected endpoint's plugin set so other code paths
-        (auto-resolution of ``PoolConfig.endpoint_name`` when None;
-        validation of endpoint-mode submissions) have live topology.
+        Also refreshes the cached per-endpoint plugin set (endpoint auto-resolve
+        + endpoint-mode validation) from the non-lost participants.
         '''
-        # Build {endpoint_name: set(plugin_names)}.  Topology payload's
-        # 'plugins' field is sometimes a list, sometimes a dict
-        # (depending on serialisation path); accept both.
+        participants = participants or {}
+
+        # Refresh {endpoint_name: set(plugin_names)} from the non-lost, non-self
+        # participants.  'plugins' is the rich name-keyed dict in the star model.
+        self_name = getattr(self._app.state, 'endpoint_name', None)
         new: dict[str, set[str]] = {}
-        for name, info in (endpoints or {}).items():
-            plugins = (info or {}).get('plugins', [])
+        for name, info in participants.items():
+            if name == self_name:
+                continue
+            if (info or {}).get('liveness') == 'lost':
+                # Drop cached plugin-sessions on a lost endpoint so a
+                # reconnecting one (endpoint-mode target) re-registers fresh.
+                for key in [k for k in self._child_sessions if k[0] == name]:
+                    self._child_sessions.pop(key, None)
+                continue
+            plugins = (info or {}).get('plugins', {})
             if isinstance(plugins, dict):
                 plugins = list(plugins.keys())
             new[name] = set(plugins)
         self._connected_endpoints = new
-        if not self._loops_started:
-            return
 
-        for ps in self._pool_states.values():
-            for pilot in list(ps.pilots.values()):
-                ce = pilot.child_endpoint_name
-                if not ce:
-                    continue
-                present = ce in new
+        if self._loops_started:
+            for ps in self._all_pools():
+                self._reconcile_pilots_for(ps, participants)
 
-                if present and pilot.state in PILOT_LIVE_STATES:
-                    # Remember we've seen this child so a later
-                    # disconnect is recognised as a genuine teardown.
-                    self._seen_child_endpoints.add(ce)
+        # Owner-session reclaim-drain (M6): arms on a *lost* owner that owns
+        # ephemeral sessions, cancels on its return.
+        await super().on_topology_change(participants)
 
-                if present and pilot.state in (PILOT_PENDING, PILOT_STARTING):
-                    self._activate_pilot(ps, pilot)
-                elif (not present and ce in self._seen_child_endpoints
-                        and pilot.state in PILOT_LIVE_STATES):
-                    self._seen_child_endpoints.discard(ce)
-                    if time.time() >= pilot.walltime_deadline:
-                        self._mark_pilot_done(
-                            ps, pilot, 'walltime reached')
-                    else:
-                        self._mark_pilot_failed(
-                            ps, pilot,
-                            'child endpoint disconnected before walltime')
+    def _reconcile_pilots_for(self, ps: 'PoolState',
+                              participants: dict) -> None:
+        '''Apply child-endpoint liveness to one pool's pilots.'''
+        for pilot in list(ps.pilots.values()):
+            ce = pilot.child_endpoint_name
+            if not ce or pilot.state not in PILOT_LIVE_STATES:
+                continue
+            info     = participants.get(ce)
+            liveness = (info or {}).get('liveness') if info else None
+
+            if liveness == 'present':
+                # Un-pause a pilot that had been paused on a suspect blip.
+                if pilot.state == PILOT_ACTIVE and not pilot.accepting_new_tasks:
+                    pilot.accepting_new_tasks = True
+                    ps.pilot_log.append(pilot)
                     self._drain_pending(ps)
+                if pilot.state in (PILOT_PENDING, PILOT_STARTING):
+                    self._activate_pilot(ps, pilot)
+
+            elif liveness == 'suspect':
+                # Pause scheduling to a suspect child (do NOT demote — a blip
+                # reaches suspect at most and must survive).
+                if pilot.state == PILOT_ACTIVE and pilot.accepting_new_tasks:
+                    pilot.accepting_new_tasks = False
+                    ps.pilot_log.append(pilot)
+
+            elif liveness == 'lost':
+                if time.time() >= pilot.walltime_deadline:
+                    self._mark_pilot_done(ps, pilot, 'walltime reached')
+                else:
+                    self._mark_pilot_failed(
+                        ps, pilot,
+                        'child endpoint lost before walltime')
+                self._drain_pending(ps)
 
     def _activate_pilot(self, ps: PoolState, pilot: PilotRecord) -> None:
         '''Transition a PENDING/STARTING pilot to ACTIVE on child handshake.'''
@@ -1327,54 +1555,84 @@ class PluginTaskDispatcher(Plugin):
             self._do_pilot_cancel(pool_state, record),
             self._main_loop)
 
-    def _get_psij_client(self, endpoint_name: str) -> Any:
-        '''Return a :class:`PSIJClient`-shaped helper targeting *endpoint_name*.
+    async def _child_session(self, dst: str, plugin: str,
+                             payload: dict | None = None,
+                             backend: str | None = None) -> str | None:
+        '''Register (once) a plugin session on a child endpoint; cache the sid.
 
-        Goes through the bridge (``self._bc.get_endpoint_client(endpoint_name)``).
-        The returned client's methods are synchronous (httpx) — callers
-        MUST wrap each call in :func:`asyncio.to_thread` to keep the
-        dispatcher's event loop responsive (otherwise the sync HTTP
-        starves WS heartbeats and the bridge marks our connection
-        dead).  This caller-side ``to_thread`` discipline also makes
-        same-endpoint calls safe: the event loop continues processing the
-        proxied WS request while the blocking HTTP waits on a worker
-        thread.
+        The session is registered over the broker caller (``/{plugin}/
+        register_session``) and cached per ``(dst, plugin, backend)`` so
+        repeated ops on the same child reuse it.  Returns ``None`` when the
+        child / plugin is unreachable.
+        '''
+        key = (dst, plugin, backend)
+        sid = self._child_sessions.get(key)
+        if sid is not None:
+            return sid
+        try:
+            data = await self._call_json(
+                dst, 'POST', f'/{plugin}/register_session', payload or {})
+        except Exception as e:
+            log.warning('[%s] %s session unavailable on %s: %s',
+                        self.instance_name, plugin, dst, e)
+            return None
+        sid = data.get('sid')
+        if not sid:
+            return None
+        self._child_sessions[key] = sid
+        return sid
 
-        Returns ``None`` if the bridge client isn't ready yet or the
-        target endpoint / psij plugin isn't reachable.
+    async def _get_psij_client(self, endpoint_name: str) -> '_PsijProxy | None':
+        '''Return an async :class:`_PsijProxy` targeting *endpoint_name*.
+
+        All traffic rides the in-process broker caller (no loopback HTTP, no
+        worker-thread offload).  Returns ``None`` when the endpoint / psij
+        plugin is unreachable.
         '''
         if not endpoint_name:
             log.warning('[%s] _get_psij_client called with empty endpoint_name',
                         self.instance_name)
             return None
-        bc = self._wait_for_bc()
-        if bc is None:
+        sid = await self._child_session(endpoint_name, 'psij')
+        if sid is None:
             return None
-        try:
-            return bc.get_endpoint_client(endpoint_name).get_plugin('psij')
-        except Exception as e:
-            log.warning('[%s] psij client unavailable on %s: %s',
-                        self.instance_name, endpoint_name, e)
-            return None
+        return _PsijProxy(self, endpoint_name, sid)
 
-    def _get_rhapsody_client(self, child_endpoint: str,
-                             backend: str | None = None) -> Any:
-        '''Return a :class:`RhapsodyClient`-shaped helper for a child endpoint.
+    async def _get_rhapsody_client(self, child_endpoint: str,
+                                   backend: str | None = None
+                                   ) -> '_RhapsodyProxy | None':
+        '''Return an async :class:`_RhapsodyProxy` for a child endpoint.
 
-        Backend is used only when the session doesn't exist yet; an
-        already-registered session keeps its backend.
+        Registers the rhapsody session (with *backend* when the session does
+        not exist yet), waiting for it to report ``ready``.  Returns ``None``
+        when the child / rhapsody plugin is unreachable.
         '''
-        bc = self._wait_for_bc()
-        if bc is None:
+        payload = {'backends': [backend]} if backend else {}
+        sid = await self._child_session(child_endpoint, 'rhapsody',
+                                        payload=payload, backend=backend)
+        if sid is None:
             return None
-        try:
-            session_kwargs = {'backends': [backend]} if backend else {}
-            return bc.get_endpoint_client(child_endpoint).get_plugin(
-                'rhapsody', **session_kwargs)
-        except Exception as e:
-            log.warning('[%s] rhapsody client unavailable on %s: %s',
-                        self.instance_name, child_endpoint, e)
-            return None
+        await self._await_rhapsody_ready(child_endpoint, sid)
+        return _RhapsodyProxy(self, child_endpoint, sid)
+
+    async def _await_rhapsody_ready(self, dst: str, sid: str) -> None:
+        '''Poll until a child rhapsody session is ready (mirrors the helper).
+
+        Rhapsody inits its session asynchronously; ``list_tasks`` answers 409
+        until it is ready.  Poll that (over the broker caller) until non-409 or
+        the timeout — best-effort, so a submit that races init still surfaces
+        its own error.
+        '''
+        deadline = time.time() + _RH_READY_TIMEOUT_SEC
+        while time.time() < deadline:
+            try:
+                resp = await self._call(dst, 'GET',
+                                        f'/rhapsody/list_tasks/{sid}')
+                if int(resp.get('status', 502)) != 409:
+                    return
+            except Exception:
+                return
+            await asyncio.sleep(_RH_READY_POLL_SEC)
 
     def _build_pilot_env(self, pool_state: PoolState,
                          record: PilotRecord) -> dict[str, str]:
@@ -1436,10 +1694,7 @@ class PluginTaskDispatcher(Plugin):
                 f'pool {pool_state.config.name!r} has no endpoint_name set')
             return
 
-        # All psij client construction goes through sync httpx via the
-        # bridge — do it in a worker thread to keep the asyncio loop
-        # free (also avoids deadlock on same-endpoint round-trips).
-        psij_c = await asyncio.to_thread(self._get_psij_client, endpoint_name)
+        psij_c = await self._get_psij_client(endpoint_name)
         if psij_c is None:
             self._mark_pilot_failed(
                 pool_state, record, 'psij client unavailable')
@@ -1456,8 +1711,7 @@ class PluginTaskDispatcher(Plugin):
         try:
             from .batch_system import detect_batch_system
             executor = detect_batch_system().psij_executor
-            result   = await asyncio.to_thread(
-                psij_c.submit_tunneled, job_spec, executor, 'none')
+            result   = await psij_c.submit_tunneled(job_spec, executor, 'none')
         except Exception as e:
             log.exception('[%s] psij submit_tunneled failed for %s: %s',
                           self.instance_name, record.pid, e)
@@ -1489,12 +1743,12 @@ class PluginTaskDispatcher(Plugin):
         if not endpoint_name or not record.psij_job_id:
             self._mark_pilot_failed(pool_state, record, 'cancel requested')
             return
-        psij_c = await asyncio.to_thread(self._get_psij_client, endpoint_name)
+        psij_c = await self._get_psij_client(endpoint_name)
         if psij_c is None:
             self._mark_pilot_failed(pool_state, record, 'cancel requested')
             return
         try:
-            await asyncio.to_thread(psij_c.cancel_job, record.psij_job_id)
+            await psij_c.cancel_job(record.psij_job_id)
         except Exception as e:
             log.warning('[%s] psij cancel failed for %s: %s',
                         self.instance_name, record.pid, e)
@@ -1508,12 +1762,11 @@ class PluginTaskDispatcher(Plugin):
         endpoint_name = pool_state.config.endpoint_name
         if not endpoint_name or not record.psij_job_id:
             return
-        psij_c = await asyncio.to_thread(self._get_psij_client, endpoint_name)
+        psij_c = await self._get_psij_client(endpoint_name)
         if psij_c is None:
             return
         try:
-            status = await asyncio.to_thread(
-                psij_c.get_job_status, record.psij_job_id)
+            status = await psij_c.get_job_status(record.psij_job_id)
         except Exception as e:
             log.warning('[%s] psij get_job_status failed for %s: %s',
                         self.instance_name, record.pid, e)
@@ -1636,15 +1889,14 @@ class PluginTaskDispatcher(Plugin):
     async def _do_rhapsody_submit(self, pool_state: PoolState,
                                    task: TaskRecord,
                                    pilot: PilotRecord) -> None:
-        '''Post the task to the pilot's rhapsody session via the bridge.'''
+        '''Post the task to the pilot's rhapsody session over the broker caller.'''
         if not pilot.child_endpoint_name:
             self._mark_task_failed(pool_state, task,
                                     'child endpoint unavailable')
             return
 
-        rh = await asyncio.to_thread(
-            self._get_rhapsody_client, pilot.child_endpoint_name,
-            pilot.rhapsody_backend)
+        rh = await self._get_rhapsody_client(
+            pilot.child_endpoint_name, pilot.rhapsody_backend)
         if rh is None:
             self._mark_task_failed(pool_state, task,
                                     'rhapsody client unavailable')
@@ -1662,12 +1914,13 @@ class PluginTaskDispatcher(Plugin):
             'task_backend_specific_kwargs': {'cwd': task.cwd},
         }
         try:
-            result = await asyncio.to_thread(rh.submit_tasks, [task_dict])
+            result = await rh.submit_tasks([task_dict])
             if result:
                 rh_uid = result[0].get('uid')
                 if rh_uid:
                     task.rhapsody_uid = rh_uid
-                    self._uid_to_task[rh_uid] = (pool_state.config.name,
+                    self._uid_to_task[rh_uid] = (pool_state.owning_sid,
+                                                  pool_state.config.name,
                                                   task.task_id)
                     pool_state.task_log.append(task)
         except Exception as e:
@@ -1676,22 +1929,19 @@ class PluginTaskDispatcher(Plugin):
             self._mark_task_failed(pool_state, task,
                                     f'rhapsody submit error: {e}')
 
-    def _on_rhapsody_task_status(self, endpoint: str, plugin: str,
-                                  topic: str, data: dict) -> None:
-        '''SSE callback: a pilot's rhapsody reported a task transition.
+    def _on_event(self, event: dict) -> None:
+        '''Broker raw-tap callback: a child rhapsody reported a task transition.
 
-        Runs in the BridgeClient listener thread; marshal back to the
-        main asyncio loop to mutate state safely.
-
-        The *endpoint* and *topic* parameters are part of the
-        ``BridgeClient.register_callback`` signature; they are received
-        but not inspected because the topic filter is already set to
-        ``'task_status'`` at registration time and the mapping from
-        rhapsody uid to pool happens via ``self._uid_to_task``.
+        The tap fires on the plugin-host loop — the dispatcher's own loop — so
+        terminal handling runs inline (no cross-thread marshalling, unlike the
+        old SSE listener thread).  The tap is unfiltered, so filter here on
+        plugin/topic; the rhapsody uid → pool mapping is ``self._uid_to_task``.
         '''
-        del endpoint, topic   # part of callback contract; unused here
-        if plugin != 'rhapsody':
+        if event.get('plugin') != 'rhapsody':
             return
+        if event.get('topic') != 'task_status':
+            return
+        data  = event.get('data') or {}
         uid   = data.get('uid')
         state = str(data.get('state', '')).upper()
         if not uid or state not in ('DONE', 'FAILED', 'CANCELED', 'COMPLETED'):
@@ -1704,15 +1954,11 @@ class PluginTaskDispatcher(Plugin):
             'FAILED'   : TASK_FAILED,
             'CANCELED' : TASK_CANCELED,
         }[state]
-
-        if self._main_loop is None:
-            return
-        self._main_loop.call_soon_threadsafe(
-            self._handle_task_terminal, uid, target, data)
+        self._handle_task_terminal(uid, target, data)
 
     def _handle_task_terminal(self, uid: str, target_state: str,
                                data: dict) -> None:
-        '''Main-loop-side handler for rhapsody task completion.'''
+        '''Host-loop handler for a child rhapsody task completion.'''
         # Endpoint-mode tasks: forget the mapping and re-emit the terminal
         # status under the dispatcher's plugin name so clients that
         # filter on plugin='task_dispatcher' still see the event.
@@ -1735,8 +1981,8 @@ class PluginTaskDispatcher(Plugin):
         mapping = self._uid_to_task.pop(uid, None)
         if not mapping:
             return
-        pool_name, task_id = mapping
-        pool_state = self._pool_states.get(pool_name)
+        sid, pool_name, task_id = mapping
+        pool_state = self._find_pool(sid, pool_name)
         if not pool_state:
             return
         task = pool_state.tasks.get(task_id)
@@ -1793,12 +2039,10 @@ class PluginTaskDispatcher(Plugin):
         # RUNNING — best-effort cancel on the pilot
         pilot = pool_state.pilots.get(task.pilot_id or '')
         if pilot and pilot.child_endpoint_name and task.rhapsody_uid:
-            rh = await asyncio.to_thread(
-                self._get_rhapsody_client, pilot.child_endpoint_name)
-            if rh is not None and getattr(rh, 'sid', None):
+            rh = await self._get_rhapsody_client(pilot.child_endpoint_name)
+            if rh is not None:
                 try:
-                    await asyncio.to_thread(rh.cancel_task,
-                                             task.rhapsody_uid)
+                    await rh.cancel_task(task.rhapsody_uid)
                 except Exception as e:
                     log.warning('[%s] rhapsody cancel_task failed: %s',
                                 self.instance_name, e)
@@ -1872,12 +2116,37 @@ class PluginTaskDispatcher(Plugin):
             ]
         return summary
 
-    def _wait_for_bc(self, timeout: float = 10.0) -> BridgeClient | None:
-        '''Wait for the bridge client thread to finish init.'''
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            with self._bc_lock:
-                if self._bc is not None:
-                    return self._bc
-            time.sleep(0.05)
-        return None
+    # -- session-close teardown (owner lost / ttl / cancel_all) ---------
+
+    async def _teardown_session_pools(self, sid: str) -> int:
+        '''Tear down every pool owned by *sid*: cancel pilots, drop the pools.
+
+        The session-close hook that ties a pool's pilots to the owning
+        session's lifetime.  Reached from :meth:`TaskDispatcherSession.close`
+        (owner ``lost`` + reclaim-drain, ttl expiry, ``unregister_session``)
+        and from ``cancel_all``.  Each live pilot is cancelled (best-effort
+        psij cancel + FAILED in the durable store); the pool's log handles are
+        closed and the pools are dropped.  Idempotent.
+        '''
+        pools = self._pool_states.pop(sid, None)
+        if not pools:
+            return 0
+        for ps in pools.values():
+            for pilot in list(ps.pilots.values()):
+                if pilot.is_terminal():
+                    continue
+                try:
+                    await self._do_pilot_cancel(ps, pilot)
+                except Exception as e:
+                    log.warning('[%s] pilot %s teardown-cancel failed: %s',
+                                self.instance_name, pilot.pid, e)
+            # Drop this pool's uid→task correlations.
+            for uid, (usid, _pool, _tid) in list(self._uid_to_task.items()):
+                if usid == sid:
+                    self._uid_to_task.pop(uid, None)
+            try:    ps.close()
+            except Exception:
+                pass
+        log.info('[%s] tore down %d pool(s) for session %s',
+                 self.instance_name, len(pools), sid)
+        return len(pools)

--- a/src/radical/orbit/task_dispatcher_state.py
+++ b/src/radical/orbit/task_dispatcher_state.py
@@ -76,6 +76,7 @@ class PilotRecord:
     pool               : str           # pool name
     size_key           : str           # key into pool.pilot_sizes
     rhapsody_backend   : str           # resolved from PilotSize
+    owning_sid         : str         = ''      # session that owns this pool
     psij_job_id        : str | None  = None    # set after submit_tunneled
     child_endpoint_name    : str | None  = None    # set at handshake
     state              : str         = PILOT_PENDING
@@ -110,6 +111,7 @@ class TaskRecord:
     pool         : str
     cmd          : list[str]
     cwd          : str                          # shared-FS scratch path
+    owning_sid   : str         = ''             # session that owns the pool
     priority     : int         = 0              # passed through from Makeflow
     inputs       : list[str]   = field(default_factory=list)
     outputs      : list[str]   = field(default_factory=list)

--- a/tests/unittests/test_dispatcher_route_contract.py
+++ b/tests/unittests/test_dispatcher_route_contract.py
@@ -1,0 +1,102 @@
+'''Contract test: dispatcher-side proxy paths vs the real plugin route tables.
+
+``plugin_task_dispatcher.py``'s ``_PsijProxy`` / ``_RhapsodyProxy`` — plus the
+plugin's own ``_child_session`` / ``_await_rhapsody_ready`` helpers — hand-
+format route paths that duplicate the route templates ``plugin_psij.py`` /
+``plugin_rhapsody.py`` register via ``add_route_get`` / ``add_route_post``.  A
+silent rename on either side 404s at runtime with no compile-time signal.
+
+These tests pin that duplication: every path the dispatcher formats is
+resolved against a locally constructed ``PluginPSIJ`` / ``PluginRhapsody``'s
+``app.state.direct_routes`` table, through ``radical.orbit.dispatch.
+match_route`` — the same matcher the broker/endpoint runtime uses to serve a
+forwarded request.  Paths are matched exactly as the dispatcher sends them
+over the broker caller: namespace-relative (``/{instance_name}/...``), which
+is what ``add_route_get``/``add_route_post`` register (``self._namespace +
+'/' + path``) since ``_PsijProxy``/``_RhapsodyProxy`` hard-code ``/psij/...``
+and ``/rhapsody/...`` — the plugins' default ``instance_name``.
+
+These tests guard the proxy window only and are deleted together with
+``_PsijProxy``/``_RhapsodyProxy`` when the async-helper convergence lands
+(the real ``PluginClient`` helpers grow a caller-backed async transport that
+runs natively on the host loop, replacing the hand-formatted proxy paths).
+'''
+
+import pytest
+from fastapi import FastAPI
+
+from radical.orbit.dispatch         import match_route
+from radical.orbit.plugin_psij      import PluginPSIJ
+from radical.orbit.plugin_rhapsody  import PluginRhapsody
+
+
+# ---------------------------------------------------------------------------
+# Route table: (method, path) exactly as formatted by the dispatcher-side
+# proxies / helpers in plugin_task_dispatcher.py, with real-looking sid/job/
+# uid values.
+# ---------------------------------------------------------------------------
+
+PSIJ_ROUTES = [
+    # PluginTaskDispatcher._child_session(dst, 'psij') — generic register path
+    ('POST', '/psij/register_session'),
+    # _PsijProxy.submit_tunneled
+    ('POST', '/psij/submit_tunneled/sid.abc123'),
+    # _PsijProxy.cancel_job
+    ('POST', '/psij/cancel/sid.abc123/job.0042'),
+    # _PsijProxy.get_job_status
+    ('GET',  '/psij/status/sid.abc123/job.0042'),
+]
+
+RHAPSODY_ROUTES = [
+    # PluginTaskDispatcher._child_session(dst, 'rhapsody') — generic register
+    ('POST', '/rhapsody/register_session'),
+    # _RhapsodyProxy.submit_tasks (msgpack body, same path template)
+    ('POST', '/rhapsody/submit/sid.def456'),
+    # _RhapsodyProxy.get_task
+    ('GET',  '/rhapsody/task/sid.def456/task.uid.001'),
+    # _RhapsodyProxy.cancel_task
+    ('POST', '/rhapsody/cancel/sid.def456/task.uid.001'),
+    # PluginTaskDispatcher._await_rhapsody_ready readiness poll
+    ('GET',  '/rhapsody/list_tasks/sid.def456'),
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: real plugins, constructed the way the existing unit tests do
+# (test_plugin_psij.py / test_plugin_rhapsody.py) — no server, no broker.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope='module')
+def psij_direct_routes():
+    app = FastAPI()
+    PluginPSIJ(app)
+    return app.state.direct_routes
+
+
+@pytest.fixture(scope='module')
+def rhapsody_direct_routes():
+    app = FastAPI()
+    PluginRhapsody(app)
+    return app.state.direct_routes
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('method, path', PSIJ_ROUTES)
+def test_psij_proxy_path_resolves(psij_direct_routes, method, path):
+    handler, params = match_route(psij_direct_routes, method, path)
+    assert handler is not None, (
+        f'{method} {path!r} does not resolve against plugin_psij.py routes '
+        f'— dispatcher proxy path and plugin route table have drifted')
+    assert params is not None
+
+
+@pytest.mark.parametrize('method, path', RHAPSODY_ROUTES)
+def test_rhapsody_proxy_path_resolves(rhapsody_direct_routes, method, path):
+    handler, params = match_route(rhapsody_direct_routes, method, path)
+    assert handler is not None, (
+        f'{method} {path!r} does not resolve against plugin_rhapsody.py '
+        f'routes — dispatcher proxy path and plugin route table have drifted')
+    assert params is not None

--- a/tests/unittests/test_plugin_task_dispatcher.py
+++ b/tests/unittests/test_plugin_task_dispatcher.py
@@ -1,18 +1,19 @@
-"""Unit tests for plugin_task_dispatcher.
+"""Unit tests for plugin_task_dispatcher (broker-hosted, strict per-session pools).
 
-Focus: plugin-level behavior that does not require a live bridge —
-routing decisions, cached-state idempotency, stage_in/stage_out,
-pilot_handshake binding, and strategy interaction.
+Focus: plugin-level behavior that does not require a live broker — strict
+per-session pool isolation, restart-time replay, session-close teardown,
+cached-state idempotency, staging, pilot binding via rich topology
+(present/suspect/lost), and the async transport port (broker caller, no
+`asyncio.to_thread`).
 
-All network paths (BridgeClient → psij / rhapsody on remote endpoints) are
-stubbed; the plugin's in-process state is exercised directly.
+Endpoint calls are stubbed via :meth:`_get_psij_client` / :meth:`_get_rhapsody_client`
+(now async, returning small async proxies); no real broker or WebSocket is needed.
 """
 
 import asyncio
 import base64
-import json
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI
@@ -25,7 +26,7 @@ from radical.orbit.task_dispatcher_config import PoolConfig, PilotSize
 from radical.orbit.task_dispatcher_state   import (
     PilotRecord, TaskRecord,
     PILOT_PENDING, PILOT_ACTIVE, PILOT_FAILED, PILOT_DONE,
-    TASK_QUEUED, TASK_RUNNING, TASK_DONE, TASK_FAILED, TASK_CANCELED,
+    TASK_QUEUED, TASK_RUNNING, TASK_DONE, TASK_CANCELED,
 )
 
 
@@ -36,7 +37,6 @@ from radical.orbit.task_dispatcher_state   import (
 def _make_pool_cfg(*, pool_name: str = 'cpu',
                    max_pilots: int = 4,
                    strategy: str = 'conservative') -> PoolConfig:
-    """Build a test-fixture PoolConfig (matches the old _write_pools_json shape)."""
     return PoolConfig(
         name         = pool_name,
         endpoint_name    = 'endpoint0',
@@ -53,195 +53,136 @@ def _make_pool_cfg(*, pool_name: str = 'cpu',
     )
 
 
-def _make_plugin(tmp_path: Path, *, pool_name: str = 'cpu',
-                 write_config: bool = True, strategy: str = 'conservative',
-                 instance: str = 'task_dispatcher') -> tuple:
-    """Instantiate a plugin bound to tmp_path; return (app, plugin).
+def _pool_dict(**overrides):
+    d = {
+        'name'        : 'cpu',
+        'endpoint_name'   : 'endpoint0',
+        'queue'       : 'batch',
+        'account'     : 'proj',
+        'default_size': 's',
+        'pilot_sizes' : {
+            's': {'nodes': 1, 'cpus_per_node': 4,
+                  'rhapsody_backend': 'concurrent'}},
+        'max_pilots'  : 4,
+        'strategy'    : 'conservative',
+        'strategy_config': {'min_dwell_sec': 0.0},
+    }
+    d.update(overrides)
+    return d
 
-    With ``write_config=True`` (default) the helper materialises one
-    test pool directly via :meth:`_materialise_pool`, mirroring how a
-    session-driven workflow would set things up.  Pass ``False`` for
-    tests that need a dispatcher with zero pools.
-    """
+
+def _make_plugin(tmp_path: Path, *, instance: str = 'task_dispatcher',
+                 broker_caller=None) -> tuple:
+    """Instantiate a plugin bound to tmp_path; return (app, plugin)."""
     app = FastAPI()
-    app.state.endpoint_name  = 'endpoint0'
-    app.state.bridge_url = 'https://localhost:9999'
-
+    app.state.endpoint_name   = 'endpoint0'
+    app.state.bridge_url      = 'https://localhost:9999'
+    app.state.broker_caller   = broker_caller
+    app.state.broker_tap      = None
     plugin = PluginTaskDispatcher(
         app, instance_name=instance,
         state_root=tmp_path / 'state',
         scratch_root=tmp_path / 'scratch')
-    if write_config:
-        plugin._materialise_pool(_make_pool_cfg(pool_name=pool_name,
-                                                strategy=strategy))
     return app, plugin
 
 
+def _register(client: TestClient, plugin, body=None, headers=None) -> str:
+    r = client.post(f'{plugin.namespace}/register_session',
+                    json=body if body is not None else {}, headers=headers)
+    assert r.status_code == 200, r.text
+    return r.json()['sid']
+
+
+def _session_with_cpu(client, plugin, headers=None, sid=None,
+                      lifetime=None) -> str:
+    body = {'pools': [_pool_dict()]}
+    if sid is not None:
+        body['sid'] = sid
+    if lifetime is not None:
+        body['lifetime'] = lifetime
+    return _register(client, plugin, body=body, headers=headers)
+
+
+def _pool(plugin, sid, name='cpu') -> PoolState:
+    return plugin._pool_states[sid][name]
+
+
 # ---------------------------------------------------------------------------
-# Plugin initialization
+# Init / is_enabled
 # ---------------------------------------------------------------------------
 
 class TestInit:
 
     def test_is_enabled_on_bridge(self):
-        """is_enabled returns True when host role is 'bridge'."""
         with patch('radical.orbit.utils.host_role') as m:
             m.return_value = {'role': 'bridge'}
             assert PluginTaskDispatcher.is_enabled(FastAPI()) is True
 
     def test_is_enabled_false_off_bridge(self):
-        """is_enabled returns False on login / compute / standalone hosts."""
         with patch('radical.orbit.utils.host_role') as m:
             for role in ('login', 'compute', 'standalone'):
                 m.return_value = {'role': role}
-                assert PluginTaskDispatcher.is_enabled(FastAPI()) is False, \
-                    f"is_enabled should be False for role={role!r}"
+                assert PluginTaskDispatcher.is_enabled(FastAPI()) is False
 
-    def test_init_with_missing_config_is_non_fatal(self, tmp_path: Path):
-        _, plugin = _make_plugin(tmp_path, write_config=False)
-        assert plugin._pool_states == {}
-
-    def test_init_loads_pools(self, tmp_path: Path):
+    def test_init_starts_with_no_pools(self, tmp_path: Path):
         _, plugin = _make_plugin(tmp_path)
-        assert 'cpu' in plugin._pool_states
-        assert isinstance(plugin._pool_states['cpu'], PoolState)
+        assert plugin._pool_states == {}
 
     def test_routes_registered(self, tmp_path: Path):
         app, plugin = _make_plugin(tmp_path)
         pats = [pat.pattern for _, pat, _, _ in app.state.direct_routes]
         ns = plugin.namespace.lstrip('/')
-        expected_fragments = [
-            f'{ns}/pools$',
-            f'{ns}/pool/',
-            f'{ns}/fleet/',
-            f'{ns}/submit/',
-            f'{ns}/task/',
-            f'{ns}/cancel/',
-            f'{ns}/stage_in/',
-            f'{ns}/stage_out/',
-        ]
-        for frag in expected_fragments:
-            assert any(frag in p for p in pats), \
-                f'route {frag} not registered; have: {pats}'
+        for frag in (f'{ns}/pools$', f'{ns}/fleet/', f'{ns}/submit/',
+                     f'{ns}/cancel/', f'{ns}/cancel_all/',
+                     f'{ns}/stage_in/', f'{ns}/stage_out/'):
+            assert any(frag in p for p in pats), f'route {frag} missing'
 
 
 # ---------------------------------------------------------------------------
-# Routes — pools / pool detail / fleet
+# Strict per-session pool isolation (the M7 verification bullet)
 # ---------------------------------------------------------------------------
 
-class TestRoutes:
+class TestStrictIsolation:
 
-    def test_list_pools(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        r = client.get(f'{plugin.namespace}/pools')
-        assert r.status_code == 200
-        body = r.json()
-        assert 'cpu' in body['pools']
-        assert body['pools']['cpu']['max_pilots'] == 4
+    def test_same_named_pools_are_distinct_across_sessions(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        sid_a = _session_with_cpu(client, plugin, sid='A', lifetime='persistent')
+        sid_b = _session_with_cpu(client, plugin, sid='B', lifetime='persistent')
+        assert sid_a != sid_b
+        ps_a = _pool(plugin, sid_a, 'cpu')
+        ps_b = _pool(plugin, sid_b, 'cpu')
+        assert ps_a is not ps_b                     # distinct PoolStates
+        assert ps_a.state_dir != ps_b.state_dir     # distinct on-disk state
 
-    def test_pool_detail(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        r = client.get(f'{plugin.namespace}/pool/cpu')
-        assert r.status_code == 200
-        assert 'pilots' in r.json()
-
-    def test_pool_detail_unknown(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        r = client.get(f'{plugin.namespace}/pool/nope')
+    def test_cross_session_attach_impossible(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        _session_with_cpu(client, plugin, sid='A', lifetime='persistent')
+        # A second session that declares no pools gets its own default; it has
+        # no 'cpu' pool → submit to 'cpu' 404s (no cross-session visibility).
+        sid_b = _register(client, plugin, body={})
+        r = client.post(f'{plugin.namespace}/submit/{sid_b}', json={
+            'pool': 'cpu', 'task_id': 't.1',
+            'cmd': ['/bin/echo'], 'cwd': '/tmp'})
         assert r.status_code == 404
 
-    def test_fleet_requires_session(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        r = client.get(f'{plugin.namespace}/fleet/nosuchsid')
-        assert r.status_code == 404
-
-
-# ---------------------------------------------------------------------------
-# Session registration + submit
-# ---------------------------------------------------------------------------
-
-def _register_session(client: TestClient, plugin, body=None) -> str:
-    if body is None:
-        r = client.post(f'{plugin.namespace}/register_session')
-    else:
-        r = client.post(f'{plugin.namespace}/register_session', json=body)
-    assert r.status_code == 200, r.text
-    return r.json()['sid']
-
-
-# ---------------------------------------------------------------------------
-# Per-session pool materialisation (Phase 4)
-# ---------------------------------------------------------------------------
-
-class TestSessionDrivenPools:
-
-    def _pool_dict(self, **overrides):
-        d = {
-            'name'        : 'gpu',
-            'endpoint_name'   : 'endpoint_remote',
-            'queue'       : 'batch',
-            'account'     : None,
-            'default_size': 's',
-            'pilot_sizes' : {
-                's': {'nodes': 1, 'cpus_per_node': 4,
-                      'gpus_per_node': 1,
-                      'rhapsody_backend': 'concurrent'}},
-            'max_pilots'  : 1,
-            'strategy'    : 'conservative',
-        }
-        d.update(overrides)
-        return d
-
-    def test_session_can_declare_new_pool(self, tmp_path: Path):
-        _, plugin = _make_plugin(tmp_path, write_config=False)
+    def test_reregister_same_pool_is_idempotent(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
         client = TestClient(plugin._app)
-        sid = _register_session(client, plugin,
-                                body={'pools': [self._pool_dict()]})
-        assert sid
-        assert 'gpu' in plugin._pool_states
-        assert plugin._pool_states['gpu'].config.endpoint_name == 'endpoint_remote'
+        sid = _session_with_cpu(client, plugin, sid='A', lifetime='persistent')
+        first = _pool(plugin, sid, 'cpu')
+        _session_with_cpu(client, plugin, sid='A', lifetime='persistent')
+        assert _pool(plugin, sid, 'cpu') is first
 
-    def test_session_with_no_pools_materialises_default(self, tmp_path: Path):
-        _, plugin = _make_plugin(tmp_path, write_config=False)
+    def test_no_pools_materialises_session_default(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
         client = TestClient(plugin._app)
-        _register_session(client, plugin)
-        assert 'default' in plugin._pool_states
+        sid = _register(client, plugin, body={})
+        assert 'default' in plugin._pool_states[sid]
 
-    def test_default_pool_materialised_only_once(self, tmp_path: Path):
-        _, plugin = _make_plugin(tmp_path, write_config=False)
-        client = TestClient(plugin._app)
-        _register_session(client, plugin)
-        first_state = plugin._pool_states['default']
-        _register_session(client, plugin)
-        second_state = plugin._pool_states['default']
-        assert first_state is second_state   # same PoolState instance
-
-    def test_matching_pool_reattaches(self, tmp_path: Path):
-        _, plugin = _make_plugin(tmp_path, write_config=False)
-        client = TestClient(plugin._app)
-        body = {'pools': [self._pool_dict()]}
-        _register_session(client, plugin, body=body)
-        first = plugin._pool_states['gpu']
-        _register_session(client, plugin, body=body)
-        assert plugin._pool_states['gpu'] is first
-
-    def test_pool_conflict_rejected(self, tmp_path: Path):
-        _, plugin = _make_plugin(tmp_path, write_config=False)
-        client = TestClient(plugin._app)
-        _register_session(client, plugin,
-                          body={'pools': [self._pool_dict()]})
-        # Same pool name, different max_pilots → conflict.
-        r = client.post(f'{plugin.namespace}/register_session',
-                        json={'pools': [self._pool_dict(max_pilots=99)]})
-        assert r.status_code == 409
-        assert 'gpu' in r.text
-
-    def test_invalid_pool_body_400(self, tmp_path: Path):
-        _, plugin = _make_plugin(tmp_path, write_config=False)
+    def test_invalid_pool_body_400(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
         client = TestClient(plugin._app)
         r = client.post(f'{plugin.namespace}/register_session',
                         json={'pools': 'not-a-list'})
@@ -249,729 +190,460 @@ class TestSessionDrivenPools:
 
 
 # ---------------------------------------------------------------------------
-# State-dir pruning (Phase 5)
+# Restart-time replay (built here, not lazy)
 # ---------------------------------------------------------------------------
 
-class TestStateSweeper:
+class TestRestartReplay:
 
-    def test_prune_removes_stale_orphan_dir(self, tmp_path: Path):
-        '''A dir not in active pools, last touched >30d ago, gets pruned.'''
-        import os
-        _, plugin = _make_plugin(tmp_path, write_config=False)
-        state_root = tmp_path / 'state'
-        state_root.mkdir(exist_ok=True)
-        stale = state_root / 'oldpool__endpoint_gone'
-        stale.mkdir()
-        (stale / 'pilot.log').write_text('{}\n')
-        # Age the only file in the dir to 40 days old.
-        old = state_root.stat().st_mtime - 40 * 86400
-        os.utime(stale / 'pilot.log', (old, old))
+    def test_replay_rebuilds_pools_for_multiple_sids(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        _session_with_cpu(client, plugin, sid='A', lifetime='persistent')
+        _session_with_cpu(client, plugin, sid='B', lifetime='persistent')
+        # seed a pilot + a RUNNING task under A
+        ps_a = _pool(plugin, 'A', 'cpu')
+        ps_a.pilots['p.1'] = PilotRecord(
+            pid='p.1', pool='cpu', owning_sid='A', size_key='s',
+            rhapsody_backend='concurrent', state=PILOT_ACTIVE)
+        ps_a.pilot_log.append(ps_a.pilots['p.1'])
+        rec = TaskRecord(task_id='t.x', pool='cpu', owning_sid='A',
+                         cmd=['/bin/echo'], cwd=str(tmp_path),
+                         state=TASK_RUNNING, pilot_id='p.1',
+                         rhapsody_uid='rh.1')
+        ps_a.tasks['t.x'] = rec
+        ps_a.task_log.append(rec)
 
-        plugin._prune_stale_state_dirs()
-        assert not stale.exists()
-
-    def test_prune_keeps_active_pool_dir(self, tmp_path: Path):
-        '''A dir matching an active pool is NEVER pruned, even if old.'''
-        import os
-        _, plugin = _make_plugin(tmp_path)   # 'cpu' pool active
-        # _make_plugin built state at state/cpu__endpoint0/ as part of PoolState init.
-        active_dir = tmp_path / 'state' / 'cpu__endpoint0'
-        if active_dir.exists():
-            for p in active_dir.iterdir():
-                old = (active_dir.stat().st_mtime - 365 * 86400)
-                os.utime(p, (old, old))
-        plugin._prune_stale_state_dirs()
-        assert active_dir.exists()
-
-    def test_prune_keeps_recent_orphan(self, tmp_path: Path):
-        '''A dir not in active pools but recently touched is NOT pruned.'''
-        _, plugin = _make_plugin(tmp_path, write_config=False)
-        state_root = tmp_path / 'state'
-        state_root.mkdir(exist_ok=True)
-        fresh = state_root / 'recent__endpoint_x'
-        fresh.mkdir()
-        (fresh / 'pilot.log').write_text('{}\n')
-        plugin._prune_stale_state_dirs()
-        assert fresh.exists()
+        # Simulate a broker restart: a fresh plugin over the same state root.
+        _, plugin2 = _make_plugin(tmp_path)
+        assert set(plugin2._pool_states.keys()) == {'A', 'B'}
+        ps2 = _pool(plugin2, 'A', 'cpu')
+        assert ps2.tasks['t.x'].state == TASK_RUNNING
+        assert 'p.1' in ps2.pilots
+        # uid→task correlation rebuilt (with the owning sid)
+        assert plugin2._uid_to_task.get('rh.1') == ('A', 'cpu', 't.x')
 
 
 # ---------------------------------------------------------------------------
-# Bridge plugin host integration (Phase 3 / Phase 5 wiring)
+# Session-close teardown + reclaim
 # ---------------------------------------------------------------------------
 
-class TestBridgeHostLoadsDispatcher:
-    '''Smoke test: BridgePluginHost can actually load + serve the dispatcher.
+class TestSessionTeardown:
 
-    The other tests in this file use a vanilla FastAPI app, which masks
-    any mismatch between the dispatcher's expectations and what
-    BridgePluginHost provides (is_bridge flag, send_notification,
-    on_topology_change fan-out, etc.).  These tests exercise the real
-    host.
-    '''
+    def test_unregister_tears_down_pools_and_cancels_pilots(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        sid = _register(client, plugin,
+                        body={'sid': 'A', 'lifetime': 'persistent',
+                              'pools': [_pool_dict()]})
+        ps = _pool(plugin, sid, 'cpu')
+        ps.pilots['p.1'] = PilotRecord(
+            pid='p.1', pool='cpu', owning_sid=sid, size_key='s',
+            rhapsody_backend='concurrent', state=PILOT_ACTIVE)
+        r = client.post(f'{plugin.namespace}/unregister_session/{sid}')
+        assert r.status_code == 200
+        assert sid not in plugin._pool_states               # pools dropped
+        assert ps.pilots['p.1'].state == PILOT_FAILED       # pilot cancelled
 
-    @pytest.fixture
-    def host(self, tmp_path: Path, monkeypatch):
-        from radical.orbit.bridge_plugin_host import BridgePluginHost
-        # Steer the dispatcher's default state/scratch roots at tmp_path
-        # so the host's auto-built plugin doesn't pollute $HOME.
-        monkeypatch.setenv('RADICAL_ORBIT_BRIDGE_URL', 'https://localhost:9999')
-        monkeypatch.setattr(
-            'radical.orbit.plugin_task_dispatcher._DEFAULT_STATE_ROOT',
-            tmp_path / 'state')
-        monkeypatch.setattr(
-            'radical.orbit.plugin_task_dispatcher._DEFAULT_SCRATCH_ROOT',
-            tmp_path / 'scratch')
-        broadcasts: list = []
+    def test_cancel_all_reclaims_persistent_pools(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        sid = _register(client, plugin,
+                        body={'sid': 'default'})   # reserved persistent
+        ps = _pool(plugin, sid, 'default')
+        ps.pilots['p.1'] = PilotRecord(
+            pid='p.1', pool='default', owning_sid=sid, size_key='s',
+            rhapsody_backend='concurrent', state=PILOT_ACTIVE)
+        r = client.post(f'{plugin.namespace}/cancel_all/{sid}')
+        assert r.status_code == 200
+        assert r.json()['pools_reclaimed'] == 1
+        assert sid not in plugin._pool_states
+        assert ps.pilots['p.1'].state == PILOT_FAILED
 
-        async def broadcast(topic, data):
-            broadcasts.append((topic, data))
+    def test_ephemeral_owner_lost_drains_and_cancels(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        plugin.reclaim_drain = 0.05        # tiny drain timer
 
-        host = BridgePluginHost(
-            plugin_names=['task_dispatcher'],
-            broadcast_fn=broadcast,
-            endpoint_name='bridge',
-            bridge_url='https://localhost:9999')
-        return host
+        async def scenario():
+            plugin._ensure_started()
+            sid = await plugin._open_session(None, 'ephemeral', None,
+                                             owner='clientA')
+            plugin._materialise_pool(sid, _make_pool_cfg())
+            ps = _pool(plugin, sid, 'cpu')
+            ps.pilots['p.1'] = PilotRecord(
+                pid='p.1', pool='cpu', owning_sid=sid, size_key='s',
+                rhapsody_backend='concurrent', state=PILOT_ACTIVE)
+            # owner declared lost → arms the reclaim-drain
+            await plugin.on_topology_change(
+                {'clientA': {'role': 'endpoint', 'plugins': {},
+                             'liveness': 'lost'}})
+            await asyncio.sleep(0.25)       # let the drain fire
+            return sid, ps
 
-    def test_dispatcher_loads(self, host):
-        '''The dispatcher plugin instantiates and registers on the bridge host.'''
-        assert 'task_dispatcher' in host._plugins
-        td = host._plugins['task_dispatcher']
-        assert td.plugin_name == 'task_dispatcher'
-        # No pools loaded at startup (Phase 5: pools are session-driven).
-        assert td._pool_states == {}
+        sid, ps = asyncio.run(scenario())
+        assert sid not in plugin._pool_states
+        assert ps.pilots['p.1'].state == PILOT_FAILED
 
-    @pytest.mark.asyncio
-    async def test_dispatcher_routes_reachable(self, host):
-        '''Dispatcher's GET /pools route is wired through the host.'''
-        # Namespace prefix is whatever the plugin chose; for task_dispatcher
-        # it's '/task_dispatcher' (inside the bridge host's view).
-        td = host._plugins['task_dispatcher']
-        path = f'{td.namespace}/pools'
-        resp = await host.handle_request('GET', path, {}, b'')
-        # JSONResponse → body has {'pools': {...}}; with no pools materialised,
-        # the dict is empty but the route shouldn't 404.
-        import json
-        body = json.loads(resp.body)
-        assert 'pools' in body
-        assert body['pools'] == {}
+    def test_persistent_pool_survives_owner_loss(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        plugin.reclaim_drain = 0.05
 
-    @pytest.mark.asyncio
-    async def test_register_session_materialises_default_pool(self, host):
-        '''POST /register_session with no body → default pool appears.'''
-        td = host._plugins['task_dispatcher']
-        path = f'{td.namespace}/register_session'
-        resp = await host.handle_request('POST', path, {}, b'{}')
-        import json
-        body = json.loads(resp.body)
-        assert 'sid' in body
-        assert 'default' in td._pool_states
+        async def scenario():
+            plugin._ensure_started()
+            sid = await plugin._open_session('P', 'persistent', None,
+                                             owner='clientA')
+            plugin._materialise_pool(sid, _make_pool_cfg())
+            await plugin.on_topology_change(
+                {'clientA': {'role': 'endpoint', 'plugins': {},
+                             'liveness': 'lost'}})
+            await asyncio.sleep(0.25)
+            return sid
 
-    def test_dispatcher_is_bridge_role(self, host):
-        '''The dispatcher's is_enabled returns True under the bridge host.'''
-        from radical.orbit.plugin_task_dispatcher import PluginTaskDispatcher
-        assert PluginTaskDispatcher.is_enabled(host._app) is True
+        sid = asyncio.run(scenario())
+        assert sid in plugin._pool_states           # persistent → not reclaimed
+
+    def test_pool_survives_suspect_owner_blip(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        plugin.reclaim_drain = 0.05
+
+        async def scenario():
+            plugin._ensure_started()
+            sid = await plugin._open_session('E', 'ephemeral', None,
+                                             owner='clientA')
+            plugin._materialise_pool(sid, _make_pool_cfg())
+            # suspect must NOT arm the drain
+            await plugin.on_topology_change(
+                {'clientA': {'role': 'endpoint', 'plugins': {},
+                             'liveness': 'suspect'}})
+            await asyncio.sleep(0.25)
+            return sid
+
+        sid = asyncio.run(scenario())
+        assert sid in plugin._pool_states           # blip → pool survives
 
 
-class TestSubmitTask:
+# ---------------------------------------------------------------------------
+# Routes: pools / fleet / submit
+# ---------------------------------------------------------------------------
 
-    def test_rejects_unknown_pool(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        r = client.post(f'{plugin.namespace}/submit/{sid}', json={
-            'pool': 'nope', 'task_id': 't.1',
-            'cmd': ['/bin/echo', 'hi'], 'cwd': '/tmp'})
+class TestRoutes:
+
+    def test_fleet_scoped_to_session(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        sid = _session_with_cpu(client, plugin, sid='A', lifetime='persistent')
+        r = client.get(f'{plugin.namespace}/fleet/{sid}')
+        assert r.status_code == 200
+        assert 'cpu' in r.json()['pools']
+
+    def test_fleet_unknown_session_404(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        r = client.get(f'{plugin.namespace}/fleet/nope')
         assert r.status_code == 404
 
-    def test_rejects_missing_fields(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
+    def test_submit_rejects_unknown_pool(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        sid = _session_with_cpu(client, plugin, sid='A', lifetime='persistent')
         r = client.post(f'{plugin.namespace}/submit/{sid}', json={
-            'pool': 'cpu'})
-        assert r.status_code == 400
+            'pool': 'nope', 'task_id': 't.1',
+            'cmd': ['/bin/echo'], 'cwd': '/tmp'})
+        assert r.status_code == 404
 
-    def test_enqueues_task_and_triggers_strategy(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-
-        spy = plugin._pool_states['cpu'].strategy
-        with patch.object(spy, 'on_task_arrived') as on_arrived, \
-             patch.object(spy, 'pick_dispatch', return_value=None) as pd:
+    def test_submit_enqueues_task_and_stamps_owner(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        sid = _session_with_cpu(client, plugin, sid='A', lifetime='persistent')
+        ps = _pool(plugin, sid, 'cpu')
+        with patch.object(ps.strategy, 'on_task_arrived') as on_arrived, \
+             patch.object(ps.strategy, 'pick_dispatch', return_value=None):
             r = client.post(f'{plugin.namespace}/submit/{sid}', json={
                 'pool': 'cpu', 'task_id': 't.1',
-                'cmd': ['/bin/echo', 'hi'],
-                'cwd': str(tmp_path), 'priority': 7,
-                'inputs': ['a'], 'outputs': ['b']})
+                'cmd': ['/bin/echo', 'hi'], 'cwd': str(tmp_path)})
             assert r.status_code == 200
             assert on_arrived.called
-            assert pd.called
-
-        # Record exists in memory and on disk
-        ps = plugin._pool_states['cpu']
-        assert 't.1' in ps.tasks
-        assert ps.tasks['t.1'].priority == 7
         assert ps.tasks['t.1'].state == TASK_QUEUED
-        # Log replays consistently
-        replayed = ps.task_log.replay()
-        assert 't.1' in replayed
+        assert ps.tasks['t.1'].owning_sid == sid
 
-    def test_cached_done_returns_without_reexec(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        ps = plugin._pool_states['cpu']
-
-        # Seed a DONE record
+    def test_cached_done_returns_without_reexec(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        sid = _session_with_cpu(client, plugin, sid='A', lifetime='persistent')
+        ps = _pool(plugin, sid, 'cpu')
         ps.tasks['t.done'] = TaskRecord(
-            task_id='t.done', pool='cpu',
-            cmd=['/bin/echo'], cwd=str(tmp_path),
-            state=TASK_DONE, exit_code=0)
-
+            task_id='t.done', pool='cpu', owning_sid=sid,
+            cmd=['/bin/echo'], cwd=str(tmp_path), state=TASK_DONE, exit_code=0)
         with patch.object(ps.strategy, 'on_task_arrived') as spy:
             r = client.post(f'{plugin.namespace}/submit/{sid}', json={
                 'pool': 'cpu', 'task_id': 't.done',
                 'cmd': ['/bin/echo'], 'cwd': str(tmp_path)})
-            assert r.status_code == 200
             assert r.json()['state'] == TASK_DONE
-            assert r.json()['exit_code'] == 0
-            spy.assert_not_called()   # no re-execution
-
-    def test_cached_failed_reexecutes(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        ps = plugin._pool_states['cpu']
-
-        ps.tasks['t.fail'] = TaskRecord(
-            task_id='t.fail', pool='cpu',
-            cmd=['/bin/echo'], cwd=str(tmp_path),
-            state=TASK_FAILED, exit_code=1)
-
-        with patch.object(ps.strategy, 'on_task_arrived') as spy:
-            r = client.post(f'{plugin.namespace}/submit/{sid}', json={
-                'pool': 'cpu', 'task_id': 't.fail',
-                'cmd': ['/bin/echo'], 'cwd': str(tmp_path)})
-            assert r.status_code == 200
-            # Re-executed → QUEUED again
-            assert r.json()['state'] == TASK_QUEUED
-            spy.assert_called_once()
-
-    def test_cached_running_attaches(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        ps = plugin._pool_states['cpu']
-
-        ps.tasks['t.run'] = TaskRecord(
-            task_id='t.run', pool='cpu',
-            cmd=['/bin/echo'], cwd=str(tmp_path),
-            state=TASK_RUNNING, pilot_id='p.xyz')
-
-        with patch.object(ps.strategy, 'on_task_arrived') as spy:
-            r = client.post(f'{plugin.namespace}/submit/{sid}', json={
-                'pool': 'cpu', 'task_id': 't.run',
-                'cmd': ['/bin/echo'], 'cwd': str(tmp_path)})
-            assert r.status_code == 200
-            assert r.json()['state'] == TASK_RUNNING
             spy.assert_not_called()
 
+    def test_cancel_queued_is_immediate(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        sid = _session_with_cpu(client, plugin, sid='A', lifetime='persistent')
+        ps = _pool(plugin, sid, 'cpu')
+        ps.tasks['t.q'] = TaskRecord(
+            task_id='t.q', pool='cpu', owning_sid=sid, cmd=['/bin/echo'],
+            cwd=str(tmp_path), state=TASK_QUEUED)
+        r = client.post(f'{plugin.namespace}/cancel/{sid}/t.q')
+        assert r.status_code == 200
+        assert ps.tasks['t.q'].state == TASK_CANCELED
 
-class TestGetTaskAndCancel:
-
-    def test_get_task_404(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
+    def test_get_task_404(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        sid = _session_with_cpu(client, plugin, sid='A', lifetime='persistent')
         r = client.get(f'{plugin.namespace}/task/{sid}/nope')
         assert r.status_code == 404
 
-    def test_cancel_queued_is_immediate(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        ps = plugin._pool_states['cpu']
-
-        # Put a queued task on the books
-        ps.tasks['t.q'] = TaskRecord(
-            task_id='t.q', pool='cpu', cmd=['/bin/echo'],
-            cwd=str(tmp_path), state=TASK_QUEUED)
-
-        r = client.post(f'{plugin.namespace}/cancel/{sid}/t.q')
-        assert r.status_code == 200
-        assert r.json()['state'] == TASK_CANCELED
-        assert ps.tasks['t.q'].state == TASK_CANCELED
-
-    def test_cancel_terminal_is_noop(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        ps = plugin._pool_states['cpu']
-        ps.tasks['t.done'] = TaskRecord(
-            task_id='t.done', pool='cpu', cmd=['/bin/echo'],
-            cwd=str(tmp_path), state=TASK_DONE, exit_code=0)
-        r = client.post(f'{plugin.namespace}/cancel/{sid}/t.done')
-        assert r.status_code == 200
-        assert r.json()['state'] == TASK_DONE   # unchanged
-
 
 # ---------------------------------------------------------------------------
-# Staging routes
+# Staging
 # ---------------------------------------------------------------------------
 
-class TestStagingRoutes:
+class TestStaging:
 
-    def test_stage_in_writes_file(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
+    def test_stage_in_out_roundtrip(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        sid = _session_with_cpu(client, plugin, sid='A', lifetime='persistent')
+        ps = _pool(plugin, sid, 'cpu')
         content = b'hello world'
         r = client.post(
             f'{plugin.namespace}/stage_in/{sid}/t.1',
-            json={'pool': 'cpu', 'filename': 'input.txt',
+            json={'pool': 'cpu', 'filename': 'in.txt',
                   'content_b64': base64.b64encode(content).decode('ascii')})
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert body['size'] == len(content)
-        path = Path(body['cwd']) / 'input.txt'
-        assert path.read_bytes() == content
+        assert r.status_code == 200
+        assert (Path(r.json()['cwd']) / 'in.txt').read_bytes() == content
 
-    def test_stage_in_rejects_bad_filename(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        for bad in ('../evil', 'sub/dir', '', '.', '..'):
-            r = client.post(
-                f'{plugin.namespace}/stage_in/{sid}/t.1',
-                json={'pool': 'cpu', 'filename': bad,
-                      'content_b64': base64.b64encode(b'x').decode('ascii')})
-            assert r.status_code == 400, \
-                f'expected 400 for filename {bad!r}'
-
-    def test_stage_in_rejects_unknown_pool(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        r = client.post(
-            f'{plugin.namespace}/stage_in/{sid}/t.1',
-            json={'pool': 'nope', 'filename': 'f.txt',
-                  'content_b64': base64.b64encode(b'x').decode('ascii')})
-        assert r.status_code == 404
-
-    def test_stage_in_overwrite_flag(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        payload = {'pool': 'cpu', 'filename': 'f.txt',
-                   'content_b64': base64.b64encode(b'v1').decode('ascii')}
-        r1 = client.post(f'{plugin.namespace}/stage_in/{sid}/t.1', json=payload)
-        assert r1.status_code == 200
-
-        # Re-upload w/o overwrite → 409
-        r2 = client.post(f'{plugin.namespace}/stage_in/{sid}/t.1', json=payload)
-        assert r2.status_code == 409
-
-        # With overwrite=True → 200 and contents updated
-        payload['content_b64'] = base64.b64encode(b'v2').decode('ascii')
-        payload['overwrite']   = True
-        r3 = client.post(f'{plugin.namespace}/stage_in/{sid}/t.1', json=payload)
-        assert r3.status_code == 200
-        path = Path(r3.json()['cwd']) / 'f.txt'
-        assert path.read_bytes() == b'v2'
-
-    def test_stage_out_returns_file(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        ps = plugin._pool_states['cpu']
         ps.tasks['t.1'] = TaskRecord(
-            task_id='t.1', pool='cpu', cmd=['/bin/echo'],
+            task_id='t.1', pool='cpu', owning_sid=sid, cmd=['/bin/echo'],
             cwd=str(tmp_path), state=TASK_DONE)
-        scratch = ps.scratch_base / 't.1'
-        scratch.mkdir(parents=True, exist_ok=True)
-        (scratch / 'out.txt').write_bytes(b'result payload')
-
+        (ps.scratch_base / 't.1' / 'out.txt').write_bytes(b'result')
         r = client.get(f'{plugin.namespace}/stage_out/{sid}/t.1/out.txt')
         assert r.status_code == 200
-        body = r.json()
-        assert body['size'] == len(b'result payload')
-        assert base64.b64decode(body['content_b64']) == b'result payload'
+        assert base64.b64decode(r.json()['content_b64']) == b'result'
 
-    def test_stage_out_missing_file(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        ps = plugin._pool_states['cpu']
-        ps.tasks['t.1'] = TaskRecord(
-            task_id='t.1', pool='cpu', cmd=['/bin/echo'],
-            cwd=str(tmp_path), state=TASK_DONE)
-        r = client.get(f'{plugin.namespace}/stage_out/{sid}/t.1/nope.txt')
-        assert r.status_code == 404
+    def test_stage_in_bad_filename(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        sid = _session_with_cpu(client, plugin, sid='A', lifetime='persistent')
+        r = client.post(
+            f'{plugin.namespace}/stage_in/{sid}/t.1',
+            json={'pool': 'cpu', 'filename': '../evil',
+                  'content_b64': base64.b64encode(b'x').decode('ascii')})
+        assert r.status_code == 400
 
 
 # ---------------------------------------------------------------------------
-# Pilot binding via topology hook
+# Pilot binding via rich topology (present / suspect / lost)
 # ---------------------------------------------------------------------------
+
+def _child_topo(name, liveness='present'):
+    return {name: {'role': 'endpoint',
+                   'plugins': {'rhapsody': {'namespace': '/rhapsody'}},
+                   'liveness': liveness}}
+
 
 class TestTopologyBinding:
 
-    def _new_pending(self, plugin, pid='p.1', child='endpoint0_p.1',
-                    state=PILOT_PENDING):
-        ps = plugin._pool_states['cpu']
-        ps.pilots[pid] = PilotRecord(
-            pid=pid, pool='cpu', size_key='s',
-            rhapsody_backend='concurrent',
-            state=state, submitted_at=100.0,
-            child_endpoint_name=child)
-        return ps
-
-    def test_topology_binds_pending_pilot(self, tmp_path: Path):
+    def _plugin_with_pilot(self, tmp_path, pid='p.1',
+                           child='endpoint0_p.1', state=PILOT_PENDING,
+                           walltime=1e12):
         _, plugin = _make_plugin(tmp_path)
-        plugin._loops_started = True   # bypass the not-yet-started gate
-        ps = self._new_pending(plugin)
+        plugin._loops_started = True
+        plugin._materialise_pool('A', _make_pool_cfg())
+        ps = _pool(plugin, 'A', 'cpu')
+        ps.pilots[pid] = PilotRecord(
+            pid=pid, pool='cpu', owning_sid='A', size_key='s',
+            rhapsody_backend='concurrent', state=state, submitted_at=100.0,
+            child_endpoint_name=child, walltime_deadline=walltime)
+        return plugin, ps
+
+    def test_present_binds_pending_pilot(self, tmp_path):
+        plugin, ps = self._plugin_with_pilot(tmp_path)
         with patch.object(ps.strategy, 'on_pilot_state') as spy:
-            asyncio.run(plugin.on_topology_change(
-                {'endpoint0_p.1': {'plugins': ['rhapsody']}}))
+            asyncio.run(plugin.on_topology_change(_child_topo('endpoint0_p.1')))
         assert ps.pilots['p.1'].state == PILOT_ACTIVE
-        # capacity = nodes(1) * cpus_per_node(4) from _make_plugin's pool
         assert ps.pilots['p.1'].capacity == 4
-        assert ps.pilots['p.1'].active_at is not None
         spy.assert_called_once()
 
-    def test_topology_ignores_unknown_endpoints(self, tmp_path: Path):
-        _, plugin = _make_plugin(tmp_path)
-        plugin._loops_started = True
-        ps = self._new_pending(plugin)
+    def test_suspect_child_pauses_not_demotes(self, tmp_path):
+        plugin, ps = self._plugin_with_pilot(tmp_path, state=PILOT_ACTIVE)
+        ps.pilots['p.1'].capacity = 4
         asyncio.run(plugin.on_topology_change(
-            {'someone_else': {'plugins': ['sysinfo']}}))
-        assert ps.pilots['p.1'].state == PILOT_PENDING
+            _child_topo('endpoint0_p.1', 'suspect')))
+        assert ps.pilots['p.1'].state == PILOT_ACTIVE           # not demoted
+        assert ps.pilots['p.1'].accepting_new_tasks is False    # paused
+        # returning present un-pauses
+        asyncio.run(plugin.on_topology_change(
+            _child_topo('endpoint0_p.1', 'present')))
+        assert ps.pilots['p.1'].accepting_new_tasks is True
 
-    def test_topology_ignores_terminal_pilot(self, tmp_path: Path):
-        _, plugin = _make_plugin(tmp_path)
-        plugin._loops_started = True
-        ps = self._new_pending(plugin, state=PILOT_FAILED)
+    def test_lost_before_walltime_marks_failed(self, tmp_path):
+        plugin, ps = self._plugin_with_pilot(tmp_path, state=PILOT_ACTIVE,
+                                             walltime=1e12)
+        ps.pilots['p.1'].capacity = 4
         asyncio.run(plugin.on_topology_change(
-            {'endpoint0_p.1': {'plugins': ['rhapsody']}}))
-        assert ps.pilots['p.1'].state == PILOT_FAILED   # unchanged
+            _child_topo('endpoint0_p.1', 'lost')))
+        assert ps.pilots['p.1'].state == PILOT_FAILED
 
-    def test_topology_no_op_before_started(self, tmp_path: Path):
-        _, plugin = _make_plugin(tmp_path)
-        # Don't flip _loops_started — emulate startup race
-        ps = self._new_pending(plugin)
+    def test_lost_after_walltime_marks_done(self, tmp_path):
+        plugin, ps = self._plugin_with_pilot(tmp_path, state=PILOT_ACTIVE,
+                                             walltime=1.0)   # long past
+        ps.pilots['p.1'].capacity = 4
         asyncio.run(plugin.on_topology_change(
-            {'endpoint0_p.1': {'plugins': ['rhapsody']}}))
-        assert ps.pilots['p.1'].state == PILOT_PENDING
+            _child_topo('endpoint0_p.1', 'lost')))
+        assert ps.pilots['p.1'].state == PILOT_DONE
+
+    def test_absent_child_not_demoted(self, tmp_path):
+        """A child never listed 'lost' (e.g. not-yet-reconnected after a
+        restart) is left alone — replaces the old `_seen` heuristic."""
+        plugin, ps = self._plugin_with_pilot(tmp_path, state=PILOT_ACTIVE)
+        asyncio.run(plugin.on_topology_change(_child_topo('someone_else')))
+        assert ps.pilots['p.1'].state == PILOT_ACTIVE
 
 
 # ---------------------------------------------------------------------------
-# Internal helpers — pilot failure re-enqueues tasks
+# Pilot failure re-enqueues tasks
 # ---------------------------------------------------------------------------
 
 class TestMarkPilotFailed:
 
-    def test_reenqueues_running_tasks(self, tmp_path: Path):
+    def test_reenqueues_running_tasks(self, tmp_path):
         _, plugin = _make_plugin(tmp_path)
-        ps = plugin._pool_states['cpu']
-        pilot = PilotRecord(
-            pid='p.1', pool='cpu', size_key='s',
-            rhapsody_backend='concurrent', state=PILOT_ACTIVE,
-            capacity=2, in_flight=2)
+        plugin._materialise_pool('A', _make_pool_cfg())
+        ps = _pool(plugin, 'A', 'cpu')
+        pilot = PilotRecord(pid='p.1', pool='cpu', owning_sid='A', size_key='s',
+                            rhapsody_backend='concurrent', state=PILOT_ACTIVE,
+                            capacity=2, in_flight=2)
         ps.pilots['p.1'] = pilot
-        t_running = TaskRecord(task_id='t.r', pool='cpu',
-                                cmd=['/bin/echo'], cwd=str(tmp_path),
-                                state=TASK_RUNNING, pilot_id='p.1')
-        t_done    = TaskRecord(task_id='t.d', pool='cpu',
-                                cmd=['/bin/echo'], cwd=str(tmp_path),
-                                state=TASK_DONE, pilot_id='p.1')
-        ps.tasks['t.r'] = t_running
-        ps.tasks['t.d'] = t_done
-
+        ps.tasks['t.r'] = TaskRecord(task_id='t.r', pool='cpu', owning_sid='A',
+                                     cmd=['/bin/echo'], cwd=str(tmp_path),
+                                     state=TASK_RUNNING, pilot_id='p.1')
         plugin._mark_pilot_failed(ps, pilot, 'test')
-
         assert pilot.state == PILOT_FAILED
         assert ps.tasks['t.r'].state == TASK_QUEUED
         assert ps.tasks['t.r'].pilot_id is None
-        assert ps.tasks['t.d'].state == TASK_DONE    # terminal unchanged
 
 
 # ---------------------------------------------------------------------------
-# Strategy submit_pilot bookkeeping (no actual psij call)
+# Async transport port: proxies over the broker caller (mocked)
 # ---------------------------------------------------------------------------
 
-class TestStrategyActions:
+class TestPilotSubmitTransport:
 
-    def test_strategy_submit_records_pilot(self, tmp_path: Path):
+    def test_submit_tunneled_passes_tunnel_none(self, tmp_path):
         _, plugin = _make_plugin(tmp_path)
-        ps = plugin._pool_states['cpu']
-
-        # Prevent the async submit from running: no event loop here anyway
-        with patch.object(plugin, '_schedule_pilot_submit') as sched:
-            pid = ps.ctx.submit_pilot(None)
-
-        assert pid.startswith('p.')
-        assert pid in ps.pilots
-        assert ps.pilots[pid].state == PILOT_PENDING
-        assert ps.pilots[pid].rhapsody_backend == 'concurrent'
-        sched.assert_called_once()
-
-    def test_strategy_submit_unknown_size(self, tmp_path: Path):
-        _, plugin = _make_plugin(tmp_path)
-        ps = plugin._pool_states['cpu']
-        with pytest.raises(KeyError):
-            ps.ctx.submit_pilot('xxl')
-
-    def test_drain_pilot_flips_flag(self, tmp_path: Path):
-        _, plugin = _make_plugin(tmp_path)
-        ps = plugin._pool_states['cpu']
-        ps.pilots['p.x'] = PilotRecord(
-            pid='p.x', pool='cpu', size_key='s',
-            rhapsody_backend='concurrent', state=PILOT_ACTIVE,
-            capacity=4, in_flight=1)
-        ps.ctx.drain_pilot('p.x')
-        assert ps.pilots['p.x'].accepting_new_tasks is False
-        # Free capacity now zero despite slots
-        assert ps.pilots['p.x'].free_capacity() == 0
-
-
-# ---------------------------------------------------------------------------
-# Handshake-arrival via handler → triggers drain (pick_dispatch loop)
-# ---------------------------------------------------------------------------
-
-class TestDispatchDrain:
-
-    def test_drain_assigns_queued_task(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        ps = plugin._pool_states['cpu']
-
-        # Two queued tasks + one active pilot
-        for i in range(2):
-            ps.tasks[f't.{i}'] = TaskRecord(
-                task_id=f't.{i}', pool='cpu',
-                cmd=['/bin/echo', str(i)], cwd=str(tmp_path),
-                state=TASK_QUEUED, priority=0, arrival_ts=float(i))
-        ps.pilots['p.1'] = PilotRecord(
-            pid='p.1', pool='cpu', size_key='s',
-            rhapsody_backend='concurrent',
-            state=PILOT_ACTIVE, capacity=4, in_flight=0,
-            child_endpoint_name='endpoint0_p.1',
-            walltime_deadline=10_000.0, submitted_at=0.0, active_at=10.0)
-
-        # Prevent the async rhapsody submit from running
-        with patch.object(plugin, '_do_rhapsody_submit') as spy, \
-             patch.object(plugin, '_main_loop'):
-            plugin._drain_pending(ps)
-
-        # Both tasks advanced to RUNNING
-        assert ps.tasks['t.0'].state == TASK_RUNNING
-        assert ps.tasks['t.1'].state == TASK_RUNNING
-        assert ps.pilots['p.1'].in_flight == 2
-
-
-# ---------------------------------------------------------------------------
-# Regression: psij submit_tunneled tunnel-arg shape
-# ---------------------------------------------------------------------------
-#
-# Bug surfaced during the local e2e smoke (memory/project_bridge_dispatcher.md):
-# the dispatcher used to call ``psij_c.submit_tunneled(spec, executor, False)``
-# but psij now requires one of ``'none'`` / ``'forward'`` / ``'reverse'`` and
-# rejects the boolean.  Fix was a literal ``False`` → ``'none'`` change in
-# _do_pilot_submit.  This test pins the contract.
-
-class TestPilotSubmitTunnelArg:
-
-    def test_passes_tunnel_none_not_false(self, tmp_path: Path):
-        _, plugin = _make_plugin(tmp_path)
-        ps = plugin._pool_states['cpu']
+        plugin._materialise_pool('A', _make_pool_cfg())
+        ps = _pool(plugin, 'A', 'cpu')
         size = ps.config.pilot_sizes[ps.config.default_size]
         record = PilotRecord(
-            pid='p.tunnel_arg', pool='cpu', size_key=ps.config.default_size,
-            rhapsody_backend=size.rhapsody_backend,
-            state=PILOT_PENDING, submitted_at=0.0)
+            pid='p.a', pool='cpu', owning_sid='A',
+            size_key=ps.config.default_size,
+            rhapsody_backend=size.rhapsody_backend, state=PILOT_PENDING)
         ps.pilots[record.pid] = record
 
         psij_mock = MagicMock()
-        psij_mock.submit_tunneled.return_value = {'job_id': 'fake-jid'}
-
-        with patch.object(plugin, '_get_psij_client', return_value=psij_mock), \
+        psij_mock.submit_tunneled = AsyncMock(return_value={'job_id': 'jid'})
+        with patch.object(plugin, '_get_psij_client',
+                          new=AsyncMock(return_value=psij_mock)), \
              patch('radical.orbit.batch_system.detect_batch_system') as bs:
             bs.return_value.psij_executor = 'local'
             asyncio.run(plugin._do_pilot_submit(ps, record, size))
 
-        psij_mock.submit_tunneled.assert_called_once()
-        # Third positional arg is the tunnel mode — must be the string
-        # 'none', not False.
-        call_args = psij_mock.submit_tunneled.call_args
-        assert call_args.args[2] == 'none', (
-            f'expected tunnel mode \'none\', got {call_args.args[2]!r}')
-        assert call_args.args[2] is not False
+        psij_mock.submit_tunneled.assert_awaited_once()
+        assert psij_mock.submit_tunneled.await_args.args[2] == 'none'
+        assert record.psij_job_id == 'jid'
+
+    def test_refuses_without_broker_caller(self, tmp_path):
+        """Old-stack construction (no caller) → the transport refuses cleanly."""
+        _, plugin = _make_plugin(tmp_path, broker_caller=None)
+        assert plugin._broker_caller is None
+        with pytest.raises(RuntimeError, match='broker-hosted only'):
+            asyncio.run(plugin._call('someone', 'GET', '/x/ping'))
 
 
 # ---------------------------------------------------------------------------
 # Endpoint-mode submit (transparent proxy to a target endpoint's rhapsody)
 # ---------------------------------------------------------------------------
 
-class TestEndpointModeSubmit:
-    '''Submit/get/cancel paths that target an endpoint directly (no pool).
+class TestEndpointMode:
 
-    These tests stub :meth:`_get_rhapsody_client` so no real bridge or
-    HTTP traffic is needed.  ``_connected_endpoints`` is poked directly to
-    simulate a topology update (the test client doesn't run the bridge
-    WS subscription thread).
-    '''
-
-    def _seed_topology(self, plugin, endpoint_plugins: dict):
-        '''Populate ``_connected_endpoints`` as on_topology_change would.'''
+    def _seed_topology(self, plugin, endpoint_plugins):
         plugin._connected_endpoints = {
-            name: set(plugins) for name, plugins in endpoint_plugins.items()
-        }
+            name: set(plugins) for name, plugins in endpoint_plugins.items()}
 
-    def test_xor_neither_set_400(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        r = client.post(f'{plugin.namespace}/submit/{sid}', json={
-            'task_id': 't.1', 'cmd': ['/bin/echo', 'hi'],
-            'cwd': '/tmp'})
-        assert r.status_code == 400
-        assert 'exactly one' in r.text
-
-    def test_xor_both_set_400(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        r = client.post(f'{plugin.namespace}/submit/{sid}', json={
-            'pool': 'cpu', 'endpoint': 'endpoint_x',
-            'task_id': 't.1', 'cmd': ['/bin/echo', 'hi'],
-            'cwd': '/tmp'})
-        assert r.status_code == 400
-        assert 'exactly one' in r.text
-
-    def test_unknown_endpoint_404(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        self._seed_topology(plugin, {})   # no endpoints connected
+    def test_unknown_endpoint_404(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        sid = _register(client, plugin, body={'sid': 'A',
+                                              'lifetime': 'persistent'})
+        self._seed_topology(plugin, {})
         r = client.post(f'{plugin.namespace}/submit/{sid}', json={
             'endpoint': 'ghost', 'task_id': 't.1',
-            'cmd': ['/bin/echo', 'hi'], 'cwd': '/tmp'})
+            'cmd': ['/bin/echo'], 'cwd': '/tmp'})
         assert r.status_code == 404
-        assert 'unknown endpoint: ghost' in r.text
 
-    def test_endpoint_without_rhapsody_503(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        self._seed_topology(plugin, {'endpoint_dumb': ['sysinfo']})
-        r = client.post(f'{plugin.namespace}/submit/{sid}', json={
-            'endpoint': 'endpoint_dumb', 'task_id': 't.1',
-            'cmd': ['/bin/echo', 'hi'], 'cwd': '/tmp'})
-        assert r.status_code == 503
-        assert 'cannot run tasks' in r.text
-
-    def test_rejects_inputs_in_endpoint_mode(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        self._seed_topology(plugin, {'endpoint_r': ['rhapsody']})
-        rh_mock = MagicMock()
-        rh_mock.submit_tasks.return_value = [{'uid': 't.1', 'state': 'NEW'}]
-        with patch.object(plugin, '_get_rhapsody_client',
-                          return_value=rh_mock):
-            r = client.post(f'{plugin.namespace}/submit/{sid}', json={
-                'endpoint': 'endpoint_r', 'task_id': 't.1',
-                'cmd': ['/bin/echo', 'hi'], 'cwd': '/tmp',
-                'inputs': ['a']})
-        assert r.status_code == 400
-        assert 'staging not supported' in r.text or \
-               'not supported for endpoint-mode' in r.text
-
-    def test_proxy_submit_invokes_rhapsody(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        self._seed_topology(plugin, {'endpoint_r': ['rhapsody', 'sysinfo']})
-        rh_mock = MagicMock()
-        rh_mock.submit_tasks.return_value = [{'uid': 't.1', 'state': 'NEW'}]
-        with patch.object(plugin, '_get_rhapsody_client',
-                          return_value=rh_mock):
-            r = client.post(f'{plugin.namespace}/submit/{sid}', json={
-                'endpoint': 'endpoint_r', 'task_id': 't.1',
-                'cmd': ['/bin/sleep', '0'], 'cwd': '/tmp'})
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert body['task_id'] == 't.1'
-        assert body['endpoint'] == 'endpoint_r'
-        # Rhapsody saw the task with the same uid + cwd carried via
-        # backend_specific_kwargs (so rhapsody's concurrent backend
-        # picks the right working dir).
-        rh_mock.submit_tasks.assert_called_once()
-        submitted = rh_mock.submit_tasks.call_args.args[0]
-        assert submitted[0]['uid'] == 't.1'
-        assert submitted[0]['executable'] == '/bin/sleep'
-        assert submitted[0]['arguments'] == ['0']
-        # Endpoint-mode mapping recorded so get/cancel can route back.
-        assert plugin._endpoint_mode_tasks.get('t.1') == 'endpoint_r'
-
-    def test_get_task_forwards_to_target_endpoint(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        plugin._endpoint_mode_tasks['t.1'] = 'endpoint_r'
-        rh_mock = MagicMock()
-        rh_mock.get_task.return_value = {'uid': 't.1', 'state': 'RUNNING'}
-        with patch.object(plugin, '_get_rhapsody_client',
-                          return_value=rh_mock):
-            r = client.get(f'{plugin.namespace}/task/{sid}/t.1')
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert body['task_id'] == 't.1'
-        assert body['endpoint'] == 'endpoint_r'
-        assert body['result']['state'] == 'RUNNING'
-        rh_mock.get_task.assert_called_once_with('t.1')
-
-    def test_cancel_task_forwards_to_target_endpoint(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        plugin._endpoint_mode_tasks['t.1'] = 'endpoint_r'
-        rh_mock = MagicMock()
-        rh_mock.cancel_task.return_value = {'uid': 't.1', 'state': 'CANCELED'}
-        with patch.object(plugin, '_get_rhapsody_client',
-                          return_value=rh_mock):
-            r = client.post(f'{plugin.namespace}/cancel/{sid}/t.1')
-        assert r.status_code == 200, r.text
-        rh_mock.cancel_task.assert_called_once_with('t.1')
-
-    def test_stage_in_rejects_endpoint_mode_task(self, tmp_path: Path):
-        app, plugin = _make_plugin(tmp_path)
-        client = TestClient(app)
-        sid = _register_session(client, plugin)
-        plugin._endpoint_mode_tasks['t.1'] = 'endpoint_r'
-        r = client.post(
-            f'{plugin.namespace}/stage_in/{sid}/t.1',
-            json={'pool': 'cpu', 'filename': 'x.txt',
-                  'content_b64': base64.b64encode(b'hi').decode('ascii')})
-        assert r.status_code == 400
-        assert 'endpoint-mode' in r.text
-
-    def test_terminal_clears_endpoint_mode_mapping(self, tmp_path: Path):
-        '''Terminal notification removes the mapping and re-emits status.'''
+    def test_endpoint_without_rhapsody_503(self, tmp_path):
         _, plugin = _make_plugin(tmp_path)
-        plugin._endpoint_mode_tasks['t.1'] = 'endpoint_r'
-        notified: list = []
-        plugin._dispatch_notify = lambda topic, data: notified.append(
-            (topic, data))   # type: ignore[method-assign]
-        plugin._handle_task_terminal(
-            't.1', TASK_DONE, {'exit_code': 0, 'error': None})
+        client = TestClient(plugin._app)
+        sid = _register(client, plugin, body={'sid': 'A',
+                                              'lifetime': 'persistent'})
+        self._seed_topology(plugin, {'ep': ['sysinfo']})
+        r = client.post(f'{plugin.namespace}/submit/{sid}', json={
+            'endpoint': 'ep', 'task_id': 't.1',
+            'cmd': ['/bin/echo'], 'cwd': '/tmp'})
+        assert r.status_code == 503
+
+    def test_proxy_submit_and_get_and_cancel(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        client = TestClient(plugin._app)
+        sid = _register(client, plugin, body={'sid': 'A',
+                                              'lifetime': 'persistent'})
+        self._seed_topology(plugin, {'ep': ['rhapsody']})
+        rh_mock = MagicMock()
+        rh_mock.submit_tasks = AsyncMock(return_value=[{'uid': 't.1',
+                                                        'state': 'NEW'}])
+        rh_mock.get_task    = AsyncMock(return_value={'uid': 't.1',
+                                                      'state': 'RUNNING'})
+        rh_mock.cancel_task = AsyncMock(return_value={'uid': 't.1',
+                                                      'state': 'CANCELED'})
+        with patch.object(plugin, '_get_rhapsody_client',
+                          new=AsyncMock(return_value=rh_mock)):
+            r = client.post(f'{plugin.namespace}/submit/{sid}', json={
+                'endpoint': 'ep', 'task_id': 't.1',
+                'cmd': ['/bin/sleep', '0'], 'cwd': '/tmp'})
+            assert r.status_code == 200, r.text
+            assert plugin._endpoint_mode_tasks.get('t.1') == 'ep'
+            rh_mock.submit_tasks.assert_awaited_once()
+
+            r = client.get(f'{plugin.namespace}/task/{sid}/t.1')
+            assert r.json()['result']['state'] == 'RUNNING'
+
+            r = client.post(f'{plugin.namespace}/cancel/{sid}/t.1')
+            assert r.status_code == 200
+            rh_mock.cancel_task.assert_awaited_once_with('t.1')
+
+    def test_terminal_event_clears_endpoint_mode(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        plugin._endpoint_mode_tasks['t.1'] = 'ep'
+        notified = []
+        plugin._dispatch_notify = lambda t, d: notified.append((t, d))
+        # Feed a rhapsody task_status event exactly as the broker tap delivers.
+        plugin._on_event({'plugin': 'rhapsody', 'topic': 'task_status',
+                          'data': {'uid': 't.1', 'state': 'DONE',
+                                   'exit_code': 0}})
         assert 't.1' not in plugin._endpoint_mode_tasks
-        assert len(notified) == 1
-        topic, data = notified[0]
-        assert topic == 'task_status'
-        assert data['task_id'] == 't.1'
-        assert data['endpoint']    == 'endpoint_r'
-        assert data['state']   == TASK_DONE
-        assert data['exit_code'] == 0
+        assert notified and notified[0][1]['state'] == TASK_DONE
+
+    def test_on_event_ignores_other_plugins(self, tmp_path):
+        _, plugin = _make_plugin(tmp_path)
+        called = []
+        plugin._handle_task_terminal = lambda *a: called.append(a)
+        plugin._on_event({'plugin': 'psij', 'topic': 'task_status',
+                          'data': {'uid': 'x', 'state': 'DONE'}})
+        assert called == []

--- a/tests/unittests/test_task_dispatcher_broker.py
+++ b/tests/unittests/test_task_dispatcher_broker.py
@@ -1,0 +1,204 @@
+"""Broker-integration tests for the task dispatcher (M7 transport port).
+
+Drives a **real** :class:`~radical.orbit.broker.Broker` (hosting the dispatcher)
+under uvicorn on an ephemeral port, plus a **real** ``EndpointRuntime`` child
+that serves a fake plugin route.  Exercises:
+
+- the in-process broker caller the dispatcher uses (``call_threadsafe`` → a real
+  child endpoint → response), end-to-end;
+- the dispatcher being wired with the broker caller + event tap on the host;
+- gateway HTTP → broker-hosted dispatcher round-trip (pre-flip item 1).
+
+No test sleeps for more than ~1 s; liveness/backoff knobs are injected tiny.
+"""
+
+import json
+import subprocess
+import threading
+import time
+
+import httpx
+import pytest
+
+from radical.orbit.plugin_base import Plugin
+
+
+# ---------------------------------------------------------------------------
+# TLS material
+# ---------------------------------------------------------------------------
+
+def _have_openssl() -> bool:
+    try:
+        subprocess.run(['openssl', 'version'], check=True, capture_output=True)
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+@pytest.fixture
+def self_signed(tmp_path):
+    if not _have_openssl():
+        pytest.skip("openssl not available")
+    import os
+    cert = tmp_path / 'cert.pem'
+    key  = tmp_path / 'key.pem'
+    subprocess.run(
+        ['openssl', 'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+         '-keyout', str(key), '-out', str(cert),
+         '-days', '1', '-subj', '/CN=localhost'],
+        check=True, capture_output=True)
+    os.chmod(key, 0o600)
+    return cert, key
+
+
+# ---------------------------------------------------------------------------
+# A tiny served plugin standing in for a pilot's rhapsody/psij
+# ---------------------------------------------------------------------------
+
+class _FakePilot(Plugin):
+    plugin_name = 'fake_pilot'
+    version     = '0.0.1'
+
+    def __init__(self, app):
+        super().__init__(app, 'fake_pilot')
+        self.add_route_get('ping', self._ping)
+
+    async def _ping(self, request):
+        return {'pong': True}
+
+
+# ---------------------------------------------------------------------------
+# Broker-under-uvicorn harness + runtime factory (mirrors test_gateway.py)
+# ---------------------------------------------------------------------------
+
+class _RunningBroker:
+    def __init__(self, broker):
+        import uvicorn
+        self.broker = broker
+        config = uvicorn.Config(
+            broker.app, host='127.0.0.1', port=0, log_level='error',
+            ws_ping_interval=20.0, ws_ping_timeout=20.0)
+        self._server = uvicorn.Server(config)
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
+
+    def start(self):
+        self._thread.start()
+        deadline = time.time() + 10.0
+        while time.time() < deadline:
+            if self._server.started and self._server.servers:
+                socks = self._server.servers[0].sockets
+                if socks:
+                    self.port = socks[0].getsockname()[1]
+                    return self
+            time.sleep(0.02)
+        raise RuntimeError("broker server did not start")
+
+    @property
+    def url(self):
+        return 'http://127.0.0.1:%d' % self.port
+
+    def stop(self):
+        self._server.should_exit = True
+        self._thread.join(timeout=10.0)
+
+
+@pytest.fixture
+def harness(self_signed, tmp_path, monkeypatch):
+    from radical.orbit import utils
+    monkeypatch.setattr(utils, 'URL_FILE',   tmp_path / 'bridge.url')
+    monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'bridge.token')
+    monkeypatch.delenv('RADICAL_ORBIT_BRIDGE_TOKEN', raising=False)
+    # Keep the dispatcher's durable store off $HOME.
+    monkeypatch.setattr(
+        'radical.orbit.plugin_task_dispatcher._DEFAULT_STATE_ROOT',
+        tmp_path / 'td_state')
+    monkeypatch.setattr(
+        'radical.orbit.plugin_task_dispatcher._DEFAULT_SCRATCH_ROOT',
+        tmp_path / 'td_scratch')
+    cert, key = self_signed
+
+    servers, runtimes = [], []
+
+    def make_broker(**kw):
+        from radical.orbit.broker import Broker
+        defaults = dict(cert=str(cert), key=str(key), no_auth=True, grace=2.0)
+        defaults.update(kw)
+        srv = _RunningBroker(Broker(**defaults)).start()
+        servers.append(srv)
+        return srv
+
+    def make_runtime(url, wait=True, **kw):
+        from radical.orbit.runtime import EndpointRuntime
+        defaults = dict(broker_url=url, token=None, ping_interval=1.0,
+                        ping_timeout=3.0, backoff_start=0.05, backoff_max=0.2)
+        defaults.update(kw)
+        rt = EndpointRuntime(**defaults)
+        runtimes.append(rt)
+        rt.start(wait=wait, timeout=10.0)
+        return rt
+
+    yield make_broker, make_runtime
+
+    for rt in runtimes:
+        try:    rt.stop()
+        except Exception:
+            pass
+    for srv in servers:
+        try:    srv.stop()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def _dispatcher(srv):
+    return srv.broker._host._plugins['task_dispatcher']
+
+
+def test_dispatcher_wired_with_caller_and_tap(harness):
+    make_broker, _ = harness
+    srv = make_broker(plugins='task_dispatcher')
+    td = _dispatcher(srv)
+    # The dispatcher is broker-hosted and reaches endpoints via the broker
+    # caller; the raw event tap is wired for child task events.
+    assert td._broker_caller is srv.broker.caller
+    assert td._broker_tap is not None
+
+
+def test_dispatcher_calls_child_via_caller(harness):
+    """End-to-end: the dispatcher's own caller reaches a real child endpoint."""
+    make_broker, make_runtime = harness
+    srv = make_broker(plugins='task_dispatcher')
+    make_runtime(srv.url, name='ep', plugins=['fake_pilot'])
+
+    td   = _dispatcher(srv)
+    # Drive the exact seam the dispatcher's `_call` uses (call_threadsafe →
+    # routing loop → child endpoint → response), from this thread.
+    fut  = td._broker_caller.call_threadsafe('ep', 'GET', '/fake_pilot/ping',
+                                             timeout=10.0)
+    resp = fut.result(timeout=10.0)
+    assert int(resp['status']) == 200
+    body = resp['body']
+    if isinstance(body, str):
+        body = body.encode()
+    assert json.loads(body)['pong'] is True
+
+
+def test_gateway_http_to_hosted_dispatcher(harness):
+    """Gateway HTTP → broker-hosted dispatcher route (pre-flip item 1)."""
+    make_broker, _ = harness
+    srv = make_broker(plugins='task_dispatcher')
+    with httpx.Client(timeout=10.0) as c:
+        r = c.get('%s/broker/task_dispatcher/pools' % srv.url)
+    assert r.status_code == 200, r.text
+    assert r.json()['pools'] == {}     # no sessions/pools declared yet
+
+
+def test_gateway_unknown_hosted_route_404(harness):
+    make_broker, _ = harness
+    srv = make_broker(plugins='task_dispatcher')
+    with httpx.Client(timeout=10.0) as c:
+        r = c.get('%s/broker/task_dispatcher/nope' % srv.url)
+    assert r.status_code == 404

--- a/tests/unittests/test_task_dispatcher_recovery.py
+++ b/tests/unittests/test_task_dispatcher_recovery.py
@@ -1,16 +1,13 @@
-"""Recovery / lifecycle tests for plugin_task_dispatcher.
+"""Recovery / lifecycle tests for plugin_task_dispatcher (broker-hosted).
 
-Covers the paths that previously had no coverage (and were buggy):
-
-- C2  pilot child-endpoint disconnect → DONE/FAILED, capacity reclaimed,
-      tasks re-enqueued; plus the restart race where a replayed-ACTIVE
-      pilot must NOT be torn down before its child reconnects.
-- C4  restart correlation: ``_uid_to_task`` rebuilt from the replayed
-      task log; endpoint-mode lendpointr replayed (terminal entries filtered).
-- C5  a late terminal event for a re-enqueued task's stale uid is
-      ignored rather than clobbering the task.
-- H2  guard: no test reintroduces the loop-state-fragile
-      ``get_event_loop().run_until_complete`` antipattern.
+- C2  pilot child-endpoint liveness → DONE/FAILED on ``lost``, capacity
+      reclaimed, tasks re-enqueued; suspect blip does not tear down; a child
+      never seen ``present`` (post-restart) is never demoted.
+- C4  restart correlation: pools + ``_uid_to_task`` rebuilt from the sid-scoped
+      durable store; endpoint-mode ledger replayed (terminal entries filtered).
+- C5  a late terminal event for a re-enqueued task's stale uid is ignored.
+- C6  endpoint-mode ledger self-prunes via snapshot.
+- H2  guard against the loop-state-fragile ``run_until_complete`` antipattern.
 """
 
 import asyncio
@@ -28,11 +25,10 @@ from radical.orbit.task_dispatcher_state import (
 )
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+_SID = 'sessA'
 
-def _pool_cfg(name: str = 'cpu') -> PoolConfig:
+
+def _pool_cfg(name='cpu'):
     return PoolConfig(
         name         = name,
         endpoint_name    = 'endpoint0',
@@ -47,85 +43,87 @@ def _pool_cfg(name: str = 'cpu') -> PoolConfig:
     )
 
 
-def _make_plugin(tmp_path: Path, *, with_pool: bool = True):
+def _make_plugin(tmp_path: Path, *, with_pool=True):
     app = FastAPI()
     app.state.endpoint_name  = 'endpoint0'
-    app.state.bridge_url = 'https://localhost:9999'
+    app.state.bridge_url     = 'https://localhost:9999'
+    app.state.broker_caller  = None
+    app.state.broker_tap     = None
     plugin = PluginTaskDispatcher(
         app, state_root=tmp_path / 'state', scratch_root=tmp_path / 'scratch')
     if with_pool:
-        plugin._materialise_pool(_pool_cfg())
+        plugin._materialise_pool(_SID, _pool_cfg())
     return plugin
+
+
+def _pool(plugin, name='cpu'):
+    return plugin._pool_states[_SID][name]
 
 
 def _active_pilot(plugin, *, pid='p.1', child='endpoint0_p.1',
                   walltime_deadline=0.0):
-    ps = plugin._pool_states['cpu']
+    ps = _pool(plugin)
     pilot = PilotRecord(
-        pid=pid, pool='cpu', size_key='s', rhapsody_backend='concurrent',
-        state=PILOT_ACTIVE, submitted_at=100.0, active_at=110.0,
-        capacity=4, in_flight=1, child_endpoint_name=child,
-        walltime_deadline=walltime_deadline)
+        pid=pid, pool='cpu', owning_sid=_SID, size_key='s',
+        rhapsody_backend='concurrent', state=PILOT_ACTIVE,
+        submitted_at=100.0, active_at=110.0, capacity=4, in_flight=1,
+        child_endpoint_name=child, walltime_deadline=walltime_deadline)
     ps.pilots[pid] = pilot
     return ps, pilot
 
 
-def _topology(plugin, endpoints_present):
-    payload = {e: {'plugins': ['rhapsody']} for e in endpoints_present}
-    asyncio.run(plugin.on_topology_change(payload))
+def _topo(plugin, name, liveness):
+    asyncio.run(plugin.on_topology_change(
+        {name: {'role': 'endpoint',
+                'plugins': {'rhapsody': {'namespace': '/rhapsody'}},
+                'liveness': liveness}}))
 
 
 # ---------------------------------------------------------------------------
-# C2 — phantom-pilot recovery on disconnect
+# C2 — pilot child liveness
 # ---------------------------------------------------------------------------
 
 class TestPhantomPilotRecovery:
 
-    def test_disconnect_after_walltime_marks_done(self, tmp_path: Path):
+    def test_lost_after_walltime_marks_done(self, tmp_path):
         plugin = _make_plugin(tmp_path)
         plugin._loops_started = True
         ps, pilot = _active_pilot(plugin, walltime_deadline=time.time() - 1)
-        task = TaskRecord(task_id='t.1', pool='cpu', cmd=['/bin/echo'],
-                          cwd=str(tmp_path), state=TASK_RUNNING,
-                          pilot_id='p.1')
-        ps.tasks['t.1'] = task
-
-        _topology(plugin, ['endpoint0_p.1'])   # child seen
-        _topology(plugin, [])              # child gone, walltime passed
-
+        ps.tasks['t.1'] = TaskRecord(task_id='t.1', pool='cpu', owning_sid=_SID,
+                                     cmd=['/bin/echo'], cwd=str(tmp_path),
+                                     state=TASK_RUNNING, pilot_id='p.1')
+        _topo(plugin, 'endpoint0_p.1', 'present')
+        _topo(plugin, 'endpoint0_p.1', 'lost')
         assert pilot.state == PILOT_DONE
-        assert ps.tasks['t.1'].state == TASK_QUEUED   # re-enqueued
+        assert ps.tasks['t.1'].state == TASK_QUEUED
         assert ps.tasks['t.1'].pilot_id is None
-        assert ps._pilots_snapshot() == []            # capacity reclaimed
+        assert ps._pilots_snapshot() == []
 
-    def test_disconnect_before_walltime_marks_failed(self, tmp_path: Path):
+    def test_lost_before_walltime_marks_failed(self, tmp_path):
         plugin = _make_plugin(tmp_path)
         plugin._loops_started = True
-        ps, pilot = _active_pilot(plugin,
-                                  walltime_deadline=time.time() + 1000)
-        _topology(plugin, ['endpoint0_p.1'])
-        _topology(plugin, [])
-
+        ps, pilot = _active_pilot(plugin, walltime_deadline=time.time() + 1000)
+        _topo(plugin, 'endpoint0_p.1', 'present')
+        _topo(plugin, 'endpoint0_p.1', 'lost')
         assert pilot.state == PILOT_FAILED
         assert ps._pilots_snapshot() == []
 
-    def test_replayed_active_not_demoted_before_child_seen(self, tmp_path):
-        """Restart race: an ACTIVE pilot whose child hasn't reconnected
-        yet must survive a topology event that doesn't list it."""
+    def test_suspect_blip_does_not_demote(self, tmp_path):
         plugin = _make_plugin(tmp_path)
         plugin._loops_started = True
-        _, pilot = _active_pilot(plugin,
-                                 walltime_deadline=time.time() + 1000)
-        # Never feed a topology event containing the child → never "seen".
-        _topology(plugin, ['some_other_endpoint'])
-        assert pilot.state == PILOT_ACTIVE   # untouched
+        _, pilot = _active_pilot(plugin, walltime_deadline=time.time() + 1000)
+        _topo(plugin, 'endpoint0_p.1', 'present')
+        _topo(plugin, 'endpoint0_p.1', 'suspect')
+        assert pilot.state == PILOT_ACTIVE
+        assert pilot.accepting_new_tasks is False
 
-    def test_disconnect_unseen_child_is_noop(self, tmp_path: Path):
+    def test_unseen_child_never_demoted(self, tmp_path):
+        """Restart race: an ACTIVE pilot whose child never appears 'present'
+        (never synthesized 'lost') survives — no `_seen` heuristic needed."""
         plugin = _make_plugin(tmp_path)
         plugin._loops_started = True
-        _, pilot = _active_pilot(plugin,
-                                 walltime_deadline=time.time() + 1000)
-        _topology(plugin, [])   # child never seen → no demotion
+        _, pilot = _active_pilot(plugin, walltime_deadline=time.time() + 1000)
+        _topo(plugin, 'some_other_endpoint', 'present')
         assert pilot.state == PILOT_ACTIVE
 
 
@@ -135,39 +133,37 @@ class TestPhantomPilotRecovery:
 
 class TestRestartCorrelation:
 
-    def test_uid_to_task_rebuilt_on_materialise(self, tmp_path: Path):
+    def test_pool_and_uid_map_rebuilt(self, tmp_path):
         plugin = _make_plugin(tmp_path)
-        ps = plugin._pool_states['cpu']
-        rec = TaskRecord(task_id='t.x', pool='cpu', cmd=['/bin/echo'],
-                         cwd=str(tmp_path), state=TASK_RUNNING,
-                         pilot_id='p.1', rhapsody_uid='rh.1')
+        ps = _pool(plugin)
+        rec = TaskRecord(task_id='t.x', pool='cpu', owning_sid=_SID,
+                         cmd=['/bin/echo'], cwd=str(tmp_path),
+                         state=TASK_RUNNING, pilot_id='p.1', rhapsody_uid='rh.1')
         ps.tasks['t.x'] = rec
         ps.task_log.append(rec)
 
-        # Simulate a bridge restart: a fresh plugin over the same state.
-        plugin2 = _make_plugin(tmp_path)
-        ps2 = plugin2._pool_states['cpu']
+        plugin2 = _make_plugin(tmp_path, with_pool=False)   # fresh; replay only
+        assert _SID in plugin2._pool_states
+        ps2 = _pool(plugin2)
         assert ps2.tasks['t.x'].state == TASK_RUNNING
-        assert plugin2._uid_to_task.get('rh.1') == ('cpu', 't.x')
+        assert plugin2._uid_to_task.get('rh.1') == (_SID, 'cpu', 't.x')
 
-    def test_endpoint_mode_lendpointr_replayed(self, tmp_path: Path):
+    def test_endpoint_mode_ledger_replayed(self, tmp_path):
         plugin = _make_plugin(tmp_path, with_pool=False)
         plugin._endpoint_mode_log.append(
             EndpointModeRecord(task_id='t.e', endpoint='gpuendpoint',
-                           state=TASK_RUNNING))
-
+                               state=TASK_RUNNING))
         plugin2 = _make_plugin(tmp_path, with_pool=False)
         assert plugin2._endpoint_mode_tasks.get('t.e') == 'gpuendpoint'
 
-    def test_endpoint_mode_terminal_filtered_on_replay(self, tmp_path: Path):
+    def test_endpoint_mode_terminal_filtered(self, tmp_path):
         plugin = _make_plugin(tmp_path, with_pool=False)
         plugin._endpoint_mode_log.append(
             EndpointModeRecord(task_id='t.e', endpoint='gpuendpoint',
-                           state=TASK_RUNNING))
+                               state=TASK_RUNNING))
         plugin._endpoint_mode_log.append(
             EndpointModeRecord(task_id='t.e', endpoint='gpuendpoint',
-                           state=TASK_DONE))
-
+                               state=TASK_DONE))
         plugin2 = _make_plugin(tmp_path, with_pool=False)
         assert 't.e' not in plugin2._endpoint_mode_tasks
 
@@ -180,50 +176,44 @@ class TestStaleUid:
 
     def test_late_terminal_for_reenqueued_task_ignored(self, tmp_path):
         plugin = _make_plugin(tmp_path)
-        ps = plugin._pool_states['cpu']
-        pilot = PilotRecord(pid='p.1', pool='cpu', size_key='s',
-                            rhapsody_backend='concurrent',
-                            state=PILOT_ACTIVE, capacity=2, in_flight=1)
+        ps = _pool(plugin)
+        pilot = PilotRecord(pid='p.1', pool='cpu', owning_sid=_SID, size_key='s',
+                            rhapsody_backend='concurrent', state=PILOT_ACTIVE,
+                            capacity=2, in_flight=1)
         ps.pilots['p.1'] = pilot
-        task = TaskRecord(task_id='t.r', pool='cpu', cmd=['/bin/echo'],
-                          cwd=str(tmp_path), state=TASK_RUNNING,
-                          pilot_id='p.1', rhapsody_uid='rh.old')
+        task = TaskRecord(task_id='t.r', pool='cpu', owning_sid=_SID,
+                          cmd=['/bin/echo'], cwd=str(tmp_path),
+                          state=TASK_RUNNING, pilot_id='p.1', rhapsody_uid='rh.old')
         ps.tasks['t.r'] = task
-        plugin._uid_to_task['rh.old'] = ('cpu', 't.r')
+        plugin._uid_to_task['rh.old'] = (_SID, 'cpu', 't.r')
 
         plugin._mark_pilot_failed(ps, pilot, 'lost')
         assert task.state == TASK_QUEUED
-        assert 'rh.old' not in plugin._uid_to_task   # mapping cleared
+        assert 'rh.old' not in plugin._uid_to_task
 
-        # A late terminal event for the dead pilot's old uid arrives.
         plugin._handle_task_terminal('rh.old', TASK_DONE, {})
-        assert task.state == TASK_QUEUED   # not clobbered
+        assert task.state == TASK_QUEUED    # not clobbered
 
 
 # ---------------------------------------------------------------------------
-# C6 — endpoint-mode lendpointr self-prunes via snapshot
+# C6 — endpoint-mode ledger self-prunes via snapshot
 # ---------------------------------------------------------------------------
 
 class TestEndpointModeCompaction:
 
-    def test_snapshot_drops_terminal_entries(self, tmp_path: Path):
+    def test_snapshot_drops_terminal_entries(self, tmp_path):
         plugin = _make_plugin(tmp_path, with_pool=False)
         log = plugin._endpoint_mode_log
-        # one live, one already-terminal
         plugin._endpoint_mode_tasks['t.live'] = 'e1'
         log.append(EndpointModeRecord(task_id='t.live', endpoint='e1',
-                                  state=TASK_RUNNING))
+                                      state=TASK_RUNNING))
         log.append(EndpointModeRecord(task_id='t.gone', endpoint='e2',
-                                  state=TASK_DONE))
-
-        # Snapshot the live set only (what the compaction sweeper does).
-        live = {tid: EndpointModeRecord(task_id=tid, endpoint=endpoint,
-                                    state=TASK_RUNNING)
-                for tid, endpoint in plugin._endpoint_mode_tasks.items()}
+                                      state=TASK_DONE))
+        live = {tid: EndpointModeRecord(task_id=tid, endpoint=ep,
+                                        state=TASK_RUNNING)
+                for tid, ep in plugin._endpoint_mode_tasks.items()}
         log.snapshot(live)
-
-        replayed = log.replay()
-        assert set(replayed.keys()) == {'t.live'}
+        assert set(log.replay().keys()) == {'t.live'}
 
 
 # ---------------------------------------------------------------------------
@@ -231,16 +221,8 @@ class TestEndpointModeCompaction:
 # ---------------------------------------------------------------------------
 
 def test_no_get_event_loop_run_until_complete_in_tests():
-    """``get_event_loop().run_until_complete`` breaks once any earlier
-    test calls ``asyncio.run`` (which nulls the loop on 3.11+).  Keep the
-    suite order-independent by forbidding the pattern outright."""
     here = Path(__file__).parent
-    pattern = 'get_event_loop().run_' + 'until_complete'  # avoid self-match
-    offenders = []
-    for path in here.glob('test_*.py'):
-        if path.name == Path(__file__).name:
-            continue
-        if pattern in path.read_text():
-            offenders.append(path.name)
-    assert not offenders, \
-        f"use asyncio.run instead of get_event_loop(): {offenders}"
+    pattern = 'get_event_loop().run_' + 'until_complete'
+    offenders = [p.name for p in here.glob('test_*.py')
+                 if p.name != Path(__file__).name and pattern in p.read_text()]
+    assert not offenders, f"use asyncio.run instead: {offenders}"


### PR DESCRIPTION
Seventh milestone of `plans/broker_architecture_plan.md` (M7 — dispatcher port, de-risked by M0), stacked on #69.

## What

**Transport port** — the dispatcher is a broker-hosted plugin on the host loop, reaching endpoints through the M0-validated in-process caller:
- Deleted: `_start_bridge_client`, `_wait_for_bc` (10 s spin-wait), the SSE thread, `_seen_child_endpoints`, all **16 `to_thread` wrappers** (each wrapped a BridgeClient HTTP call; grep-verified none remain).
- Endpoint calls: `BrokerCaller.call_threadsafe → asyncio.wrap_future` on the host loop, via minimal async psij/rhapsody proxies preserving the exact wire shapes (the sync `PluginClient` helpers would block the host loop — judgment call, flagged).
- Task events: consumed from the broker raw tap, firing on the host loop (no cross-thread marshalling).
- Child liveness: rich `on_topology_change` — `suspect` pauses scheduling, `lost` demotes + re-enqueues; the broker now delivers topology to hosted plugins with the synthesized post-grace `lost` (mirrors the runtime's served-plugin delivery).
- `bridge_url` survives **only** as the spawned child's dial-in URL (children genuinely need it).

**Strict per-session pools** (the Pre-M0 user decision):
- Keyed `(owning_sid, pool_name)`; cross-session attach impossible by construction; `_pool_configs_compatible` + attach-or-409 **deleted, not ported**.
- Store re-keyed with `owning_sid`, sid-scoped layout (`<state_root>/<sid>/<pool>__<endpoint>/` + `pool.json` declarations); **restart-time replay built** (startup scan rebuilds all sids' pools/pilots; the old lazy re-declare recovery is gone). Owner reconciliation rides M1 create-or-reconnect + M6 owner check.
- **Session-close teardown added** (previously absent): fires from `unregister_session`, ttl expiry, and the M6 reclaim-drain. Ephemeral owner `lost` → drain → pilots cancelled; a suspect blip never reclaims (tested); persistent/`default` pools live until the new explicit `cancel_all` route.

**Pre-flip item 1 closed**: gateway catch-all routes the broker's own name into the new `Broker.call_host()` (extracted from `_dispatch_to_host`) — hosted plugins are HTTP-reachable through the gateway again (end-to-end tested).

Framework seam changes, all flagged: `bridge_plugin_host.py` +9 (optional `broker_caller`/`broker_tap` params → `app.state`; `None` under old-stack construction, the dispatcher refuses cleanly), `broker.py` ~+90 (seam pass-through, `call_host`, host topology delivery), `gateway.py` +15.

## Testing

51 dispatcher tests (37 rewritten + 10 recovery + 4 broker-integration): same-named pools isolated across sessions, replay across multiple sids, teardown/drain/blip/cancel_all matrix, suspect/lost child handling, e2e over a real broker-hosted dispatcher + real `EndpointRuntime` child, gateway HTTP → dispatcher round-trip, clean refusal without the caller seam.

Full suite: **900 passed, 2 skipped** (down from 916: superseded sharing/attach tests consolidated into stricter isolation tests — the sharing model is deleted by design); `flake8 src/ bin/` clean.

## Notes for review

- `_route_pools` (session-less monitoring) now groups by owning sid (`{pools: {sid: {...}}}`) — flat names collide under strict isolation.
- Cosmetic: host-shutdown can emit "Task was destroyed but it is pending" from dispatcher sweepers (broker doesn't call plugin shutdown; pre-existing pattern) — candidate for the final-flip cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)