### PR TITLE
Docs: IRI plugin reference + machine setup guide (#70, #71)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,6 +40,8 @@ Contents:
    plugin_development.rst
    plugin_api.rst
    plugin_globus.rst
+   plugin_iri.rst
+   machine_guide.rst
    rest_api.rst
 
 

--- a/docs/source/machine_guide.rst
+++ b/docs/source/machine_guide.rst
@@ -1,0 +1,120 @@
+
+.. _machine_guide:
+
+###################
+Machine setup guide
+###################
+
+ORBIT reaches an HPC facility through **three complementary access paths**,
+each provided by a plugin.  A given workflow may use one or several:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 40 30
+
+   * - Path
+     - What it does
+     - Plugin
+   * - **PsiJ**
+     - Submit and monitor *batch jobs* on the machine, through an ORBIT edge
+       running on that machine's login/compute node.
+     - :ref:`psij <rest_api>`
+   * - **IRI**
+     - Drive the facility's *IRI REST API* (resources, jobs, incidents,
+       allocations) — no edge on the machine required.
+     - :ref:`iri <plugin_iri>`
+   * - **Globus**
+     - Move *data* between facility collections, out of band.
+     - :ref:`globus <plugin_globus>`
+
+This guide shows how to set each one up, then gives per-facility notes.
+
+
+PsiJ — batch jobs via an edge
+=============================
+
+1. Start the bridge somewhere reachable from the machine (see the
+   *Getting Started* guide), and copy its URL (and, for HTTPS, its
+   certificate and auth token) to the machine.
+2. On the machine's login node, start an edge::
+
+      radical-orbit-endpoint --url https://<bridge-host>:8000 \
+                             --cert bridge_cert.pem
+
+   The edge auto-detects the batch system (SLURM ``squeue`` / PBSPro
+   ``qstat``) and loads the ``psij`` and ``queue_info`` plugins.
+3. Submit jobs through the ``psij`` client
+   (``submit_job`` / ``get_job_status`` / ``cancel_job``).
+
+**Firewalled compute nodes.**  When the edge must run on a compute node that
+cannot open a direct socket to the bridge, ``submit_tunneled`` launches a child
+edge with an SSH tunnel.  Pick the mode that matches the site's SSH policy:
+
+* ``forward`` — the child opens ``ssh -L`` from compute to the login host.
+  Use where **compute → login SSH is allowed** and login → compute is blocked
+  (e.g. Perlmutter, Aurora).
+* ``reverse`` — the login-side parent opens ``ssh -R`` to the compute host.
+  Use where **compute → login is blocked** but login → compute works
+  (e.g. Odo).
+* ``none`` — the child connects directly (no SSH).
+
+
+IRI — facility REST API
+=======================
+
+No edge is required — the bridge talks to the facility's IRI service directly.
+
+1. Obtain a facility access token (NERSC uses Globus, OLCF uses S3M — see the
+   per-facility notes below).
+2. Connect and use the per-endpoint instance client (see
+   :ref:`Plugin: iri <plugin_iri>` for the full API)::
+
+      iri   = bridge.get_plugin("iri_connect")
+      nersc = iri.connect("nersc", token="<token>")
+      print(nersc.list_resources("compute"))
+
+The token lives only in bridge process memory and is dropped on
+``disconnect``.
+
+
+Globus — data staging
+=====================
+
+1. Acquire a Globus Transfer token (or a refresh token + client id for
+   long transfers).
+2. Register a ``globus`` session with that credential and submit transfers
+   between two collection UUIDs.  Bytes flow collection-to-collection, never
+   through ORBIT.  See :ref:`Plugin: globus <plugin_globus>`.
+
+
+Per-facility notes
+==================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 20 20 24
+
+   * - Facility
+     - IRI auth
+     - PsiJ scheduler
+     - Compute tunnel
+   * - **NERSC / Perlmutter**
+     - Globus (``iri.nersc`` → ``api.iri.nersc.gov``)
+     - SLURM
+     - ``forward``
+   * - **OLCF / Frontier**
+     - S3M (``iri.olcf`` → ``amsc-open.s3m.olcf.ornl.gov``)
+     - SLURM
+     - ``forward`` (verify site policy)
+   * - **OLCF / Odo**
+     - S3M (``iri.olcf``)
+     - SLURM
+     - ``reverse``
+
+.. note::
+
+   The IRI endpoints and their auth methods are defined in
+   ``radical.orbit.iri_endpoints`` (``IRI_ENDPOINTS``); add a facility by
+   extending that table.  Scheduler and tunnel choices reflect current site
+   SSH policy — confirm against the facility's own documentation before a
+   production run, as policies change.

--- a/docs/source/plugin_iri.rst
+++ b/docs/source/plugin_iri.rst
@@ -59,7 +59,7 @@ Disconnecting removes the instance and drops the token.
 
 The Explorer UI prompts for the token and shares it with the plugin through the
 ``iri_tokens`` browser storage key; from Python you pass it to
-:py:meth:`IRIConnectClient.connect`.
+``IRIConnectClient.connect()``.
 
 
 Client API

--- a/docs/source/plugin_iri.rst
+++ b/docs/source/plugin_iri.rst
@@ -1,0 +1,144 @@
+
+.. _plugin_iri:
+
+################
+Plugin: ``iri``
+################
+
+The IRI integration lets ORBIT drive `IRI
+<https://iri.science/>`_ (Integrated Research Infrastructure) facility
+endpoints — listing compute resources, submitting and monitoring jobs, and
+reading facility incidents, projects and allocations — through the same
+plugin/client model as every other ORBIT plugin.
+
+It comes in two cooperating parts:
+
+``iri_connect``
+   A **bridge-side** configurator.  It lists the known IRI facility endpoints
+   and, on :py:meth:`connect`, dynamically registers a per-endpoint instance
+   plugin named ``iri.<endpoint>`` (e.g. ``iri.nersc``) that then appears as a
+   first-class node in the Explorer tree.
+
+``iri.<endpoint>``
+   A **dynamic per-endpoint instance** (class ``PluginIRIInstance``) created by
+   ``iri_connect``.  It talks to one facility's IRI REST API and exposes its
+   resources and jobs.  It is *not* auto-registered — instances exist only for
+   endpoints a user has connected to.
+
+
+Supported endpoints
+===================
+
+The facility endpoints are defined in
+:mod:`radical.orbit.iri_endpoints` (``IRI_ENDPOINTS``):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 40 15
+
+   * - Key
+     - REST base URL
+     - Auth
+   * - ``nersc``
+     - ``https://api.iri.nersc.gov`` (NERSC / Perlmutter)
+     - Globus
+   * - ``olcf``
+     - ``https://amsc-open.s3m.olcf.ornl.gov`` (OLCF / Frontier, Odo)
+     - S3M
+
+Add or change facility endpoints by editing ``IRI_ENDPOINTS``.
+
+
+Authentication
+==============
+
+A facility access token is supplied at ``connect`` time.  The token is held in
+**bridge process memory** (inside the instance's HTTP client) for the lifetime
+of the ``iri.<endpoint>`` instance and is **never written to disk**.
+Disconnecting removes the instance and drops the token.
+
+The Explorer UI prompts for the token and shares it with the plugin through the
+``iri_tokens`` browser storage key; from Python you pass it to
+:py:meth:`IRIConnectClient.connect`.
+
+
+Client API
+==========
+
+``IRIConnectClient`` (the ``iri_connect`` plugin):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 55
+
+   * - Method
+     - Description
+   * - ``list_endpoints()``
+     - The known facility endpoints (from ``IRI_ENDPOINTS``) and which are
+       currently connected.
+   * - ``connect(endpoint, token)``
+     - Connect to *endpoint* with *token*; registers ``iri.<endpoint>`` and
+       returns an :class:`IRIInstanceClient` bound to it.  Idempotent — an
+       already-connected endpoint has its token refreshed in place.
+   * - ``disconnect(endpoint)``
+     - Tear down ``iri.<endpoint>`` and its sessions.
+   * - ``get_status()``
+     - Connection status of the configured endpoints.
+
+``IRIInstanceClient`` (the ``iri.<endpoint>`` instance):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 55
+
+   * - Method
+     - Description
+   * - ``list_resources(resource_type='compute')``
+     - Facility resources of the given type.
+   * - ``get_resource(resource_id)``
+     - Detail for one resource.
+   * - ``submit_job(resource_id, job_spec)``
+     - Submit a job to a resource; returns the facility job id.
+   * - ``get_job_status(resource_id, job_id)``
+     - Current job state.
+   * - ``list_jobs(resource_id)``
+     - Jobs on a resource.
+   * - ``cancel_job(resource_id, job_id)``
+     - Cancel a job.
+   * - ``list_incidents()``
+     - Facility incident/outage feed.
+   * - ``list_projects()``
+     - Projects visible to the token.
+   * - ``list_allocations(project_id)``
+     - Allocations for a project.
+
+The instance runs a background poller (~10 s) and emits ``job_status``
+notifications as jobs change state, so a client can register a notification
+callback instead of polling.
+
+
+Usage
+=====
+
+.. code-block:: python
+
+   from radical.orbit.client import BridgeClient
+
+   client = BridgeClient(url="https://my-bridge:8000")
+   bridge = client.get_endpoint_client("bridge")   # iri_connect is bridge-hosted
+   iri    = bridge.get_plugin("iri_connect")
+
+   # discover facilities, then connect (token from your facility login flow)
+   print(iri.list_endpoints())
+   nersc = iri.connect("nersc", token="<globus-access-token>")
+
+   # use the per-endpoint instance client
+   resources = nersc.list_resources("compute")
+   rid       = resources["resources"][0]["id"]
+   job       = nersc.submit_job(rid, {"executable": "/bin/hostname"})
+   print(nersc.get_job_status(rid, job["job_id"]))
+
+   iri.disconnect("nersc")
+
+See also the :ref:`Machine setup guide <machine_guide>` for how IRI fits
+alongside the ``globus`` and ``psij`` access paths per facility.

--- a/docs/source/plugin_iri.rst
+++ b/docs/source/plugin_iri.rst
@@ -78,7 +78,7 @@ Client API
        currently connected.
    * - ``connect(endpoint, token)``
      - Connect to *endpoint* with *token*; registers ``iri.<endpoint>`` and
-       returns an :class:`IRIInstanceClient` bound to it.  Idempotent — an
+       returns an ``IRIInstanceClient`` bound to it.  Idempotent — an
        already-connected endpoint has its token refreshed in place.
    * - ``disconnect(endpoint)``
      - Tear down ``iri.<endpoint>`` and its sessions.

--- a/docs/source/plugin_iri.rst
+++ b/docs/source/plugin_iri.rst
@@ -15,7 +15,7 @@ It comes in two cooperating parts:
 
 ``iri_connect``
    A **bridge-side** configurator.  It lists the known IRI facility endpoints
-   and, on :py:meth:`connect`, dynamically registers a per-endpoint instance
+   and, on ``connect()``, dynamically registers a per-endpoint instance
    plugin named ``iri.<endpoint>`` (e.g. ``iri.nersc``) that then appears as a
    first-class node in the Explorer tree.
 

--- a/docs/source/rest_api.rst
+++ b/docs/source/rest_api.rst
@@ -1,3 +1,5 @@
+.. _rest_api:
+
 
 REST API Reference
 ******************


### PR DESCRIPTION
Adds the missing IRI documentation (#70) and a machine setup guide (#71).

## #70 — `docs/source/plugin_iri.rst`
Documents the IRI integration end to end:
- the bridge-side **`iri_connect`** configurator and the dynamically-registered per-endpoint **`iri.<endpoint>`** instance;
- the supported facility endpoints (NERSC → Globus, OLCF → S3M) sourced from `radical.orbit.iri_endpoints.IRI_ENDPOINTS`;
- the in-process-memory-only token model (never written to disk);
- the full `IRIConnectClient` / `IRIInstanceClient` API tables and a usage example.

## #71 — `docs/source/machine_guide.rst`
A machine setup guide tying the three access paths together:
- **PsiJ** (batch jobs via an edge, incl. the `forward`/`reverse`/`none` tunnel modes for firewalled compute), **IRI** (facility REST API), **Globus** (data staging);
- how to set each up, cross-linked to the plugin docs;
- a per-facility table (NERSC/Perlmutter, OLCF/Frontier, OLCF/Odo) with a note that scheduler/tunnel choices should be confirmed against current site policy.

Both pages are added to the toctree; `rest_api.rst` gains a label so the guide can link to it. The Sphinx build is clean for the new pages (remaining warnings are pre-existing).

Fixes #70
Fixes #71