### PR TITLE
M8: event-replay plugin — tap retention, cursor/ack pull replay, splice

### DIFF
--- a/src/radical/orbit/__init__.py
+++ b/src/radical/orbit/__init__.py
@@ -26,6 +26,7 @@ from .plugin_queue_info  import PluginQueueInfo   # noqa: F401
 from .plugin_sysinfo    import PluginSysInfo  # noqa: F401
 from .plugin_staging    import PluginStaging  # noqa: F401
 from .plugin_task_dispatcher import PluginTaskDispatcher  # noqa: F401
+from .plugin_replay      import PluginReplay  # noqa: F401
 
 # Optional plugins with external dependencies.
 try:

--- a/src/radical/orbit/plugin_replay.py
+++ b/src/radical/orbit/plugin_replay.py
@@ -1,0 +1,521 @@
+'''
+Event-replay plugin — the optional retaining subscriber for radical.orbit.
+
+The broker core is deliberately **stateless** about events: it stamps every
+``event`` frame with an authoritative ``seq``/``ts`` (monotone per session for
+session-scoped events, monotone per the global session-less stream otherwise),
+fans it out to live subscribers, and forgets it.  ``PluginReplay`` is the single
+component that *retains* the stream so a consumer that connected late — or
+dropped and reconnected — can pull what it missed.
+
+Because the wire already carries everything replay needs (``ts``/``seq`` are
+frozen with the envelope), this plugin needs **no protocol change**: it is a
+pure consumer of the broker's raw event tap (``app.state.broker_tap`` — see
+:mod:`radical.orbit.broker_events`), which delivers *every* event dict on the
+plugin-host loop, including events for endpoints that are not connected.  That
+is why replay must be **broker-hosted**: a retaining subscriber has to see the
+whole stream, not just its own endpoint's slice.
+
+Replay is **not** in the broker's default plugin set — the core stays stateless
+and this plugin is the one retaining subscriber, loaded per use case.  Operators
+add ``replay`` to the broker ``--plugins`` spec when a use case needs durable
+ephemeral-event delivery.
+
+Retention
+---------
+* **Session-scoped events** (``event['session']`` set): one bounded buffer per
+  session, capped by BOTH an age (``session_max_age``, default 600 s) and a
+  byte size (``session_max_bytes``, default 4 MB, measured as the msgpack size
+  of the event dict).  Per-session isolation means one chatty session cannot
+  evict another's history.
+* **Session-less events** (``event['session']`` is ``None``): one global ring
+  capped by total bytes (``global_max_bytes``, default 16 MB).
+
+Every eviction — age or size — increments the buffer's ``dropped`` counter, so
+a gap is *observable*: the ``stats`` route exposes retained count, byte size,
+dropped, and lowest/highest ``seq`` for the global ring and each per-session
+buffer.
+
+Delivery is **at-least-once on the wire with ``seq`` dedup at the consumer =
+effectively-once**: a per-consumer cursor advances only on ACK, so a drop
+mid-replay re-sends rather than loses, and the consumer discards duplicates by
+``seq``.
+'''
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+from collections import deque
+from typing      import Any, Callable, Dict, List, Optional
+
+import msgpack
+
+from fastapi import FastAPI, HTTPException, Request
+
+from .client               import PluginClient
+from .plugin_base          import Plugin
+from .plugin_session_base  import PluginSession
+
+log = logging.getLogger('radical.orbit')
+
+
+# ---------------------------------------------------------------------------
+# Defaults (class attributes on the plugin; injectable per instance for tests)
+# ---------------------------------------------------------------------------
+
+_SESSION_MAX_AGE   = 600.0              # per-session buffer age bound  (s)
+_SESSION_MAX_BYTES = 4  * 1024 * 1024   # per-session buffer size bound (bytes)
+_GLOBAL_MAX_BYTES  = 16 * 1024 * 1024   # global session-less ring bound (bytes)
+_CURSOR_TTL        = 3600.0             # cursor inactivity expiry (s)
+_FETCH_MAX_EVENTS  = 256                # default per-fetch event cap
+_FETCH_MAX_BYTES   = 1024 * 1024        # default per-fetch byte cap
+_SWEEP_INTERVAL    = 30.0              # background age/cursor sweep cadence (s)
+
+
+# ---------------------------------------------------------------------------
+# _RingBuffer — one bounded, drop-oldest retention buffer
+# ---------------------------------------------------------------------------
+
+class _RingBuffer:
+    '''A bounded, drop-oldest event buffer with a dropped-events counter.
+
+    Entries are ``(seq, ts, size, event)`` tuples held oldest-first.  A
+    per-session buffer sets ``max_age``; the global ring leaves it ``None``
+    (bytes-only).  Both enforce ``max_bytes``.  Every eviction bumps
+    :attr:`dropped` so a consumer can see the loss as a ``seq`` discontinuity.
+    '''
+
+    def __init__(self, max_bytes: int, max_age: Optional[float] = None) -> None:
+        self.max_bytes = max_bytes
+        self.max_age   = max_age
+        self.events: deque = deque()   # (seq, ts, size, event)
+        self.nbytes  = 0
+        self.dropped = 0
+
+    def append(self, seq: int, ts: float, size: int,
+               event: Dict[str, Any], now: float) -> None:
+        self.events.append((seq, ts, size, event))
+        self.nbytes += size
+        self._enforce(now)
+
+    def _drop_left(self) -> None:
+        _, _, size, _ = self.events.popleft()
+        self.nbytes  -= size
+        self.dropped += 1
+
+    def _enforce(self, now: float) -> None:
+        if self.max_age is not None:
+            while self.events and (now - self.events[0][1]) > self.max_age:
+                self._drop_left()
+        while self.nbytes > self.max_bytes and self.events:
+            self._drop_left()
+
+    def evict_aged(self, now: float) -> None:
+        '''Lazily drop age-expired entries (called on any access + by sweep).'''
+        if self.max_age is None:
+            return
+        while self.events and (now - self.events[0][1]) > self.max_age:
+            self._drop_left()
+
+    @property
+    def lowest_seq(self) -> Optional[int]:
+        return self.events[0][0] if self.events else None
+
+    @property
+    def highest_seq(self) -> Optional[int]:
+        return self.events[-1][0] if self.events else None
+
+    def stats(self) -> Dict[str, Any]:
+        return {
+            'retained'   : len(self.events),
+            'bytes'      : self.nbytes,
+            'dropped'    : self.dropped,
+            'lowest_seq' : self.lowest_seq,
+            'highest_seq': self.highest_seq,
+        }
+
+    def select(self, after_exclusive: int, patterns: List[dict],
+               max_events: int, max_bytes: int) -> List[Dict[str, Any]]:
+        '''Return matching events with ``seq > after_exclusive``, oldest-first.
+
+        Bounded by *max_events* / *max_bytes*, but always returns at least the
+        first matching event so a single oversized event can never stall the
+        cursor.
+        '''
+        out: List[Dict[str, Any]] = []
+        nbytes = 0
+        for seq, _ts, size, event in self.events:
+            if seq <= after_exclusive:
+                continue
+            if not _event_matches(patterns, event):
+                continue
+            if out and (len(out) >= max_events or nbytes + size > max_bytes):
+                break
+            out.append(event)
+            nbytes += size
+        return out
+
+
+# ---------------------------------------------------------------------------
+# _Cursor — per-consumer replay position
+# ---------------------------------------------------------------------------
+
+class _Cursor:
+    '''A consumer's replay position: the highest ``seq`` it has ACKed.
+
+    Keyed by a client-chosen ``cursor_id``.  A *stable* consumer name makes
+    reconnect-resume work — the same cursor_id picks up exactly where the
+    consumer left off — mirroring the stable-endpoint-name reattach story.
+    The position advances only on ACK; it starts at ``-1`` so a fresh cursor
+    (no ``after_seq``) replays the whole retained buffer.
+    '''
+
+    __slots__ = ('position', 'last_access')
+
+    def __init__(self, position: int, last_access: float) -> None:
+        self.position    = position
+        self.last_access = last_access
+
+
+# ---------------------------------------------------------------------------
+# pattern matching — same None-wildcard semantics as protocol.SubscribePattern
+# ---------------------------------------------------------------------------
+
+def _event_matches(patterns: List[dict], event: Dict[str, Any]) -> bool:
+    '''True if *event* matches any of *patterns* (empty/None -> match all).
+
+    A pattern is ``{endpoint?, plugin?, topic?}``; a ``None``/absent field is a
+    wildcard.  ``endpoint`` matches the event's broker-stamped ``src``.  This is
+    the same OR-of-patterns, AND-of-fields rule the broker's subscription
+    registry and the client callback registry use.
+    '''
+    if not patterns:
+        return True
+    src   = event.get('src')
+    plug  = event.get('plugin')
+    topic = event.get('topic')
+    for p in patterns:
+        if p.get('endpoint') is not None and p['endpoint'] != src:
+            continue
+        if p.get('plugin')   is not None and p['plugin']   != plug:
+            continue
+        if p.get('topic')    is not None and p['topic']    != topic:
+            continue
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+class ReplayClient(PluginClient):
+    '''Consumer-side helper for the event-replay plugin (session-less).
+
+    Replay→live splice
+    ------------------
+    To receive every event across a late join or reconnect **exactly once**,
+    the consumer splices replay into live delivery:
+
+    1. Register the live callback **first**
+       (``runtime.register_callback(endpoint=..., plugin=..., topic=...)``), so
+       no live event is missed while replay drains.
+    2. Drain ``replay_iter(cursor_id, patterns=..., session=...)``, feeding each
+       replayed event through the same handler as the live callback.
+    3. **Dedup by ``seq``.**  Replayed events carry ``event['seq']``; keep a set
+       of seen ``seq`` (per stream) and skip any already seen.
+
+    Because live delivery starts *before* replay finishes, the two streams
+    overlap around the join point; the ``seq`` dedup discards the duplicates, so
+    the handler observes each event once — at-least-once on the wire + ``seq``
+    dedup = effectively-once.  A ``fetch`` reporting ``gap=True`` means retained
+    events were evicted before the cursor reached them: the consumer re-syncs
+    state (topology + state-mirroring recover on reconnect regardless) instead
+    of trusting continuity.
+
+    A stable ``cursor_id`` (a consumer name) makes reconnect-resume work: the
+    cursor picks up where the last ACK left off.
+    '''
+
+    def register_session(self, **_kwargs: Any) -> None:
+        '''No-op: the replay routes are all session-less.'''
+        return
+
+    def fetch(self, cursor_id: str, patterns: Optional[list] = None,
+              session: Optional[str] = None, after_seq: Optional[int] = None,
+              ack_seq: Optional[int] = None,
+              max_events: Optional[int] = None) -> dict:
+        '''Pull one batch of retained events for *cursor_id*.
+
+        *ack_seq*, when given, advances the stored cursor to that ``seq``
+        **before** the next batch is selected (a batch fetched without an ACK is
+        re-delivered on the next fetch — the at-least-once property).  *session*
+        selects the per-session buffer (``None`` = the global ring).  *patterns*
+        filters with the same None-wildcard semantics as a subscribe pattern.
+
+        Returns ``{events, next_seq, gap}``.
+        '''
+        body: dict = {'cursor_id': cursor_id}
+        if patterns   is not None: body['patterns']   = patterns
+        if session    is not None: body['session']    = session
+        if after_seq  is not None: body['after_seq']  = after_seq
+        if ack_seq    is not None: body['ack_seq']    = ack_seq
+        if max_events is not None: body['max_events'] = max_events
+        resp = self._http.post(self._url('fetch'), json=body)
+        self._raise(resp, 'fetch')
+        return resp.json()
+
+    def drop_cursor(self, cursor_id: str) -> dict:
+        '''Forget a cursor's stored position (cleanup).'''
+        resp = self._http.post(self._url('drop_cursor'),
+                               json={'cursor_id': cursor_id})
+        self._raise(resp, 'drop_cursor')
+        return resp.json()
+
+    def stats(self) -> dict:
+        '''Buffer stats: global ring + per-session (session-less route).'''
+        resp = self._http.get(self._url('stats'))
+        self._raise(resp, 'stats')
+        return resp.json()
+
+    def replay_iter(self, cursor_id: str, patterns: Optional[list] = None,
+                    session: Optional[str] = None,
+                    after_seq: Optional[int] = None,
+                    max_events: Optional[int] = None):
+        '''Generator that drains replay: fetch, yield each event, ACK, repeat.
+
+        Fetches a batch, yields its events, ACKs it (so the cursor advances),
+        and stops when a batch comes back empty.  This is the drain step of the
+        splice recipe (see the class docstring): register the live callback
+        first, then drive this generator, deduping by ``seq``.
+        '''
+        ack: Optional[int] = None
+        first = True
+        while True:
+            resp = self.fetch(cursor_id, patterns=patterns, session=session,
+                              after_seq=(after_seq if first else None),
+                              ack_seq=ack, max_events=max_events)
+            first  = False
+            events = resp.get('events') or []
+            if not events:
+                break
+            for event in events:
+                yield event
+            ack = resp['next_seq']
+
+
+# ---------------------------------------------------------------------------
+# Plugin
+# ---------------------------------------------------------------------------
+
+class PluginReplay(Plugin):
+    '''Broker-hosted event-replay plugin (the single retaining subscriber).
+
+    Subscribes to the broker's raw event tap at load time (retention starts
+    immediately, not on first request) and serves pull-based replay with
+    per-consumer cursors.  Loaded per use case via the broker ``--plugins``
+    spec — it is **not** in the default set.
+    '''
+
+    plugin_name   = 'replay'
+    session_class = PluginSession
+    client_class  = ReplayClient
+    version       = '0.0.1'
+
+    # Retention / cursor tunables — injectable per instance for tests (mirrors
+    # the session_ttl / reclaim_drain precedent).
+    session_max_age   = _SESSION_MAX_AGE
+    session_max_bytes = _SESSION_MAX_BYTES
+    global_max_bytes  = _GLOBAL_MAX_BYTES
+    cursor_ttl        = _CURSOR_TTL
+    default_max_events = _FETCH_MAX_EVENTS
+    default_max_bytes  = _FETCH_MAX_BYTES
+    sweep_interval    = _SWEEP_INTERVAL
+
+    ui_config = {
+        'icon'       : '🎞️',
+        'title'      : 'Event Replay',
+        'description': 'Retains the broker event stream for replay to '
+                       'late/reconnecting consumers.',
+    }
+
+    @classmethod
+    def is_enabled(cls, app: FastAPI) -> bool:
+        '''Broker hosts only, and only when the raw event tap is wired.
+
+        A retaining subscriber must see the whole event stream, which only the
+        broker's tap provides — so replay is disabled off the broker and
+        disabled when the tap is absent (e.g. a host with no ``broker_tap``).
+        '''
+        from .utils import host_role
+        if host_role(app)['role'] != 'bridge':
+            return False
+        return getattr(app.state, 'broker_tap', None) is not None
+
+    def __init__(self, app: FastAPI, instance_name: str = 'replay') -> None:
+        super().__init__(app, instance_name)
+
+        self._now: Callable[[], float] = time.time
+
+        # Global ring (session-less broadcasts) + per-session buffers.
+        self._global = _RingBuffer(self.global_max_bytes)
+        self._session_buffers: Dict[str, _RingBuffer] = {}
+
+        # Per-consumer cursors, keyed by client-chosen cursor_id.
+        self._cursors: Dict[str, _Cursor] = {}
+
+        # Subscribe to the raw event tap NOW so retention starts at load time
+        # (a late consumer must find events already buffered).  Absent (None)
+        # off the broker — is_enabled keeps us from loading there anyway.
+        self._broker_tap = getattr(app.state, 'broker_tap', None)
+        self._untap: Optional[Callable[[], None]] = None
+        if self._broker_tap is not None:
+            self._untap = self._broker_tap(self._on_event)
+
+        # Background age/cursor sweeper — started only when a loop is already
+        # running (the broker constructs hosted plugins on the running host
+        # loop).  Tests without a loop drive _evict/_prune_cursors directly.
+        self._sweeper: Optional[asyncio.Task] = None
+        self._maybe_start_sweeper()
+
+        self.add_route_post('fetch',       self._route_fetch)
+        self.add_route_post('drop_cursor', self._route_drop_cursor)
+        self.add_route_get ('stats',       self._route_stats)
+
+    # -- retention (raw-tap consumer; runs on the plugin-host loop) --------
+
+    def _on_event(self, event: Dict[str, Any]) -> None:
+        '''Retain one broker event (fed by the raw tap on the host loop).
+
+        Session-scoped events go to a per-session buffer (age+size bounded);
+        session-less events go to the global ring (bytes bounded).  The size
+        measure is the msgpack-encoded size of the event dict.
+        '''
+        if event.get('kind') != 'event':
+            return
+        seq = event.get('seq')
+        if seq is None:
+            return
+        now = self._now()
+        ts  = event.get('ts') or now
+        try:
+            size = len(msgpack.packb(event, use_bin_type=True))
+        except Exception:
+            size = 0
+
+        session = event.get('session')
+        if session:
+            buf = self._session_buffers.get(session)
+            if buf is None:
+                buf = _RingBuffer(self.session_max_bytes, self.session_max_age)
+                self._session_buffers[session] = buf
+        else:
+            buf = self._global
+        buf.append(int(seq), float(ts), size, event, now)
+
+    # -- housekeeping (injectable timers; sweep + lazy on access) ----------
+
+    def _evict_aged(self, now: float) -> None:
+        self._global.evict_aged(now)
+        for buf in list(self._session_buffers.values()):
+            buf.evict_aged(now)
+
+    def _prune_cursors(self, now: float) -> int:
+        '''Drop cursors idle longer than ``cursor_ttl``.  Returns the count.'''
+        stale = [cid for cid, cur in self._cursors.items()
+                 if now - cur.last_access > self.cursor_ttl]
+        for cid in stale:
+            self._cursors.pop(cid, None)
+        return len(stale)
+
+    def _maybe_start_sweeper(self) -> None:
+        if self._sweeper is not None:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        self._sweeper = loop.create_task(self._sweep_loop())
+
+    async def _sweep_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self.sweep_interval)
+                now = self._now()
+                self._evict_aged(now)
+                self._prune_cursors(now)
+            except asyncio.CancelledError:
+                return
+            except Exception as e:
+                log.exception('[%s] replay sweeper error: %s',
+                              self.instance_name, e)
+
+    # -- routes ------------------------------------------------------------
+
+    async def _route_fetch(self, request: Request) -> dict:
+        '''Pull a batch for a cursor; ACK-advance first, then select.
+
+        Body: ``{cursor_id, patterns?, session?, after_seq?, ack_seq?,
+        max_events?, max_bytes?}``.  Returns ``{events, next_seq, gap}`` where
+        ``gap`` is true when the cursor position has fallen below the buffer's
+        lowest retained ``seq`` (events were evicted — re-sync, don't trust
+        continuity).
+        '''
+        body = await request.json()
+        cursor_id = body.get('cursor_id')
+        if not cursor_id:
+            raise HTTPException(status_code=400,
+                                detail="fetch requires 'cursor_id'")
+
+        patterns   = body.get('patterns') or []
+        session    = body.get('session')
+        after_seq  = body.get('after_seq')
+        ack_seq    = body.get('ack_seq')
+        max_events = int(body.get('max_events') or self.default_max_events)
+        max_bytes  = int(body.get('max_bytes')  or self.default_max_bytes)
+
+        now = self._now()
+        cur = self._cursors.get(cursor_id)
+        if cur is None:
+            cur = _Cursor(position=-1, last_access=now)
+            self._cursors[cursor_id] = cur
+        cur.last_access = now
+
+        # ACK advances the persistent cursor FIRST — a batch fetched without an
+        # ACK is therefore re-delivered on the next fetch (at-least-once).
+        if ack_seq is not None:
+            cur.position = max(cur.position, int(ack_seq))
+
+        lower = int(after_seq) if after_seq is not None else cur.position
+
+        buf = (self._global if session is None
+               else self._session_buffers.get(session))
+        if buf is None:
+            return {'events': [], 'next_seq': lower, 'gap': False}
+        buf.evict_aged(now)
+
+        events   = buf.select(lower, patterns, max_events, max_bytes)
+        lowest   = buf.lowest_seq
+        gap      = lowest is not None and lowest > lower + 1
+        next_seq = events[-1]['seq'] if events else lower
+        return {'events': events, 'next_seq': next_seq, 'gap': gap}
+
+    async def _route_drop_cursor(self, request: Request) -> dict:
+        body = await request.json()
+        cursor_id = body.get('cursor_id')
+        existed = self._cursors.pop(cursor_id, None) is not None
+        return {'dropped': existed}
+
+    async def _route_stats(self, request: Request) -> dict:
+        now = self._now()
+        self._evict_aged(now)
+        sessions = {sid: buf.stats()
+                    for sid, buf in self._session_buffers.items()}
+        return {
+            'global'  : self._global.stats(),
+            'sessions': sessions,
+            'cursors' : len(self._cursors),
+        }

--- a/tests/unittests/test_plugin_replay.py
+++ b/tests/unittests/test_plugin_replay.py
@@ -1,0 +1,584 @@
+"""Unit + broker-integration tests for the event-replay plugin (M8).
+
+The in-process tests drive :class:`~radical.orbit.plugin_replay.PluginReplay`
+directly: they feed event dicts through the raw-tap consumer (``_on_event``) and
+call the route handlers with a :class:`~radical.orbit.dispatch.RequestShim`, the
+same in-process pattern ``test_task_dispatcher_broker.py`` uses.  Timers are
+injected (a fake clock + direct ``_prune_cursors`` / ``_evict_aged`` calls), so
+no test sleeps for age/cursor expiry.
+
+The e2e test drives a **real** :class:`~radical.orbit.broker.Broker` hosting
+``replay`` plus a **real** ``EndpointRuntime`` emitting events, and a second
+runtime that connects late, registers a live callback, and drains
+``replay_iter`` — exercising the replay→live splice with ``seq`` dedup.
+"""
+
+import asyncio
+import json
+import subprocess
+import threading
+import time
+
+import pytest
+
+from fastapi import FastAPI
+
+from radical.orbit.dispatch      import RequestShim
+from radical.orbit.plugin_base   import Plugin
+from radical.orbit.plugin_replay import (PluginReplay, ReplayClient,
+                                         _event_matches, _RingBuffer)
+
+
+# ---------------------------------------------------------------------------
+# in-process helpers
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    """Run a coroutine on a fresh loop (route handlers are stateless per call)."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _shim(body):
+    return RequestShim({}, {}, json.dumps(body).encode())
+
+
+def _make_plugin(**attrs):
+    """A PluginReplay on a fresh app with a capturing fake tap."""
+    taps = []
+    app = FastAPI()
+    app.state.is_bridge   = True
+    app.state.broker_tap  = lambda cb: (taps.append(cb)
+                                        or (lambda: taps.remove(cb)))
+    p = PluginReplay(app, 'replay')
+    for k, v in attrs.items():
+        setattr(p, k, v)
+    p._taps = taps
+    return p
+
+
+def _ev(seq, session=None, topic='t', src='ep', plugin='rh', ts=None,
+        data=None):
+    # Default to a fresh timestamp so session buffers (age-bounded) don't
+    # age-evict under the real clock; age tests pass an explicit ts + fake now.
+    return {'kind': 'event', 'seq': seq, 'session': session, 'plugin': plugin,
+            'topic': topic, 'src': src,
+            'ts': time.time() if ts is None else ts, 'data': data or {}}
+
+
+class _InProcHTTP:
+    """Minimal httpx-shaped adapter routing a ReplayClient onto plugin routes."""
+
+    def __init__(self, plugin):
+        self._p = plugin
+
+    def post(self, url, json=None, **kw):
+        body = json or {}
+        if   url.endswith('/fetch'):        data = _run(self._p._route_fetch(_shim(body)))
+        elif url.endswith('/drop_cursor'):  data = _run(self._p._route_drop_cursor(_shim(body)))
+        else:                               raise AssertionError(url)
+        return _Resp(data)
+
+    def get(self, url, **kw):
+        if url.endswith('/stats'):          data = _run(self._p._route_stats(_shim({})))
+        else:                               raise AssertionError(url)
+        return _Resp(data)
+
+
+class _Resp:
+    def __init__(self, data):
+        self._d          = data
+        self.status_code = 200
+        self.is_error    = False
+
+    def json(self):
+        return self._d
+
+    @property
+    def text(self):
+        return json.dumps(self._d)
+
+
+def _client(plugin):
+    return ReplayClient(_InProcHTTP(plugin), '/replay',
+                        endpoint_id='broker', plugin_name='replay')
+
+
+# ---------------------------------------------------------------------------
+# retention: session vs global split
+# ---------------------------------------------------------------------------
+
+def test_retention_session_vs_global_split():
+    p = _make_plugin()
+    for i in range(3):
+        p._on_event(_ev(i))                       # session-less -> global ring
+    p._on_event(_ev(0, session='s1'))
+    p._on_event(_ev(1, session='s1'))
+    p._on_event(_ev(0, session='s2'))
+
+    assert p._global.stats()['retained'] == 3
+    assert p._session_buffers['s1'].stats()['retained'] == 2
+    assert p._session_buffers['s2'].stats()['retained'] == 1
+    # session buffers are isolated: s2 is not in s1's bookkeeping.
+    assert set(p._session_buffers) == {'s1', 's2'}
+
+
+def test_non_event_and_seqless_ignored():
+    p = _make_plugin()
+    p._on_event({'kind': 'topology', 'seq': 0})   # not an event
+    p._on_event({'kind': 'event'})                # no seq
+    assert p._global.stats()['retained'] == 0
+
+
+# ---------------------------------------------------------------------------
+# age eviction (fake clock) + dropped counter + stats shape
+# ---------------------------------------------------------------------------
+
+def test_age_eviction_and_dropped_counter():
+    clock = {'t': 1000.0}
+    p = _make_plugin(session_max_age=600.0, session_max_bytes=10 ** 9)
+    p._now = lambda: clock['t']
+
+    p._on_event(_ev(0, session='s', ts=1000.0))
+    p._on_event(_ev(1, session='s', ts=1000.0))
+    assert p._session_buffers['s'].stats()['retained'] == 2
+
+    # jump past the age bound and force a lazy sweep
+    clock['t'] = 1000.0 + 601.0
+    p._evict_aged(clock['t'])
+    st = p._session_buffers['s'].stats()
+    assert st['retained'] == 0
+    assert st['dropped']  == 2
+
+
+def test_stats_shape():
+    p = _make_plugin()
+    p._on_event(_ev(5))
+    p._on_event(_ev(7))
+    p._on_event(_ev(0, session='s'))
+    st = _run(p._route_stats(_shim({})))
+    assert set(st) == {'global', 'sessions', 'cursors'}
+    g = st['global']
+    assert set(g) == {'retained', 'bytes', 'dropped', 'lowest_seq',
+                      'highest_seq'}
+    assert g['lowest_seq'] == 5 and g['highest_seq'] == 7
+    assert g['retained'] == 2 and g['bytes'] > 0
+    assert st['sessions']['s']['retained'] == 1
+
+
+# ---------------------------------------------------------------------------
+# size eviction + dropped counter
+# ---------------------------------------------------------------------------
+
+def test_size_eviction_global_ring():
+    p = _make_plugin()
+    one = len(__import__('msgpack').packb(_ev(0), use_bin_type=True))
+    p.global_max_bytes = one * 2 + 1      # rebind after construction
+    p._global = _RingBuffer(p.global_max_bytes)   # honour the new bound
+    for i in range(5):
+        p._on_event(_ev(i))
+    st = p._global.stats()
+    assert st['retained'] == 2            # only the last two fit
+    assert st['dropped']  == 3
+    assert st['lowest_seq'] == 3 and st['highest_seq'] == 4
+
+
+def test_size_eviction_per_session_isolated():
+    p = _make_plugin(session_max_age=10 ** 9, session_max_bytes=len(
+        __import__('msgpack').packb(_ev(0, session='s1'), use_bin_type=True)
+        ) * 2 + 1)
+    for i in range(4):
+        p._on_event(_ev(i, session='s1'))
+    for i in range(1):
+        p._on_event(_ev(i, session='s2'))
+    # s1 is chatty and self-evicts; s2 keeps its single event untouched.
+    assert p._session_buffers['s1'].stats()['dropped']  == 2
+    assert p._session_buffers['s1'].stats()['retained'] == 2
+    assert p._session_buffers['s2'].stats()['dropped']  == 0
+    assert p._session_buffers['s2'].stats()['retained'] == 1
+
+
+# ---------------------------------------------------------------------------
+# pattern filtering incl. wildcards
+# ---------------------------------------------------------------------------
+
+def test_event_matches_wildcards():
+    ev = _ev(0, src='epA', plugin='psij', topic='job_status')
+    assert _event_matches([], ev) is True                       # match-all
+    assert _event_matches([{}], ev) is True                     # all-wildcard
+    assert _event_matches([{'endpoint': 'epA'}], ev) is True
+    assert _event_matches([{'endpoint': 'epB'}], ev) is False
+    assert _event_matches([{'plugin': 'psij', 'topic': 'job_status'}], ev)
+    assert _event_matches([{'topic': 'other'}], ev) is False
+    # OR across patterns
+    assert _event_matches([{'endpoint': 'epB'}, {'plugin': 'psij'}], ev)
+
+
+def test_fetch_pattern_filter():
+    p = _make_plugin()
+    p._on_event(_ev(0, plugin='psij', topic='job_status'))
+    p._on_event(_ev(1, plugin='rhapsody', topic='task_status'))
+    p._on_event(_ev(2, plugin='psij', topic='job_status'))
+    r = _run(p._route_fetch(_shim(
+        {'cursor_id': 'c', 'patterns': [{'plugin': 'psij'}]})))
+    assert [e['seq'] for e in r['events']] == [0, 2]
+
+
+# ---------------------------------------------------------------------------
+# fetch/ack cursor advance + at-least-once (unacked re-delivery)
+# ---------------------------------------------------------------------------
+
+def test_fetch_ack_cursor_advance_and_redelivery():
+    p = _make_plugin()
+    for i in range(3):
+        p._on_event(_ev(i))
+
+    a = _run(p._route_fetch(_shim({'cursor_id': 'c'})))
+    assert [e['seq'] for e in a['events']] == [0, 1, 2]
+    assert a['next_seq'] == 2 and a['gap'] is False
+
+    # A second fetch WITHOUT ack re-delivers the same batch (at-least-once).
+    b = _run(p._route_fetch(_shim({'cursor_id': 'c'})))
+    assert [e['seq'] for e in b['events']] == [0, 1, 2]
+
+    # ACK advances the cursor; the next fetch returns only newer events.
+    c = _run(p._route_fetch(_shim({'cursor_id': 'c', 'ack_seq': 2})))
+    assert c['events'] == [] and c['next_seq'] == 2
+
+    p._on_event(_ev(3))
+    d = _run(p._route_fetch(_shim({'cursor_id': 'c', 'ack_seq': 2})))
+    assert [e['seq'] for e in d['events']] == [3]
+
+
+def test_max_events_batches():
+    p = _make_plugin()
+    for i in range(5):
+        p._on_event(_ev(i))
+    r = _run(p._route_fetch(_shim({'cursor_id': 'c', 'max_events': 2})))
+    assert [e['seq'] for e in r['events']] == [0, 1]
+    assert r['next_seq'] == 1
+
+
+# ---------------------------------------------------------------------------
+# seq dedup end-to-end across a simulated drop mid-drain (replay_iter)
+# ---------------------------------------------------------------------------
+
+def test_replay_iter_seq_dedup_across_drop():
+    p = _make_plugin()
+    for i in range(5):
+        p._on_event(_ev(i))
+    cl = _client(p)
+
+    # First drain aborts after two events WITHOUT ever acking (a mid-drain
+    # drop): replay_iter acks a batch only on its *next* fetch, which never
+    # runs once we break.
+    partial = []
+    for ev in cl.replay_iter('cur', max_events=2):
+        partial.append(ev['seq'])
+        if len(partial) == 2:
+            break
+    assert partial == [0, 1]
+
+    # Fresh drain with the same cursor_id: the unacked prefix is re-delivered
+    # (at-least-once); the consumer dedups by seq.
+    seen = {}
+    for ev in cl.replay_iter('cur', max_events=2):
+        seen[ev['seq']] = seen.get(ev['seq'], 0) + 1
+
+    # every event delivered at least once; dedup yields each exactly once
+    assert set(seen) == {0, 1, 2, 3, 4}
+    # the re-delivery actually happened (0/1 came back after the drop)
+    assert seen[0] == 1 and seen[1] == 1        # within the second drain
+    # across BOTH drains 0 and 1 were delivered twice total → dedup earns keep
+    total_deliveries = len(partial) + sum(seen.values())
+    assert total_deliveries == 2 + 5            # 2 dropped + 5 clean
+
+
+# ---------------------------------------------------------------------------
+# gap detection after eviction
+# ---------------------------------------------------------------------------
+
+def test_gap_true_after_eviction():
+    # keep a bound that holds ~2 events so early ones evict but some remain
+    two = len(__import__('msgpack').packb(_ev(0, session='s'),
+                                          use_bin_type=True)) * 2 + 1
+    p = _make_plugin(session_max_age=10 ** 9, session_max_bytes=two)
+    for i in range(5):
+        p._on_event(_ev(i, session='s'))
+    buf = p._session_buffers['s']
+    assert buf.lowest_seq == 3 and buf.stats()['dropped'] == 3
+
+    # a fresh cursor (position -1) sits below the lowest retained seq -> gap
+    r = _run(p._route_fetch(_shim({'cursor_id': 'c', 'session': 's'})))
+    assert r['gap'] is True
+    assert [e['seq'] for e in r['events']] == [3, 4]
+
+    # a cursor that only wants seq > 4 sees no gap
+    r2 = _run(p._route_fetch(_shim(
+        {'cursor_id': 'c2', 'session': 's', 'after_seq': 4})))
+    assert r2['gap'] is False and r2['events'] == []
+
+
+def test_no_gap_on_contiguous_stream():
+    p = _make_plugin()
+    for i in range(3):
+        p._on_event(_ev(i))
+    r = _run(p._route_fetch(_shim({'cursor_id': 'c'})))
+    assert r['gap'] is False
+
+
+# ---------------------------------------------------------------------------
+# cursor expiry + drop_cursor
+# ---------------------------------------------------------------------------
+
+def test_cursor_expiry_by_inactivity():
+    clock = {'t': 1000.0}
+    p = _make_plugin(cursor_ttl=100.0)
+    p._now = lambda: clock['t']
+
+    _run(p._route_fetch(_shim({'cursor_id': 'c'})))
+    assert 'c' in p._cursors
+
+    clock['t'] = 1000.0 + 101.0
+    assert p._prune_cursors(clock['t']) == 1
+    assert 'c' not in p._cursors
+
+
+def test_drop_cursor():
+    p = _make_plugin()
+    _run(p._route_fetch(_shim({'cursor_id': 'c'})))
+    r = _run(p._route_drop_cursor(_shim({'cursor_id': 'c'})))
+    assert r['dropped'] is True
+    assert 'c' not in p._cursors
+    r2 = _run(p._route_drop_cursor(_shim({'cursor_id': 'nope'})))
+    assert r2['dropped'] is False
+
+
+def test_fetch_requires_cursor_id():
+    from fastapi import HTTPException
+    p = _make_plugin()
+    with pytest.raises(HTTPException) as ei:
+        _run(p._route_fetch(_shim({})))
+    assert ei.value.status_code == 400
+
+
+def test_fetch_unknown_session_empty_no_gap():
+    p = _make_plugin()
+    r = _run(p._route_fetch(_shim({'cursor_id': 'c', 'session': 'ghost'})))
+    assert r['events'] == [] and r['gap'] is False
+
+
+# ---------------------------------------------------------------------------
+# is_enabled gating
+# ---------------------------------------------------------------------------
+
+def test_is_enabled_requires_broker_and_tap():
+    app = FastAPI()
+    app.state.is_bridge  = True
+    app.state.broker_tap = lambda cb: (lambda: None)
+    assert PluginReplay.is_enabled(app) is True
+
+    # broker host but no tap -> disabled
+    app2 = FastAPI()
+    app2.state.is_bridge = True
+    assert PluginReplay.is_enabled(app2) is False
+
+    # not a broker host -> disabled even if a tap were present
+    app3 = FastAPI()
+    app3.state.broker_tap = lambda cb: (lambda: None)
+    assert PluginReplay.is_enabled(app3) is False
+
+
+def test_not_in_default_plugin_set():
+    # Documented: replay is opt-in via --plugins, never auto-loaded.  The
+    # 'default' special token must not expand to include it.
+    from radical.orbit.plugin_host_base import _expand_special_tokens
+    app = FastAPI()
+    app.state.is_bridge = True
+    available = Plugin.get_plugin_names()
+    assert 'replay' in available
+    expanded = _expand_special_tokens(['default'], app, available)
+    assert 'replay' not in expanded
+
+
+# ===========================================================================
+# e2e: real broker hosting replay + real runtimes (late consumer + splice)
+# ===========================================================================
+
+def _have_openssl():
+    try:
+        subprocess.run(['openssl', 'version'], check=True, capture_output=True)
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+class _ReplayEmit(Plugin):
+    """A served plugin that emits N session-less events per burst call."""
+
+    plugin_name = 'replay_emit'
+    version     = '0.0.1'
+
+    def __init__(self, app):
+        super().__init__(app, 'replay_emit')
+        self.add_route_get('burst/{n}/{base}', self._burst)
+
+    async def _burst(self, request):
+        n    = int(request.path_params['n'])
+        base = int(request.path_params['base'])
+        for i in range(n):
+            await self.send_notification('tick', {'n': base + i})
+        return {'sent': n}
+
+
+class _RunningBroker:
+    def __init__(self, broker):
+        import uvicorn
+        self.broker = broker
+        config = uvicorn.Config(
+            broker.app, host='127.0.0.1', port=0, log_level='error',
+            ws_ping_interval=20.0, ws_ping_timeout=20.0)
+        self._server = uvicorn.Server(config)
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
+
+    def start(self):
+        self._thread.start()
+        deadline = time.time() + 10.0
+        while time.time() < deadline:
+            if self._server.started and self._server.servers:
+                socks = self._server.servers[0].sockets
+                if socks:
+                    self.port = socks[0].getsockname()[1]
+                    return self
+            time.sleep(0.02)
+        raise RuntimeError("broker server did not start")
+
+    @property
+    def url(self):
+        return 'http://127.0.0.1:%d' % self.port
+
+    def stop(self):
+        self._server.should_exit = True
+        self._thread.join(timeout=10.0)
+
+
+@pytest.fixture
+def harness(tmp_path, monkeypatch):
+    if not _have_openssl():
+        pytest.skip("openssl not available")
+    import os
+    from radical.orbit import utils
+    monkeypatch.setattr(utils, 'URL_FILE',   tmp_path / 'bridge.url')
+    monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'bridge.token')
+    monkeypatch.delenv('RADICAL_ORBIT_BRIDGE_TOKEN', raising=False)
+    cert = tmp_path / 'cert.pem'
+    key  = tmp_path / 'key.pem'
+    subprocess.run(
+        ['openssl', 'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+         '-keyout', str(key), '-out', str(cert),
+         '-days', '1', '-subj', '/CN=localhost'],
+        check=True, capture_output=True)
+    os.chmod(key, 0o600)
+
+    servers, runtimes = [], []
+
+    def make_broker(**kw):
+        from radical.orbit.broker import Broker
+        defaults = dict(cert=str(cert), key=str(key), no_auth=True, grace=2.0)
+        defaults.update(kw)
+        srv = _RunningBroker(Broker(**defaults)).start()
+        servers.append(srv)
+        return srv
+
+    def make_runtime(url, wait=True, **kw):
+        from radical.orbit.runtime import EndpointRuntime
+        defaults = dict(broker_url=url, token=None, ping_interval=1.0,
+                        ping_timeout=3.0, backoff_start=0.05, backoff_max=0.2)
+        defaults.update(kw)
+        rt = EndpointRuntime(**defaults)
+        runtimes.append(rt)
+        rt.start(wait=wait, timeout=10.0)
+        return rt
+
+    yield make_broker, make_runtime
+
+    for rt in runtimes:
+        try:    rt.stop()
+        except Exception:
+            pass
+    for srv in servers:
+        try:    srv.stop()
+        except Exception:
+            pass
+
+
+def _wait(cond, timeout=8.0, interval=0.02):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if cond():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def test_e2e_late_consumer_replays_with_splice(harness):
+    import httpx
+
+    make_broker, make_runtime = harness
+    srv = make_broker(plugins='replay')
+
+    replay = srv.broker._host._plugins['replay']
+    assert replay is not None
+
+    # emitter endpoint emits 5 events BEFORE any consumer exists
+    make_runtime(srv.url, name='epA', plugins=['replay_emit'])
+    assert _wait(lambda: 'epA' in srv.broker.registry)
+    r = httpx.get('%s/epA/replay_emit/burst/5/0' % srv.url, timeout=10.0)
+    assert r.status_code == 200, r.text
+    assert _wait(lambda: replay._global.stats()['retained'] >= 5)
+
+    # a consumer connects LATE (missed all 5 live)
+    consumer = make_runtime(srv.url, name='cons', plugins=[])
+    assert _wait(lambda: 'broker' in consumer.topology()
+                 and 'replay' in consumer.topology()['broker'].get('plugins', {}))
+
+    # 1) register the LIVE callback first, keyed by the app-level id in data
+    lock = threading.Lock()
+    live_ns = []
+
+    def on_live(endpoint, plugin, topic, data):
+        with lock:
+            live_ns.append(data['n'])
+
+    consumer.register_callback(endpoint_id='epA', plugin_name='replay_emit',
+                               callback=on_live)
+    time.sleep(0.3)                                   # let subscribe land
+
+    # 2) emit 2 MORE events — these arrive LIVE at the consumer AND land in the
+    #    replay buffer (the overlap window of the splice)
+    httpx.get('%s/epA/replay_emit/burst/2/5' % srv.url, timeout=10.0)
+    assert _wait(lambda: set(live_ns) >= {5, 6})
+
+    # 3) drain replay and merge; dedup across live + replay by the event key
+    rc = consumer.get_plugin('broker', 'replay')
+    replayed_ns  = []
+    replayed_seq = []
+    for ev in rc.replay_iter('cons-cursor',
+                             patterns=[{'endpoint': 'epA'}]):
+        replayed_ns.append(ev['data']['n'])
+        replayed_seq.append(ev['seq'])
+
+    # replay covers the whole stream (0..6), each seq exactly once
+    assert replayed_seq == sorted(set(replayed_seq))
+    assert set(replayed_ns) == set(range(7))
+
+    # the splice: live delivered 5 & 6, replay ALSO delivered them → overlap.
+    # After dedup by the per-event key the consumer holds each event once.
+    with lock:
+        all_deliveries = list(live_ns) + replayed_ns
+    deduped = set(all_deliveries)
+    assert deduped == set(range(7))                  # exactly-once after dedup
+    assert len(all_deliveries) > len(deduped)        # overlap actually occurred


### PR DESCRIPTION
Eighth milestone of `plans/broker_architecture_plan.md` (M8 — optional event-replay plugin), stacked on #73. No wire/protocol change — the broker-stamped `ts`/`seq` frozen at M2 carry everything replay needs, which was the design's point.

## What

`PluginReplay` — broker-hosted, **opt-in** (`--plugins replay`; not in the default set; `is_enabled` requires the broker role *and* a wired raw event tap). Core stays stateless; this is the single retaining subscriber the plan describes.

- **Retention** (fed by the raw tap from plugin load, so late consumers find events already buffered): per-session buffers bounded by **age (600 s) and size (4 MB)** — one chatty session can't evict another — plus a **16 MB global ring** for session-less events; every eviction increments a dropped counter; session-less `stats` route exposes retained/bytes/dropped/seq-range per buffer. All tunables are injectable class attributes.
- **Replay**: pull-based `fetch` with client-named cursors that advance **only on ack** — an un-acked batch is re-delivered on the next fetch (**at-least-once**), the client dedups by `seq` (**effectively-once**). `gap=true` when eviction outran the cursor: re-sync, don't trust continuity. Cursor expiry + `drop_cursor` cleanup. Oversized single events can't stall a batch (always returns ≥1 match).
- **Splice** (documented recipe in `ReplayClient`): register the live callback first, drain `replay_iter` (fetch → yield → ack), dedup across the overlap. A stable `cursor_id` makes reconnect-resume work — mirroring the stable-endpoint-name reattach story.

## Flagged for review

The runtime's live-callback API delivers `(endpoint, plugin, topic, data)` — no `seq` — so the live+replay overlap in practice dedups on an application-level event key; pure-replay re-delivery dedups on `seq` literally. Honest consequence of "no wire change"; surfacing `seq` to live callbacks would be a small, additive runtime enhancement if wanted later.

Also: an entirely-evicted buffer reports `events=[], gap=false` (gap is defined against the lowest *retained* seq); consumers distinguish "caught up" from "everything gone" via `stats`.

## Testing

20 new tests: retention split/eviction/isolation/counters (fake clock, no long sleeps), pattern wildcards, ack semantics + un-acked re-delivery, seq dedup across a simulated mid-drain drop, gap detection, cursor expiry, gating, not-in-default-set, and a real-broker e2e — late consumer + live/replay overlap → each event exactly once.

Full suite: **861 passed, 2 skipped**; `flake8 src/ bin/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)