### PR TITLE
Fix #42: edge accepts an unauthorized bridge certificate

### DIFF
--- a/src/radical/orbit/service.py
+++ b/src/radical/orbit/service.py
@@ -448,6 +448,27 @@ class EndpointService(PluginHostBase):
             return 'relax'
         return 'abort'
 
+    @staticmethod
+    def _build_ssl_context(cert: Optional[str],
+                           check_hostname: bool) -> ssl.SSLContext:
+        """Build the TLS context for the outbound WSS connection to the bridge.
+
+        When a bridge certificate is pinned (``--cert``), trust **only** that
+        certificate — pass it as the sole ``cafile`` so the system CA store is
+        *not* loaded (issue #42).  Otherwise a bridge presenting any cert that
+        chains to a system-trusted CA, or a different self-signed cert
+        generated on the same host, would be accepted in place of the
+        configured one, defeating ``CERT_REQUIRED``.  Without a pinned cert we
+        fall back to the system store (standard public-CA trust).
+        """
+        if cert and os.path.exists(cert):
+            ctx = ssl.create_default_context(cafile=cert)
+        else:
+            ctx = ssl.create_default_context()
+        ctx.check_hostname = check_hostname
+        ctx.verify_mode    = ssl.CERT_REQUIRED
+        return ctx
+
     async def run(self) -> None:
         """
         Main async entry point.
@@ -500,15 +521,12 @@ class EndpointService(PluginHostBase):
                 if not ws_url.endswith("/register"):
                     ws_url += "/register"
 
-                # Determine if we need SSL
+                # Determine if we need SSL.  The context trusts ONLY the
+                # pinned bridge cert (issue #42) — see _build_ssl_context.
                 ssl_ctx = None
                 if ws_url.startswith("wss://"):
-                    ssl_ctx = ssl.create_default_context()
-                    ssl_ctx.check_hostname = ssl_check_hostname
-                    ssl_ctx.verify_mode = ssl.CERT_REQUIRED
-                    # Cert path was already resolved + validated in __init__.
-                    if self._cert and os.path.exists(self._cert):
-                        ssl_ctx.load_verify_locations(self._cert)
+                    ssl_ctx = self._build_ssl_context(self._cert,
+                                                      ssl_check_hostname)
 
                 async with websockets.connect(ws_url,
                                               ssl=ssl_ctx,

--- a/tests/unittests/test_service_cert.py
+++ b/tests/unittests/test_service_cert.py
@@ -46,3 +46,60 @@ def test_other_cert_failures_always_abort():
 def test_empty_message_aborts():
     assert _classify("",   cert_pinned=True, check_hostname=True) == 'abort'
     assert _classify(None, cert_pinned=True, check_hostname=True) == 'abort'
+
+
+# ---------------------------------------------------------------------------
+# _build_ssl_context — the pinned bridge cert must be the ONLY trust root
+# (issue #42): the system CA store must not be loaded when a cert is pinned,
+# or a bridge presenting any other system-trusted / same-host cert would be
+# accepted in place of the configured one.
+# ---------------------------------------------------------------------------
+
+import ssl
+import subprocess
+
+import pytest
+
+
+def _have_openssl() -> bool:
+    try:
+        subprocess.run(['openssl', 'version'], check=True, capture_output=True)
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+def _gen_cert(tmp_path, name, cn) -> str:
+    cert = tmp_path / f'{name}.pem'
+    key  = tmp_path / f'{name}.key'
+    subprocess.run(
+        ['openssl', 'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+         '-keyout', str(key), '-out', str(cert),
+         '-days', '1', '-subj', f'/CN={cn}'],
+        check=True, capture_output=True,
+    )
+    return str(cert)
+
+
+def test_build_ssl_context_pins_only_configured_cert(tmp_path):
+    if not _have_openssl():
+        pytest.skip("openssl not available")
+    cert_a = _gen_cert(tmp_path, 'bridge_a', 'bridgeA')
+
+    ctx = EndpointService._build_ssl_context(cert_a, check_hostname=False)
+
+    cas = ctx.get_ca_certs()
+    # Exactly one trusted CA — the pinned cert — NOT the system store.
+    assert len(cas) == 1, \
+        "pinned context must not also trust the system CA store (issue #42)"
+    subject = dict(x[0] for x in cas[0]['subject'])
+    assert subject.get('commonName') == 'bridgeA'
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.check_hostname is False
+
+
+def test_build_ssl_context_no_pinned_cert_uses_system_store():
+    ctx = EndpointService._build_ssl_context(None, check_hostname=True)
+    # With no pinned cert we fall back to the system CA store (many roots).
+    assert len(ctx.get_ca_certs()) > 1
+    assert ctx.verify_mode == ssl.CERT_REQUIRED


### PR DESCRIPTION
## Problem (security)
The edge built its outbound-WSS TLS trust with `ssl.create_default_context()` — which loads the **system CA store** — and then merely *added* the pinned bridge cert via `load_verify_locations()`. Under `CERT_REQUIRED` the peer was accepted if it presented the pinned cert **or any cert chaining to a system-trusted CA** (or a different self-signed cert generated on the same host). So an edge configured for bridge cert A still connected to a bridge presenting a different cert B. This also invalidated the assumption `_classify_cert_error` documents ("CERT_REQUIRED guarantees the peer presents exactly that certificate").

## Fix
Pin trust to the configured certificate only: build the context with `ssl.create_default_context(cafile=cert)`, which trusts that cert as the sole root and does **not** load the system store. Falls back to the system store only when no cert is pinned. Extracted as `EndpointService._build_ssl_context(cert, check_hostname)` for testability.

## Test
- `test_build_ssl_context_pins_only_configured_cert`: with a pinned cert, `ctx.get_ca_certs()` has exactly one entry (the configured cert), `verify_mode == CERT_REQUIRED` — the pre-fix code trusted the whole system store + the pin.
- `test_build_ssl_context_no_pinned_cert_uses_system_store`: no cert → system store loaded.

Local: `test_service_cert.py` 7 passed; flake8 clean.

Fixes #42