### PR TITLE
Fix #43: unregistering an edge keeps the name reserved

### DIFF
--- a/src/radical/orbit/bridge.py
+++ b/src/radical/orbit/bridge.py
@@ -740,6 +740,20 @@ class Bridge:
             except Exception as e:
                 log.warning("[Bridge] Error shutting down endpoint %s: %s",
                             endpoint_name, e)
+
+            # Free the name synchronously (issue #43): closing the socket above
+            # only schedules the register handler's disconnect cleanup, which
+            # races a re-registration under the same name (rejected as "already
+            # used").  Drop it from both maps here so the name is immediately
+            # available; the register handler's ``endpoint_ws.get(name) == ws``
+            # guard then makes its own cleanup a no-op.
+            if self_.endpoint_ws.get(endpoint_name) == ws:
+                del self_.endpoint_ws[endpoint_name]
+                if endpoint_name in self_.endpoints["endpoints"]:
+                    del self_.endpoints["endpoints"][endpoint_name]
+                    await self_._broadcast_event("topology", self_.endpoints)
+                    await self_._broadcast_topology_to_endpoints()
+
             return JSONResponse({"status": "shutdown", "endpoint": endpoint_name})
 
         @app.post("/bridge/terminate", tags=["Management"])

--- a/tests/unittests/test_bridge.py
+++ b/tests/unittests/test_bridge.py
@@ -226,6 +226,30 @@ def test_disconnect_removes_endpoint_from_both_maps(make_bridge):
     json.dumps(bridge.endpoints)
 
 
+def test_management_disconnect_frees_name_immediately(make_bridge):
+    """The ``/endpoint/disconnect/{name}`` management route must free the name
+    synchronously so a re-registration is not rejected as "already used"
+    while the socket-close cleanup is still pending (issue #43)."""
+    bridge = make_bridge()
+    client = TestClient(bridge.app)
+
+    with client.websocket_connect("/register") as ws:
+        _register(ws)
+        assert _wait_until(lambda: _registered(bridge))
+        assert "thinkie" in bridge.endpoint_ws
+
+        resp = client.post("/endpoint/disconnect/thinkie")
+        assert resp.status_code == 200
+
+        # Freed by the route itself — no waiting on the async socket cleanup.
+        assert "thinkie" not in bridge.endpoint_ws
+        assert "thinkie" not in bridge.endpoints["endpoints"]
+
+    # Unknown / already-freed name -> 404, not a lingering reservation.
+    resp = client.post("/endpoint/disconnect/thinkie")
+    assert resp.status_code == 404
+
+
 # ---------------------------------------------------------------------------
 # _strip_headers — bridge credential must not leak to endpoint plugins
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
After disconnecting an endpoint via `POST /endpoint/disconnect/{name}`, the name stays reserved: the route closes the socket but delegates the `endpoint_ws`/topology cleanup to the register handler's async disconnect path, which races a re-registration under the same name — rejected as "already used".

## Fix
Free the name synchronously in the route: drop it from `endpoint_ws` and the topology dict (and broadcast the change) right after closing the socket. The register handler's `endpoint_ws.get(name) == ws` guard makes its own later cleanup a harmless no-op.

## Test
`test_management_disconnect_frees_name_immediately`: register over the WS, call the disconnect route, and assert the name is gone from both maps immediately (no waiting on the socket cleanup); a second disconnect returns 404.

Local: `test_bridge.py` 8 passed; flake8 clean.

Fixes #43