### PR TITLE
Fix #34/#35/#39: Explorer session auto-recovery + task listing & cancel-all

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,7 @@ with open('%s/requirements.txt' % root, encoding='utf-8') as freq:
 with open('%s/docs/requirements.txt' % root, encoding='utf-8') as fdoc:
     doc_requirements = fdoc.readlines()
 
-test_requirements = ['pytest', 'pytest-asyncio']
+test_requirements = ['pytest', 'pytest-asyncio', 'quickjs']
 lint_requirements = ['flake8', 'pylint']
 dev_requirements  = test_requirements + lint_requirements + doc_requirements
 

--- a/src/radical/orbit/data/orbit_explorer.html
+++ b/src/radical/orbit/data/orbit_explorer.html
@@ -1168,6 +1168,7 @@
     let eventSource = null;
     let sessions = {};   // key: "endpointName/pluginName" -> sid
     let sessionRegBodies = {};   // key -> last register_session body (for auto-recovery re-register)
+    let healingSessions  = {};   // key -> in-flight re-register promise (single-flight heal)
     let endpointData = {};   // endpointName -> plugin info from /endpoint/list
     let queueDataCache      = {}; // endpointName -> { queues: {...}, allocations: [...] }
     let jobAllocationCache  = {}; // endpointName -> allocation dict | null
@@ -1883,7 +1884,9 @@
     // session auto-recovery.  Deleting the key drops both a resolved sid and any
     // in-flight registration promise stored under the same key.
     function invalidateSession(endpointName, pluginName) {
-      delete sessions[`${endpointName}/${pluginName}`];
+      const key = `${endpointName}/${pluginName}`;
+      delete sessions[key];
+      delete sessionRegBodies[key];   // drop the register body too (no leak on churn)
     }
 
     async function registerSession(endpointName, pluginName, body = {}) {
@@ -1944,11 +1947,18 @@
       const m  = su.matchSessionForPath(path, sessions, getNs);
       if (!m) return null;
 
-      invalidateSession(m.endpoint, m.plugin);
+      // Single-flight: concurrent pollers that all 404 on the same session
+      // coalesce onto ONE re-registration instead of each spawning their own.
+      if (!healingSessions[m.key]) {
+        const body = sessionRegBodies[m.key] || {};   // capture before invalidate
+        invalidateSession(m.endpoint, m.plugin);
+        healingSessions[m.key] =
+          registerSession(m.endpoint, m.plugin, body)
+            .finally(() => { delete healingSessions[m.key]; });
+      }
       let newSid;
       try {
-        newSid = await registerSession(m.endpoint, m.plugin,
-                                       sessionRegBodies[m.key] || {});
+        newSid = await healingSessions[m.key];
       } catch (_) {
         return null;   // re-register failed — let the original error surface
       }
@@ -2077,6 +2087,7 @@
       endpointData = {};
       sessions = {};
       sessionRegBodies = {};
+      healingSessions  = {};
       queueDataCache     = {};
       jobAllocationCache = {};
       window.lastEndpoints = {};

--- a/src/radical/orbit/data/orbit_explorer.html
+++ b/src/radical/orbit/data/orbit_explorer.html
@@ -1840,9 +1840,8 @@
           // that the job/task is missing.  Re-register once and retry with a
           // fresh sid.  The `_sidRetried` guard caps this at a single retry so a
           // persistently failing request can't loop.
-          const staleSession = res.status === 410 ||
-                               (res.status === 404 && t.includes('unknown session id'));
-          if (staleSession && !opts._sidRetried) {
+          const su = await ensureSU();
+          if (su.isStaleSession(res.status, t) && !opts._sidRetried) {
             const healedPath = await tryHealSession(path);
             if (healedPath) {
               return await apiFetch(healedPath, { ...opts, _sidRetried: true });
@@ -1924,6 +1923,15 @@
       return endpointData[endpointName]?.plugins?.[pluginName]?.namespace;
     }
 
+    // Pure session-heal helpers (isStaleSession / matchSessionForPath / swapSid)
+    // live in a shared, unit-tested module; load it once, lazily, on first use
+    // (only ever hit on an error path, so no cost on the happy path).
+    let SU = null;
+    async function ensureSU() {
+      if (!SU) SU = await import('/plugins/session_util.js');
+      return SU;
+    }
+
     // Stale-session auto-recovery.  When a session-scoped request 404/410s
     // because the sid is unknown/expired (endpoint restarted, or the server's
     // idle-expiry fired), find the cached session whose sid appears in this
@@ -1932,28 +1940,20 @@
     // matching cached session is found or the re-register fails, so the caller
     // surfaces the original error instead of looping.
     async function tryHealSession(path) {
-      for (const [key, val] of Object.entries(sessions)) {
-        if (typeof val !== 'string') continue;   // still an in-flight promise
-        const slash = key.indexOf('/');
-        const en = key.slice(0, slash);
-        const pn = key.slice(slash + 1);
-        const ns = getNs(en, pn);
-        // Only heal a session whose namespace and sid both appear in this path.
-        if (!ns || !path.startsWith(ns + '/') || !path.includes(val)) continue;
+      const su = await ensureSU();
+      const m  = su.matchSessionForPath(path, sessions, getNs);
+      if (!m) return null;
 
-        const oldSid = val;
-        invalidateSession(en, pn);
-        let newSid;
-        try {
-          newSid = await registerSession(en, pn, sessionRegBodies[key] || {});
-        } catch (_) {
-          return null;   // re-register failed — let the original error surface
-        }
-        if (!newSid || newSid === oldSid) return null;
-        // Swap the stale sid for the fresh one (sid is a unique UUID segment).
-        return path.split(oldSid).join(newSid);
+      invalidateSession(m.endpoint, m.plugin);
+      let newSid;
+      try {
+        newSid = await registerSession(m.endpoint, m.plugin,
+                                       sessionRegBodies[m.key] || {});
+      } catch (_) {
+        return null;   // re-register failed — let the original error surface
       }
-      return null;
+      if (!newSid || newSid === m.sid) return null;
+      return su.swapSid(path, m.sid, newSid);
     }
 
     // ─────────────────────────────────────────────────────────────

--- a/src/radical/orbit/data/orbit_explorer.html
+++ b/src/radical/orbit/data/orbit_explorer.html
@@ -1167,6 +1167,7 @@
     let BROKER = '';
     let eventSource = null;
     let sessions = {};   // key: "endpointName/pluginName" -> sid
+    let sessionRegBodies = {};   // key -> last register_session body (for auto-recovery re-register)
     let endpointData = {};   // endpointName -> plugin info from /endpoint/list
     let queueDataCache      = {}; // endpointName -> { queues: {...}, allocations: [...] }
     let jobAllocationCache  = {}; // endpointName -> allocation dict | null
@@ -1834,6 +1835,20 @@
           const t = await res.text();
           const errMsg = `HTTP ${res.status}: ${t}`;
 
+          // Stale-session auto-recovery: a 410 (expired) or a 404 whose detail
+          // is specifically "unknown session id" means the sid is dead — not
+          // that the job/task is missing.  Re-register once and retry with a
+          // fresh sid.  The `_sidRetried` guard caps this at a single retry so a
+          // persistently failing request can't loop.
+          const staleSession = res.status === 410 ||
+                               (res.status === 404 && t.includes('unknown session id'));
+          if (staleSession && !opts._sidRetried) {
+            const healedPath = await tryHealSession(path);
+            if (healedPath) {
+              return await apiFetch(healedPath, { ...opts, _sidRetried: true });
+            }
+          }
+
           // Show toast for HTTP errors (unless caller opts out)
           if (!opts.quiet) {
             if (res.status >= 500) {
@@ -1864,6 +1879,14 @@
       }
     }
 
+    // Drop a cached (or in-flight) session so the next getSession() re-registers.
+    // Used by the topology handler (endpoint restarted) and by apiFetch's stale
+    // session auto-recovery.  Deleting the key drops both a resolved sid and any
+    // in-flight registration promise stored under the same key.
+    function invalidateSession(endpointName, pluginName) {
+      delete sessions[`${endpointName}/${pluginName}`];
+    }
+
     async function registerSession(endpointName, pluginName, body = {}) {
       const key = `${endpointName}/${pluginName}`;
 
@@ -1872,6 +1895,11 @@
       // immediately prevents concurrent callers from racing into multiple
       // register_session RPCs.
       if (sessions[key]) return sessions[key];
+
+      // Remember the register body so a stale-session re-register (see
+      // apiFetch auto-recovery) reproduces the same session (e.g. rhapsody
+      // backends) rather than silently falling back to defaults.
+      sessionRegBodies[key] = body;
 
       const nsData = endpointData[endpointName]?.plugins?.[pluginName];
       if (!nsData) throw new Error(`Plugin ${pluginName} not found on ${endpointName}`);
@@ -1894,6 +1922,38 @@
 
     function getNs(endpointName, pluginName) {
       return endpointData[endpointName]?.plugins?.[pluginName]?.namespace;
+    }
+
+    // Stale-session auto-recovery.  When a session-scoped request 404/410s
+    // because the sid is unknown/expired (endpoint restarted, or the server's
+    // idle-expiry fired), find the cached session whose sid appears in this
+    // request path, invalidate + re-register it, and return a rebuilt path with
+    // the fresh sid so apiFetch can retry exactly once.  Returns null when no
+    // matching cached session is found or the re-register fails, so the caller
+    // surfaces the original error instead of looping.
+    async function tryHealSession(path) {
+      for (const [key, val] of Object.entries(sessions)) {
+        if (typeof val !== 'string') continue;   // still an in-flight promise
+        const slash = key.indexOf('/');
+        const en = key.slice(0, slash);
+        const pn = key.slice(slash + 1);
+        const ns = getNs(en, pn);
+        // Only heal a session whose namespace and sid both appear in this path.
+        if (!ns || !path.startsWith(ns + '/') || !path.includes(val)) continue;
+
+        const oldSid = val;
+        invalidateSession(en, pn);
+        let newSid;
+        try {
+          newSid = await registerSession(en, pn, sessionRegBodies[key] || {});
+        } catch (_) {
+          return null;   // re-register failed — let the original error surface
+        }
+        if (!newSid || newSid === oldSid) return null;
+        // Swap the stale sid for the fresh one (sid is a unique UUID segment).
+        return path.split(oldSid).join(newSid);
+      }
+      return null;
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -2016,6 +2076,7 @@
       BROKER = '';
       endpointData = {};
       sessions = {};
+      sessionRegBodies = {};
       queueDataCache     = {};
       jobAllocationCache = {};
       window.lastEndpoints = {};
@@ -2089,6 +2150,25 @@
           } else if (msg.topic === 'topology') {
             // Auto-refresh hierarchy on topology changes
             const endpoints = (msg.data && msg.data.endpoints) || {};
+
+            // Drop cached sessions for any endpoint whose presence changed.
+            // An endpoint that left (its old sids are dead) or (re)appeared (a
+            // restart reuses the name but starts with fresh, empty sessions)
+            // must not have its stale sids reused — invalidate them so the next
+            // getSession() re-registers against the live endpoint.
+            const prevNames = new Set(Object.keys(window.lastEndpoints || {}));
+            const curNames  = new Set(Object.keys(endpoints));
+            const changed   = new Set([...prevNames, ...curNames]);
+            for (const en of changed) {
+              if (prevNames.has(en) && curNames.has(en)) continue;  // unchanged
+              for (const key of Object.keys(sessions)) {
+                const slash = key.indexOf('/');
+                if (key.slice(0, slash) === en) {
+                  invalidateSession(en, key.slice(slash + 1));
+                }
+              }
+            }
+
             for (const [en, ed] of Object.entries(endpoints)) {
               endpointData[en] = ed;
             }

--- a/src/radical/orbit/data/plugins/psij.js
+++ b/src/radical/orbit/data/plugins/psij.js
@@ -407,14 +407,16 @@ async function loadExistingJobs(page, api) {
   const jobs = (res && res.jobs) || [];
   for (const job of jobs) {
     if (!job || !job.job_id) continue;
-    if (psijJobs[job.job_id]) {
-      // Already tracked (e.g. submitted from this tab) — just refresh state.
-      Object.assign(psijJobs[job.job_id], job);
+    psijJobs[job.job_id] = Object.assign(psijJobs[job.job_id] || {}, job);
+    // Idempotency is keyed off the DOM row, NOT the module-level psijJobs cache:
+    // that cache is an ES-module singleton that persists across reloads /
+    // reconnects / endpoint switches, so a freshly-rebuilt (empty) table still
+    // needs the row added even when the job is already in the cache.
+    if (page.querySelector(`tr[data-job-id="${CSS.escape(job.job_id)}"]`)) {
       updateJobRow(page, job.job_id, job.state, job);
-      continue;
+    } else {
+      addJobRow(page, api, job);   // renders state/cancel affordance from job.state
     }
-    psijJobs[job.job_id] = job;
-    addJobRow(page, api, job);   // renders state/cancel affordance from job.state
   }
 }
 

--- a/src/radical/orbit/data/plugins/psij.js
+++ b/src/radical/orbit/data/plugins/psij.js
@@ -134,6 +134,11 @@ export function init(page, api) {
     }
   }
 
+  // Populate the Job Monitor from jobs already in the endpoint session, so a
+  // page reload (or a panel opened after jobs were submitted elsewhere) isn't
+  // blank.  Fire-and-forget; a fresh/empty session simply yields no rows.
+  loadExistingJobs(page, api);
+
   // Prefill from cached queue data if already available
   const qd = api.getQueueData();
   if (qd) replaceQueueAccountDropdowns(page, qd);
@@ -387,6 +392,32 @@ function updateJobRowTunnel(page, jobId, tunnelStatus) {
   badge.textContent = tunnelStatus;
 }
 
+// Fetch jobs already known to the endpoint session (route: list_jobs/{sid},
+// PSIJPlugin.list_jobs -> {jobs: [...]}) and render any not already shown.
+// Idempotent: existing rows are refreshed, not duplicated.  Best-effort — a
+// missing session or transient error is swallowed (quiet fetch, no toast).
+async function loadExistingJobs(page, api) {
+  let res;
+  try {
+    const sid = await api.getSession('psij');
+    res = await api.fetch(`list_jobs/${sid}`, { quiet: true });
+  } catch (e) {
+    return;
+  }
+  const jobs = (res && res.jobs) || [];
+  for (const job of jobs) {
+    if (!job || !job.job_id) continue;
+    if (psijJobs[job.job_id]) {
+      // Already tracked (e.g. submitted from this tab) — just refresh state.
+      Object.assign(psijJobs[job.job_id], job);
+      updateJobRow(page, job.job_id, job.state, job);
+      continue;
+    }
+    psijJobs[job.job_id] = job;
+    addJobRow(page, api, job);   // renders state/cancel affordance from job.state
+  }
+}
+
 // ─────────────────────────────────────────────────────────────
 //  Job detail overlay with streaming
 // ─────────────────────────────────────────────────────────────
@@ -468,7 +499,20 @@ async function openJobDetail(api, jobId) {
           }
         }
       } catch (e) {
-        // Silently ignore poll errors
+        // A 404/410 here means the session was reset (endpoint restarted or the
+        // sid expired) — apiFetch already tried to re-register once, so this
+        // job can no longer be polled.  Stop the interval and surface a clear
+        // "session reset" state instead of spinning forever.  Other (transient
+        // network) errors are left non-fatal so a one-off blip keeps polling.
+        const msg = (e && e.message) || '';
+        if (msg.includes('404') || msg.includes('410')) {
+          stopPoller();
+          const stateEl = document.getElementById('psij-detail-state');
+          if (stateEl) {
+            stateEl.className   = 'badge badge-red';
+            stateEl.textContent = 'session reset — reopen';
+          }
+        }
       }
     }, 3000);
   }

--- a/src/radical/orbit/data/plugins/rhapsody.js
+++ b/src/radical/orbit/data/plugins/rhapsody.js
@@ -38,7 +38,10 @@ export function template() {
       <button class="btn btn-success" data-action="submit">▶ Submit Task</button>
     </div>
     <div class="card rh-tasks-card">
-      <div class="card-title">📊 Task Monitor</div>
+      <div class="card-title" style="display:flex;align-items:center;justify-content:space-between;">
+        <span>📊 Task Monitor</span>
+        <button class="btn btn-secondary btn-sm rh-cancel-all-btn" data-action="cancel-all" title="Cancel all tasks in this session">🛑 Cancel All</button>
+      </div>
       <div class="rh-table-area"><p style="color:var(--muted)">No tasks submitted yet.</p></div>
     </div>
   `;
@@ -59,6 +62,16 @@ export function init(page, api) {
   if (submitBtn) {
     submitBtn.addEventListener('click', () => submitTask(page, api));
   }
+
+  const cancelAllBtn = page.querySelector('[data-action="cancel-all"]');
+  if (cancelAllBtn) {
+    cancelAllBtn.addEventListener('click', () => cancelAllTasks(page, api));
+  }
+
+  // Populate the Task Monitor from tasks already in the endpoint session, so a
+  // page reload (or a panel opened after tasks were submitted elsewhere) isn't
+  // blank.  Fire-and-forget; a fresh/empty session simply yields no rows.
+  loadExistingTasks(page, api);
 }
 
 export function onNotification(data, page, api) {
@@ -174,6 +187,49 @@ function updateTaskRow(page, uid, state, data) {
   return true;
 }
 
+// Fetch tasks already known to the endpoint session (route: list_tasks/{sid},
+// RhapsodyPlugin.list_tasks -> {tasks: [...]}) and render any not already
+// shown.  Idempotent: existing rows are refreshed, not duplicated.
+// Best-effort — a missing session or transient error is swallowed.
+async function loadExistingTasks(page, api) {
+  let res;
+  try {
+    const sid = await api.getSession('rhapsody');
+    res = await api.fetch(`list_tasks/${sid}`, { quiet: true });
+  } catch (e) {
+    return;
+  }
+  const tasks = (res && res.tasks) || [];
+  for (const task of tasks) {
+    if (!task || !task.uid) continue;
+    if (rhTasks[task.uid]) {
+      // Already tracked (e.g. submitted from this tab) — just refresh state.
+      Object.assign(rhTasks[task.uid], task);
+      updateTaskRow(page, task.uid, task.state, task);
+      continue;
+    }
+    rhTasks[task.uid] = task;
+    addTaskRow(page, api, task);   // renders state/cancel affordance from task.state
+  }
+}
+
+// Cancel every task in the session (route: cancel_all/{sid},
+// RhapsodyPlugin.cancel_all_tasks).  Confirm + flash like the per-task cancel.
+async function cancelAllTasks(page, api) {
+  if (!confirm('Cancel ALL tasks in this session?')) return;
+  const btn = page.querySelector('[data-action="cancel-all"]');
+  if (btn) { btn.disabled = true; btn.textContent = '…'; }
+  try {
+    const sid = await api.getSession('rhapsody');
+    await api.fetch(`cancel_all/${sid}`, { method: 'POST' });
+    api.flash('Cancel requested for all tasks');
+  } catch (err) {
+    api.flash('Cancel all failed: ' + err.message, false);
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = '🛑 Cancel All'; }
+  }
+}
+
 // ─────────────────────────────────────────────────────────────
 //  Task detail overlay with polling
 // ─────────────────────────────────────────────────────────────
@@ -249,7 +305,20 @@ async function openTaskDetail(api, uid) {
           if (rhTasks[uid]) Object.assign(rhTasks[uid], upd);
         }
       } catch (e) {
-        // Silently ignore poll errors
+        // A 404/410 here means the session was reset (endpoint restarted or the
+        // sid expired) — apiFetch already tried to re-register once, so this
+        // task can no longer be polled.  Stop the interval and surface a clear
+        // "session reset" state instead of spinning forever.  Other (transient
+        // network) errors are left non-fatal so a one-off blip keeps polling.
+        const msg = (e && e.message) || '';
+        if (msg.includes('404') || msg.includes('410')) {
+          stopPoller();
+          const stateEl = document.getElementById('rh-detail-state');
+          if (stateEl) {
+            stateEl.className   = 'badge badge-red';
+            stateEl.textContent = 'session reset — reopen';
+          }
+        }
       }
     }, 3000);
   }

--- a/src/radical/orbit/data/plugins/rhapsody.js
+++ b/src/radical/orbit/data/plugins/rhapsody.js
@@ -202,14 +202,16 @@ async function loadExistingTasks(page, api) {
   const tasks = (res && res.tasks) || [];
   for (const task of tasks) {
     if (!task || !task.uid) continue;
-    if (rhTasks[task.uid]) {
-      // Already tracked (e.g. submitted from this tab) — just refresh state.
-      Object.assign(rhTasks[task.uid], task);
+    rhTasks[task.uid] = Object.assign(rhTasks[task.uid] || {}, task);
+    // Idempotency is keyed off the DOM row, NOT the module-level rhTasks cache:
+    // that cache is an ES-module singleton that persists across reloads /
+    // reconnects / endpoint switches, so a freshly-rebuilt (empty) table still
+    // needs the row added even when the task is already in the cache.
+    if (page.querySelector(`tr[data-uid="${CSS.escape(task.uid)}"]`)) {
       updateTaskRow(page, task.uid, task.state, task);
-      continue;
+    } else {
+      addTaskRow(page, api, task);   // renders state/cancel affordance from task.state
     }
-    rhTasks[task.uid] = task;
-    addTaskRow(page, api, task);   // renders state/cancel affordance from task.state
   }
 }
 

--- a/src/radical/orbit/data/plugins/session_util.js
+++ b/src/radical/orbit/data/plugins/session_util.js
@@ -1,0 +1,47 @@
+// Pure session-heal helpers for the Explorer.
+//
+// Shared by two callers so the logic is written (and tested) once:
+//   - the browser imports this as an ES module (orbit_explorer.html, served at
+//     /plugins/session_util.js);
+//   - pytest exercises it under the quickjs engine
+//     (tests/unittests/test_explorer_js.py).
+//
+// Deliberately free of DOM / fetch / global state — every input is a plain
+// argument — so both callers can drive the same functions.
+
+// A session-scoped request 404/410s because its sid is dead (the endpoint
+// restarted, or the server's idle-expiry fired) — as opposed to a plain
+// "job/task not found" 404.  Only the former should trigger a re-register:
+// a 410, or a 404 whose detail says "unknown session id".
+function isStaleSession(status, detail) {
+  return status === 410 ||
+         (status === 404 && (detail || '').includes('unknown session id'));
+}
+
+// Reverse-lookup.  Given the cached sessions map ("endpoint/plugin" -> sid) and
+// a request path, find the session this request was scoped to: the entry whose
+// plugin namespace prefixes the path and whose sid appears in it.
+// `nsOf(endpoint, plugin)` returns the plugin namespace (e.g. "/ep/psij").
+// Entries still holding an in-flight registration promise (non-string) are
+// skipped.  Returns {key, endpoint, plugin, sid} or null.
+function matchSessionForPath(path, sessions, nsOf) {
+  for (const key of Object.keys(sessions)) {
+    const val = sessions[key];
+    if (typeof val !== 'string') continue;
+    const slash    = key.indexOf('/');
+    const endpoint = key.slice(0, slash);
+    const plugin   = key.slice(slash + 1);
+    const ns = nsOf(endpoint, plugin);
+    if (!ns || !path.startsWith(ns + '/') || !path.includes(val)) continue;
+    return { key: key, endpoint: endpoint, plugin: plugin, sid: val };
+  }
+  return null;
+}
+
+// Rewrite a request path, replacing the stale sid with a fresh one.  The sid is
+// a unique UUID segment, so a plain global replace is safe.
+function swapSid(path, oldSid, newSid) {
+  return path.split(oldSid).join(newSid);
+}
+
+export { isStaleSession, matchSessionForPath, swapSid };

--- a/tests/unittests/test_explorer_js.py
+++ b/tests/unittests/test_explorer_js.py
@@ -1,0 +1,124 @@
+"""Browser-JS unit tests, run under pytest via the quickjs engine.
+
+The Explorer's pure session-heal helpers live in a shared, dependency-free ES
+module (``src/radical/orbit/data/plugins/session_util.js``) that the browser
+imports and these tests load into a quickjs context.  Only pure logic (no DOM /
+fetch / SSE) is exercised here; end-to-end UI coverage would need a browser
+harness (e.g. pytest-playwright) and is out of scope.
+
+quickjs is a ``[test]`` / ``[dev]`` extra; the whole module skips where it is
+not installed so the suite stays green.
+"""
+
+import json
+import pathlib
+import re
+
+import pytest
+
+quickjs = pytest.importorskip("quickjs")
+
+
+_MODULE = (pathlib.Path(__file__).resolve().parents[2]
+           / "src" / "radical" / "orbit" / "data" / "plugins"
+           / "session_util.js")
+
+
+def _context():
+    """A quickjs context with session_util.js loaded.
+
+    The file is an ES module (for the browser); quickjs ``eval`` runs a plain
+    script, so the trailing ``export { ... }`` line is stripped — the function
+    declarations then live in the context's global scope.
+    """
+    src = _MODULE.read_text()
+    src = re.sub(r'^\s*export\s*\{[^}]*\};?\s*$', '', src, flags=re.M)
+    ctx = quickjs.Context()
+    ctx.eval(src)
+    return ctx
+
+
+def _run(ctx, expr):
+    """Evaluate a JS expression and return its JSON-decoded value.
+
+    Results cross the boundary as a JSON string (``JSON.stringify``) to avoid
+    per-type marshalling; inputs are inlined as JSON literals by the caller.
+    """
+    return json.loads(ctx.eval("JSON.stringify((%s))" % expr))
+
+
+@pytest.fixture(scope="module")
+def ctx():
+    return _context()
+
+
+# ── isStaleSession ─────────────────────────────────────────────────────────
+
+def test_is_stale_session_410_is_stale(ctx):
+    assert _run(ctx, "isStaleSession(410, 'session expired: s1')") is True
+
+
+def test_is_stale_session_404_unknown_sid_is_stale(ctx):
+    assert _run(ctx, "isStaleSession(404, 'unknown session id: s1')") is True
+
+
+def test_is_stale_session_404_job_not_found_is_not_stale(ctx):
+    # A live session that simply doesn't have the job/task -> NOT a stale sid.
+    assert _run(ctx, "isStaleSession(404, 'job not found: j1')") is False
+
+
+def test_is_stale_session_other_status_is_not_stale(ctx):
+    assert _run(ctx, "isStaleSession(500, 'boom')") is False
+    assert _run(ctx, "isStaleSession(404, null)")   is False
+
+
+# ── matchSessionForPath ────────────────────────────────────────────────────
+
+_NSOF = "(en, pn) => '/' + en + '/' + pn"
+
+
+def test_match_finds_session_scoped_by_namespace_and_sid(ctx):
+    sessions = {"ep/psij": "sid-abc", "ep/rhapsody": "sid-xyz"}
+    got = _run(ctx, "matchSessionForPath("
+                    "'/ep/psij/status/sid-abc/job1', %s, %s)"
+                    % (json.dumps(sessions), _NSOF))
+    assert got == {"key": "ep/psij", "endpoint": "ep",
+                   "plugin": "psij", "sid": "sid-abc"}
+
+
+def test_match_requires_namespace_prefix(ctx):
+    # sid present but the path is under a different namespace -> no match.
+    sessions = {"ep/psij": "sid-abc"}
+    got = _run(ctx, "matchSessionForPath("
+                    "'/ep/rhapsody/x/sid-abc', %s, %s)"
+                    % (json.dumps(sessions), _NSOF))
+    assert got is None
+
+
+def test_match_requires_sid_in_path(ctx):
+    sessions = {"ep/psij": "sid-abc"}
+    got = _run(ctx, "matchSessionForPath("
+                    "'/ep/psij/status/sid-other/job1', %s, %s)"
+                    % (json.dumps(sessions), _NSOF))
+    assert got is None
+
+
+def test_match_skips_in_flight_promise_entries(ctx):
+    # A non-string value is an in-flight registration promise -> skipped.
+    got = _run(ctx,
+               "matchSessionForPath('/ep/psij/status/x', "
+               "(function(){var s={}; s['ep/psij']={then:1}; return s;})(), %s)"
+               % _NSOF)
+    assert got is None
+
+
+# ── swapSid ────────────────────────────────────────────────────────────────
+
+def test_swap_sid_replaces_stale_segment(ctx):
+    got = _run(ctx, "swapSid('/ep/psij/status/sid-old/job1', 'sid-old', 'sid-new')")
+    assert got == "/ep/psij/status/sid-new/job1"
+
+
+def test_swap_sid_no_op_when_absent(ctx):
+    got = _run(ctx, "swapSid('/ep/psij/status/sid-x/j', 'sid-old', 'sid-new')")
+    assert got == "/ep/psij/status/sid-x/j"


### PR DESCRIPTION
Closes #34, #35, #39. Browser-JS only (`orbit_explorer.html`, `psij.js`, `rhapsody.js`) — the `cancel_all` / `list_tasks` / `list_jobs` routes already exist server-side, so no backend change.

## #34 / #35 — stale browser session
A cached `sid` that goes dead (endpoint restarted, or the server's 3600s idle-expiry) returned **404/410**, but the Explorer only toasted and the psij/rhapsody detail pollers **silently swallowed** the error and span forever.
- **`apiFetch` auto-recovery:** on a 410 (or a 404 whose detail is `unknown session id` — deliberately distinguished from job/task-not-found), it invalidates the cached session, re-registers (reproducing the original register body via a new `sessionRegBodies` cache, so e.g. rhapsody `backends` survive the heal), and **retries once** (loop-guarded by `_sidRetried`).
- **Topology invalidation:** the SSE `topology` handler now drops cached sessions for any endpoint that left or (re)appeared, so a restart's stale sids are never reused.
- **Pollers stop swallowing:** a 404/410 halts the interval and shows a `session reset — reopen` badge instead of spinning; transient/network blips stay non-fatal.

## #39 — cancel tasks in portal
Per-task cancel already existed; the real gaps were (a) tasks not submitted from this tab had no row (nothing to cancel) and (b) `cancel_all` had no UI.
- rhapsody + psij panels call **`list_tasks`/`list_jobs` on open** to populate existing session tasks/jobs (idempotent — refreshes, never duplicates).
- rhapsody gains a **Cancel All** button wired to the existing `cancel_all/{sid}` route.

## Verification
No JS test harness exists in the repo, so this was reviewed by inspection: calling conventions checked against existing code (`api.fetch`/`api.getSession`/`api.flash(msg, ok)`, `addTaskRow`/`addJobRow` arity), routes confirmed against `plugin_rhapsody.py`/`plugin_psij.py`, and brace/paren/bracket balance verified on all three files. (See the separate discussion about adding a JS harness under pytest.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)