### PR TITLE
Fix #82: terminate gracefully when a child job fails before its endpoint connects

### DIFF
--- a/examples/amsc.py
+++ b/examples/amsc.py
@@ -540,6 +540,10 @@ def _endpoint_argv(endpoint_name, broker_url, tunnel, login_host):
     if tunnel != 'none':
         args += ['--tunnel', tunnel]
         if tunnel == 'forward':
+            if not login_host:
+                raise ValueError(
+                    "tunnel 'forward' requires a login_host (the host the "
+                    "child opens 'ssh -L' to)")
             args += ['--tunnel-via', login_host]
     return args
 
@@ -749,7 +753,11 @@ class _JobFailureWatch:
         bc.register_callback(topic='job_status', callback=self._cb)
 
     def _on_status(self, endpoint, plugin, topic, data):
-        if self.failed or data.get('job_id') != self._job_id:
+        # Runs on the callback-dispatcher thread; a malformed/None payload must
+        # not raise here (it would kill that thread), so guard the type.
+        if self.failed or not isinstance(data, dict):
+            return
+        if data.get('job_id') != self._job_id:
             return
         state = str(data.get('state', '')).lower()
         if state in self._FAILED:

--- a/examples/amsc.py
+++ b/examples/amsc.py
@@ -529,6 +529,21 @@ def read_token(endpoint):
     return token
 
 
+def _endpoint_argv(endpoint_name, broker_url, tunnel, login_host):
+    """Build the ``radical-orbit-endpoint.py`` argv for a child endpoint.
+
+    ``tunnel`` is one of ``'none'`` / ``'forward'`` / ``'reverse'`` (see
+    ``bin/radical-orbit-endpoint.py``).  Forward mode needs ``--tunnel-via``
+    (the login host the child opens ``ssh -L`` to); reverse / none do not.
+    """
+    args = ['--name', endpoint_name, '--url', broker_url]
+    if tunnel != 'none':
+        args += ['--tunnel', tunnel]
+        if tunnel == 'forward':
+            args += ['--tunnel-via', login_host]
+    return args
+
+
 def launch_iri(bc, endpoint, cfg, broker_url):
     """Connect to the IRI endpoint and submit a job that starts an endpoint.
 
@@ -544,9 +559,8 @@ def launch_iri(bc, endpoint, cfg, broker_url):
     COUNTERS[endpoint] += 1
 
     # Build the radical-orbit-endpoint.py CLI.  See bin/radical-orbit-endpoint.py.
-    args = ['--name', endpoint_name, '--url', broker_url]
-    if cfg['tunnel']:
-        args += ['--tunnel', '--tunnel-via', cfg['login_host']]
+    args = _endpoint_argv(endpoint_name, broker_url,
+                          cfg['tunnel'], cfg.get('login_host'))
 
     # Per-endpoint custom attributes.  Anything beyond queue/duration
     # (constraint, reservation, …) goes through ``attributes`` so the
@@ -710,16 +724,63 @@ def _heartbeat_dot():
     sys.stdout.flush()
 
 
-def _wait_for_endpoint(bc, name):
+class _JobFailureWatch:
+    """Subscribe to ``job_status`` notifications for one job and record its
+    first *terminal failure*.
+
+    The child endpoint only registers once its HPC job reaches ``RUNNING``; if
+    the job instead dies (bad submission, tunnel setup failure, scheduler
+    rejection) the endpoint never appears and a plain topology poll would block
+    for the full ``ENDPOINT_WAIT_SECONDS`` timeout.  Watching the job's own
+    status lets the wait bail the moment the job fails.  Both the IRI poller
+    and the psij watcher emit ``job_status`` with a ``{job_id, state}`` payload
+    (IRI states are lower-case, psij upper-case — compared case-folded)."""
+
+    _FAILED = {'failed', 'cancelled', 'canceled', 'error'}
+
+    def __init__(self, bc, job_id):
+        self._bc     = bc
+        self._job_id = job_id
+        self.failed  = False
+        self.reason  = None
+        # Bind the handler once: register/unregister match callbacks by
+        # identity, and each ``self._on_status`` access is a fresh bound method.
+        self._cb     = self._on_status
+        bc.register_callback(topic='job_status', callback=self._cb)
+
+    def _on_status(self, endpoint, plugin, topic, data):
+        if self.failed or data.get('job_id') != self._job_id:
+            return
+        state = str(data.get('state', '')).lower()
+        if state in self._FAILED:
+            self.reason = (data.get('error') or data.get('details')
+                           or f'job entered state {state!r}')
+            self.failed = True
+
+    def close(self):
+        try:
+            self._bc.unregister_callback(topic='job_status',
+                                         callback=self._cb)
+        except Exception:
+            pass
+
+
+def _wait_for_endpoint(bc, name, failure=None):
     """Poll ``bc.topology()`` until *name* registers, adding the demo's
-    heartbeat-dot progress UI and guaranteeing a trailing newline on
-    either path."""
+    heartbeat-dot progress UI and guaranteeing a trailing newline on either
+    path.  If *failure* (a :class:`_JobFailureWatch`) trips first — the child
+    job died before its endpoint connected — raise immediately instead of
+    blocking until the timeout."""
     start   = time.time()
     last_hb = start
     try:
         while time.time() - start < ENDPOINT_WAIT_SECONDS:
             if name in bc.topology():
                 return name
+            if failure is not None and failure.failed:
+                raise RuntimeError(
+                    f'endpoint {name!r} will not appear — its job failed: '
+                    f'{failure.reason}')
             time.sleep(3.0)
             if time.time() - last_hb >= 10.0:
                 _heartbeat_dot()
@@ -1363,10 +1424,14 @@ def _main_target(bc, broker_url, kind, name,
                  newline=False)
 
             t0 = time.time()
+            watch = _JobFailureWatch(bc, rec['job_id'])
             try:
-                first = _wait_for_endpoint(bc, rec['endpoint_name'])
+                first = _wait_for_endpoint(bc, rec['endpoint_name'],
+                                           failure=watch)
             except Exception as exc:
                 abort(f'wait_for_endpoint failed: {exc}')
+            finally:
+                watch.close()
             step(5, 'await child endpoint', f'up after {int(time.time() - t0)}s')
 
             _step_run(bc, broker_url, first, rec.get('cfg') or cfg)
@@ -1398,10 +1463,14 @@ def _main_target(bc, broker_url, kind, name,
                  newline=False)
 
             t0 = time.time()
+            watch = _JobFailureWatch(bc, rec['job_id'])
             try:
-                first = _wait_for_endpoint(bc, rec['endpoint_name'])
+                first = _wait_for_endpoint(bc, rec['endpoint_name'],
+                                           failure=watch)
             except Exception as exc:
                 abort(f'wait_for_endpoint failed: {exc}')
+            finally:
+                watch.close()
             step(5, 'await child endpoint', f'up after {int(time.time() - t0)}s')
 
             _step_run(bc, broker_url, first, rec.get('cfg') or cfg)

--- a/tests/unittests/test_amsc_wait.py
+++ b/tests/unittests/test_amsc_wait.py
@@ -1,0 +1,114 @@
+
+# pylint: disable=protected-access
+"""Endpoint-wait / job-failure logic from the amsc demo (issue #82).
+
+`examples/amsc.py` is a demo script, not a package module, so it is loaded by
+path and the whole suite skips gracefully if its (optional) imports are absent.
+"""
+
+import os
+import importlib.util
+
+import pytest
+
+
+_AMSC = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), '..', '..', 'examples', 'amsc.py'))
+
+
+def _load_amsc():
+    spec = importlib.util.spec_from_file_location('amsc_demo', _AMSC)
+    mod  = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+try:
+    amsc = _load_amsc()
+    _SKIP = None
+except Exception as e:                       # missing optional demo deps
+    amsc  = None
+    _SKIP = f'examples/amsc.py not importable: {e}'
+
+pytestmark = pytest.mark.skipif(amsc is None, reason=_SKIP or '')
+
+
+class _FakeBC:
+    """Minimal stand-in for EndpointRuntime: a controllable topology and the
+    register/unregister callback surface _JobFailureWatch touches."""
+
+    def __init__(self, topo=None):
+        self._topo = topo or {}
+        self.subs  = []
+
+    def topology(self):
+        return dict(self._topo)
+
+    def register_callback(self, topic=None, callback=None, **kw):
+        self.subs.append((topic, callback))
+
+    def unregister_callback(self, topic=None, callback=None, **kw):
+        self.subs = [(t, c) for (t, c) in self.subs if c is not callback]
+
+
+# ── _endpoint_argv (the --tunnel argv root-cause fix) ──────────────────────
+
+def test_endpoint_argv_forward_includes_mode_and_via():
+    assert amsc._endpoint_argv('ep', 'wss://b:8000', 'forward', 'login.host') \
+        == ['--name', 'ep', '--url', 'wss://b:8000',
+            '--tunnel', 'forward', '--tunnel-via', 'login.host']
+
+
+def test_endpoint_argv_reverse_omits_via():
+    assert amsc._endpoint_argv('ep', 'u', 'reverse', 'login') \
+        == ['--name', 'ep', '--url', 'u', '--tunnel', 'reverse']
+
+
+def test_endpoint_argv_none_has_no_tunnel_args():
+    assert amsc._endpoint_argv('ep', 'u', 'none', None) \
+        == ['--name', 'ep', '--url', 'u']
+
+
+# ── _wait_for_endpoint ─────────────────────────────────────────────────────
+
+def test_wait_returns_when_endpoint_appears():
+    bc = _FakeBC({'ep.0': {'plugins': {}}})
+    assert amsc._wait_for_endpoint(bc, 'ep.0') == 'ep.0'
+
+
+def test_wait_bails_immediately_on_job_failure():
+    bc    = _FakeBC({})                       # endpoint never appears
+    watch = amsc._JobFailureWatch(bc, 'job-1')
+    watch._on_status('broker', 'iri.nersc', 'job_status',
+                     {'job_id': 'job-1', 'state': 'failed', 'details': 'boom'})
+    with pytest.raises(RuntimeError, match='job failed'):
+        amsc._wait_for_endpoint(bc, 'ep.0', failure=watch)
+
+
+def test_wait_times_out_when_nothing_happens(monkeypatch):
+    monkeypatch.setattr(amsc, 'ENDPOINT_WAIT_SECONDS', 0)
+    bc = _FakeBC({})
+    with pytest.raises(TimeoutError):
+        amsc._wait_for_endpoint(bc, 'ep.0')
+
+
+# ── _JobFailureWatch ───────────────────────────────────────────────────────
+
+def test_watch_subscribes_and_only_trips_on_own_terminal_failure():
+    bc    = _FakeBC()
+    watch = amsc._JobFailureWatch(bc, 'job-1')
+    assert bc.subs and bc.subs[0][0] == 'job_status'
+
+    watch._on_status('b', 'p', 'job_status',                # different job
+                     {'job_id': 'other', 'state': 'failed'})
+    watch._on_status('b', 'p', 'job_status',                # non-terminal
+                     {'job_id': 'job-1', 'state': 'running'})
+    assert not watch.failed
+
+    watch._on_status('b', 'p', 'job_status',                # psij upper-case
+                     {'job_id': 'job-1', 'state': 'FAILED'})
+    assert watch.failed
+    assert watch.reason
+
+    watch.close()
+    assert bc.subs == []

--- a/tests/unittests/test_amsc_wait.py
+++ b/tests/unittests/test_amsc_wait.py
@@ -69,6 +69,12 @@ def test_endpoint_argv_none_has_no_tunnel_args():
         == ['--name', 'ep', '--url', 'u']
 
 
+def test_endpoint_argv_forward_requires_login_host():
+    # forward mode with no login_host would append None to argv -> raise instead.
+    with pytest.raises(ValueError, match='login_host'):
+        amsc._endpoint_argv('ep', 'u', 'forward', None)
+
+
 # ── _wait_for_endpoint ─────────────────────────────────────────────────────
 
 def test_wait_returns_when_endpoint_appears():
@@ -112,3 +118,14 @@ def test_watch_subscribes_and_only_trips_on_own_terminal_failure():
 
     watch.close()
     assert bc.subs == []
+
+
+def test_watch_ignores_malformed_payload():
+    # The callback runs on the dispatcher thread; a None / non-dict payload must
+    # not raise (that would kill the thread).
+    bc    = _FakeBC()
+    watch = amsc._JobFailureWatch(bc, 'job-1')
+    watch._on_status('b', 'p', 'job_status', None)
+    watch._on_status('b', 'p', 'job_status', 'not-a-dict')
+    watch._on_status('b', 'p', 'job_status', 42)
+    assert not watch.failed


### PR DESCRIPTION
Closes #82.

## Symptom
Running `examples/amsc.py` against an IRI target: the HPC job fails, but ORBIT sits "stuck waiting for the edge to come up." `_wait_for_endpoint` polled `bc.topology()` only, and its **sole** failure exit was the 30-minute `ENDPOINT_WAIT_SECONDS` timeout — so a job that died in seconds still stalled the client for half an hour.

## Fix — two parts
1. **Race the wait against job status (the graceful-termination fix).** `_JobFailureWatch` subscribes (via `EndpointRuntime.register_callback(topic='job_status', ...)`) to the terminal-failure notifications that **both** the IRI poller (`plugin_iri_instance`) and the psij tunnel watcher (`plugin_psij`) already emit. `_wait_for_endpoint` now bails immediately with the failure reason instead of blocking to the timeout. (Callback-based per the agreed approach; the callback is bound once so `register`/`unregister` — which match by identity — pair up correctly.)
2. **Fix the likely root cause for tunnelled IRI targets.** `launch_iri` built `['--tunnel', '--tunnel-via', <host>]` — dropping the tunnel *mode* value, so argparse consumed `'--tunnel-via'` as `--tunnel`'s value, failed its `choices=['none','forward','reverse']` check, and the child endpoint exited instantly (`SystemExit(2)`) — exactly the failure that then hung the wait. Argv building is now a tested `_endpoint_argv()` helper emitting `--tunnel <mode>` (+ `--tunnel-via` only for `forward`).

## Tests
`tests/unittests/test_amsc_wait.py` covers the argv builder (forward/reverse/none), the wait paths (endpoint appears / job fails / times out), and the watcher's job-id + terminal-state matching. `examples/amsc.py` is a demo script, so it's loaded by path and the suite skips if its optional deps are absent. Full suite: **874 passed, 2 skipped**, flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)