### PR TITLE
Fix #40: surface more quinfo job info + consistent state formatting

### DIFF
--- a/docs/source/plugin_queue_info.rst
+++ b/docs/source/plugin_queue_info.rst
@@ -6,8 +6,9 @@ Plugin: ``queue_info``
 ######################
 
 The ``queue_info`` plugin exposes batch system queue information, job
-listings, and allocation data via REST endpoints.  It currently supports
-SLURM (24.11.5+) and is designed for easy extension to other batch systems.
+listings, and allocation data via REST endpoints.  It supports SLURM
+(24.11.5+) and PBSPro, with a no-op backend on hosts where neither is
+present, and is designed for easy extension to other batch systems.
 
 
 Architecture
@@ -19,9 +20,12 @@ The plugin consists of three layers:
    Abstract base class defining the backend interface and providing
    thread-safe caching with a configurable TTL (default 1 hour).
 
-``QueueInfoSlurm``
-   SLURM implementation that calls ``sinfo``, ``squeue``, ``scontrol``,
-   and ``sacctmgr`` with ``--json`` output and parses the results.
+``QueueInfoSlurm`` / ``QueueInfoPBSPro`` / ``QueueInfoNone``
+   Backend implementations.  ``QueueInfoSlurm`` calls ``sinfo``,
+   ``squeue``, ``scontrol``, and ``sacctmgr`` with ``--json`` output;
+   ``QueueInfoPBSPro`` parses ``qstat`` / ``pbsnodes`` text output; the
+   ``None`` backend is a graceful no-op.  The active backend is chosen
+   automatically by :func:`make_queue_info`.
 
 ``PluginQueueInfo``
    Endpoint plugin that exposes the backend via REST endpoints and manages
@@ -66,9 +70,28 @@ All paths are relative to the plugin namespace
 ``GET /list_jobs/{cid}/{queue}?user=<name>&force=true``
    List jobs in a partition.  Optionally filter by user.
 
+``GET /list_all_jobs/{cid}?user=<name>&force=true``
+   List all of the user's jobs across every partition.
+
 ``GET /list_allocations/{cid}?user=<name>&force=true``
    List SLURM associations (accounts/allocations).  Optionally filter by
    user.
+
+``POST /cancel/{cid}/{job_id}``
+   Cancel a job via the active batch system (``scancel`` / ``qdel``).
+
+``GET /backend``
+   Session-less.  Report the active backend: ``{"backend": "slurm" |
+   "pbs" | "none"}``.
+
+``GET /job_allocation``
+   Session-less.  Return the **endpoint** process's own batch allocation
+   (``{"allocation": {...}}``), or ``{"allocation": null}`` when the
+   endpoint runs on a login node.
+
+``GET /nodelist``
+   Session-less.  Return the expanded hostname list of the endpoint's own
+   allocation (``{"nodelist": [...]}``); empty on a login node.
 
 
 Data structures
@@ -124,13 +147,34 @@ Job list (``list_jobs``)
          "start_time":  1700000000,
          "priority":    50000,
          "account":     "proj_alpha",
-         "node_list":   "node010-node019"
+         "node_list":   "node010-node019",
+         "reason":      "",
+         "qos":         "normal",
+         "dependency":  "",
+         "std_out":     "/home/alice/job.out",
+         "std_err":     "/home/alice/job.err",
+         "work_dir":    "/home/alice/run",
+         "command":     "/home/alice/run.sh",
+         "exit_code":   null,
+         "array_job_id":  null,
+         "array_task_id": null,
+         "tres_req":    "cpu=1280,mem=...",
+         "tres_alloc":  "cpu=1280,node=10,...",
+         "restart_cnt": 0
        }
      ]
    }
 
 ``time_limit`` and ``time_used`` are in minutes and seconds respectively.
 ``time_limit`` is ``null`` for unlimited jobs.
+
+The fields from ``reason`` onward are additional per-job detail surfaced
+for the Explorer's job-detail overlay.  They are populated from whatever
+the scheduler reports (``squeue --json`` fields on SLURM, ``qstat -f``
+attributes on PBSPro — where PBSPro also adds ``owner`` and ``mem_used``)
+and default to ``""`` / ``null`` when the scheduler does not provide them,
+so older SLURM releases and PBS jobs without the attribute still parse.
+Array-job and TRES fields apply to SLURM only.
 
 
 Allocations (``list_allocations``)
@@ -158,6 +202,39 @@ Allocations (``list_allocations``)
 
 When ``user`` is empty, the row represents an account-level association.
 The ``*_node_hours`` fields are reserved for future accounting integration.
+
+
+Client API
+==========
+
+``QueueInfoClient`` (obtained via ``endpoint.get_plugin(name, 'queue_info')``)
+exposes:
+
+``get_info(user=None, force=False)``
+   Queue/partition information (session required).
+
+``list_jobs(queue, user=None, force=False)``
+   Jobs in a single partition (session required).
+
+``list_all_jobs(user=None, force=False)``
+   All of the user's jobs across every partition (session required).
+
+``list_allocations(user=None, force=False)``
+   Associations / allocations (session required).
+
+``cancel_job(job_id)``
+   Cancel a job through the active batch system (session required).
+
+``job_allocation()``
+   Session-less.  The endpoint's own batch allocation summary, or ``None``
+   on a login node.
+
+``nodelist()``
+   Session-less.  Expanded hostnames of the endpoint's own allocation.
+
+``backend()``
+   Session-less.  The active backend name: ``'slurm'``, ``'pbs'``, or
+   ``'none'``.
 
 
 Example

--- a/src/radical/orbit/data/plugins/queue_info.js
+++ b/src/radical/orbit/data/plugins/queue_info.js
@@ -47,6 +47,74 @@ let queueDataCache = {};
 // Shared with api.escHtml — set in init()
 let escHtml = s => String(s || '');  // safe fallback until init()
 
+// Shared job-state → badge colour map, covering the common SLURM and PBS
+// state vocabularies so states like CANCELLED / TIMEOUT / SUSPENDED get a
+// meaningful colour instead of falling through to grey.
+const JOB_STATE_BADGES = {
+  RUNNING      : 'badge-green',
+  COMPLETING   : 'badge-green',
+  COMPLETED    : 'badge-blue',
+  PENDING      : 'badge-orange',
+  CONFIGURING  : 'badge-orange',
+  SUSPENDED    : 'badge-orange',
+  PREEMPTED    : 'badge-orange',
+  HELD         : 'badge-orange',
+  FAILED       : 'badge-red',
+  TIMEOUT      : 'badge-red',
+  NODE_FAIL    : 'badge-red',
+  BOOT_FAIL    : 'badge-red',
+  DEADLINE     : 'badge-red',
+  OUT_OF_MEMORY: 'badge-red',
+  CANCELLED    : 'badge-gray',
+  CANCELED     : 'badge-gray',
+  MOVED        : 'badge-gray',
+};
+
+function jobStateBadge(state) {
+  return JOB_STATE_BADGES[String(state || '').toUpperCase()] || 'badge-gray';
+}
+
+// One job-detail grid row (label + value); value is inserted verbatim, so
+// callers escape it as needed.
+function jobDetailRow(label, value) {
+  return `
+      <div class="job-detail-item">
+        <span class="label">${label}</span>
+        <span class="value">${value}</span>
+      </div>`;
+}
+
+// Conditional extra rows for the newly-surfaced job fields (issue #40).
+// Absent/empty fields are skipped so overlays don't show blank rows.
+function extraJobDetailRows(job) {
+  let rows = '';
+  if (job.reason && job.reason !== 'None')
+    rows += jobDetailRow('Reason', escHtml(job.reason));
+  if (job.qos)
+    rows += jobDetailRow('QoS', escHtml(job.qos));
+  if (job.dependency)
+    rows += jobDetailRow('Dependency', escHtml(job.dependency));
+  if (job.work_dir)
+    rows += jobDetailRow('Working Dir', escHtml(job.work_dir));
+  if (job.command)
+    rows += jobDetailRow('Command', escHtml(job.command));
+  if (job.exit_code !== undefined && job.exit_code !== null)
+    rows += jobDetailRow('Exit Code', escHtml(String(job.exit_code)));
+  if (job.array_job_id !== undefined && job.array_job_id !== null)
+    rows += jobDetailRow('Array Job ID', escHtml(String(job.array_job_id)));
+  if (job.array_task_id !== undefined && job.array_task_id !== null)
+    rows += jobDetailRow('Array Task ID', escHtml(String(job.array_task_id)));
+  if (job.tres_req)
+    rows += jobDetailRow('TRES (req)', escHtml(job.tres_req));
+  if (job.tres_alloc)
+    rows += jobDetailRow('TRES (alloc)', escHtml(job.tres_alloc));
+  if (job.std_out)
+    rows += jobDetailRow('Std Out', escHtml(job.std_out));
+  if (job.std_err)
+    rows += jobDetailRow('Std Err', escHtml(job.std_err));
+  return rows;
+}
+
 export function init(page, api) {
   escHtml = api.escHtml;
   // Bind refresh button
@@ -248,8 +316,8 @@ async function loadQueueJobs(api, sid, queue, btn) {
 
       for (const j of jobs) {
         const jobId = j.job_id || j.id || '-';
-        const st = j.state || j.job_state || '-';
-        const badge = { 'RUNNING': 'badge-green', 'PENDING': 'badge-orange', 'COMPLETED': 'badge-blue', 'FAILED': 'badge-red' }[st] || 'badge-gray';
+        const st = j.state || '-';
+        const badge = jobStateBadge(st);
         const eid = escHtml(jobId);
         const cancelBtn = CANCELLABLE.has(st)
           ? `<button class="task-cancel-btn cancel-job-btn" data-job-id="${eid}" title="Cancel job ${eid}">❌</button>`
@@ -259,7 +327,7 @@ async function loadQueueJobs(api, sid, queue, btn) {
           <td><span class="badge ${badge}">${escHtml(st)}</span></td>
           <td>${escHtml(j.job_name || j.name || '-')}</td>
           <td>${escHtml(j.user || j.user_name || '-')}</td>
-          <td>${j.nodes || j.num_nodes || '-'}</td>
+          <td>${j.nodes || '-'}</td>
           <td>${formatDuration(j.time_used)}</td>
           <td>${cancelBtn}</td>
         </tr>`;
@@ -314,8 +382,8 @@ function showJobDetail(jobId) {
   const detailPanel = document.getElementById('job-detail-panel');
   if (!detailPanel) return;
 
-  const st = job.state || job.job_state || '-';
-  const badge = { 'RUNNING': 'badge-green', 'PENDING': 'badge-orange', 'COMPLETED': 'badge-blue', 'FAILED': 'badge-red' }[st] || 'badge-gray';
+  const st = job.state || '-';
+  const badge = jobStateBadge(st);
 
   detailPanel.innerHTML = `
     <h4>📋 Job Details: ${escHtml(job.job_id || job.id || '-')}</h4>
@@ -342,7 +410,7 @@ function showJobDetail(jobId) {
       </div>
       <div class="job-detail-item">
         <span class="label">Nodes</span>
-        <span class="value">${job.nodes || job.num_nodes || '-'}</span>
+        <span class="value">${job.nodes || '-'}</span>
       </div>
       <div class="job-detail-item">
         <span class="label">CPUs</span>
@@ -371,7 +439,7 @@ function showJobDetail(jobId) {
       <div class="job-detail-item">
         <span class="label">Priority</span>
         <span class="value">${job.priority || '-'}</span>
-      </div>
+      </div>${extraJobDetailRows(job)}
     </div>
   `;
   detailPanel.style.display = 'block';
@@ -408,8 +476,8 @@ async function loadMyJobs(content, api, sid) {
     for (const j of jobs) {
       const jobId = j.job_id || j.id || '-';
       const eid = escHtml(jobId);
-      const st = j.state || j.job_state || '-';
-      const badge = { 'RUNNING': 'badge-green', 'PENDING': 'badge-orange', 'COMPLETED': 'badge-blue', 'FAILED': 'badge-red' }[st] || 'badge-gray';
+      const st = j.state || '-';
+      const badge = jobStateBadge(st);
       const cancelBtn = CANCELLABLE.has(st)
         ? `<button class="task-cancel-btn my-cancel-job-btn" data-job-id="${eid}" title="Cancel job ${eid}">❌</button>`
         : '';
@@ -418,7 +486,7 @@ async function loadMyJobs(content, api, sid) {
         <td><span class="badge ${badge}">${escHtml(st)}</span></td>
         <td>${escHtml(j.job_name || j.name || '-')}</td>
         <td>${escHtml(j.partition || '-')}</td>
-        <td>${j.nodes || j.num_nodes || '-'}</td>
+        <td>${j.nodes || '-'}</td>
         <td>${formatDuration(j.time_used)}</td>
         <td>${cancelBtn}</td>
       </tr>`;
@@ -464,8 +532,8 @@ function showJobDetailOverlay(jobId, api) {
   const job = myJobsData.find(j => (j.job_id || j.id) === jobId);
   if (!job) return;
 
-  const st = job.state || job.job_state || '-';
-  const badge = { 'RUNNING': 'badge-green', 'PENDING': 'badge-orange', 'COMPLETED': 'badge-blue', 'FAILED': 'badge-red' }[st] || 'badge-gray';
+  const st = job.state || '-';
+  const badge = jobStateBadge(st);
 
   const body = `
     <div class="job-detail-grid">
@@ -491,7 +559,7 @@ function showJobDetailOverlay(jobId, api) {
       </div>
       <div class="job-detail-item">
         <span class="label">Nodes</span>
-        <span class="value">${job.nodes || job.num_nodes || '-'}</span>
+        <span class="value">${job.nodes || '-'}</span>
       </div>
       <div class="job-detail-item">
         <span class="label">CPUs</span>
@@ -520,7 +588,7 @@ function showJobDetailOverlay(jobId, api) {
       <div class="job-detail-item">
         <span class="label">Priority</span>
         <span class="value">${job.priority || '-'}</span>
-      </div>
+      </div>${extraJobDetailRows(job)}
     </div>
   `;
 

--- a/src/radical/orbit/queue_info_pbs.py
+++ b/src/radical/orbit/queue_info_pbs.py
@@ -111,6 +111,21 @@ _STATE_DISPLAY = {
 }
 
 
+def _pbs_var_value(varlist: str, key: str) -> str:
+    """Return the value of *key* from a PBSPro ``Variable_List`` string.
+
+    ``Variable_List`` is a comma-separated ``NAME=value`` list (e.g.
+    ``PBS_O_HOME=/home/x,PBS_O_WORKDIR=/scratch/x``).  Returns '' when the
+    key is absent.
+    """
+    for item in varlist.split(','):
+        if '=' in item:
+            k, v = item.split('=', 1)
+            if k.strip() == key:
+                return v.strip()
+    return ''
+
+
 def _acl_match(acl_str: str, candidates: set) -> bool:
     """Check a PBSPro ACL list against a set of identifier *candidates*.
 
@@ -464,6 +479,17 @@ class QueueInfoPBSPro(QueueInfo):
         except ValueError:
             cpus_n = 0
 
+        try:
+            priority = int(info.get('Priority', '0') or 0)
+        except (ValueError, TypeError):
+            priority = 0
+
+        def _int_or_none(s):
+            try:
+                return int(s)
+            except (ValueError, TypeError):
+                return None
+
         # PBSPro timestamps (qtime, stime, mtime) are RFC-2822-ish strings;
         # parse what we can, leave 0 otherwise.
         def _ts(key):
@@ -487,7 +513,20 @@ class QueueInfoPBSPro(QueueInfo):
             'time_used'  : wall_used or 0,
             'submit_time': _ts('qtime'),
             'start_time' : _ts('stime'),
-            'priority'   : 0,
+            'priority'   : priority,
             'account'    : info.get('Account_Name', ''),
             'node_list'  : ','.join(_parse_exec_host(info.get('exec_host', ''))),
+            # extra detail surfaced for the Explorer (issue #40); additive,
+            # defensive — absent qstat -f attributes default to ''/None
+            'owner'      : info.get('Job_Owner', ''),
+            'reason'     : info.get('comment', ''),
+            'qos'        : info.get('Resource_List.qos', ''),
+            'dependency' : info.get('depend', ''),
+            'std_out'    : info.get('Output_Path', ''),
+            'std_err'    : info.get('Error_Path', ''),
+            'work_dir'   : _pbs_var_value(info.get('Variable_List', ''),
+                                          'PBS_O_WORKDIR'),
+            'command'    : info.get('Submit_arguments', ''),
+            'exit_code'  : _int_or_none(info.get('Exit_status')),
+            'mem_used'   : info.get('resources_used.mem', ''),
         }

--- a/src/radical/orbit/queue_info_slurm.py
+++ b/src/radical/orbit/queue_info_slurm.py
@@ -35,6 +35,23 @@ def _unwrap(obj):
     return obj.get('number')
 
 
+def _exit_code(job):
+    """
+    Extract a numeric exit/return code from a squeue JSON job object.
+
+    Newer SLURM wraps it as ``{status, return_code:{set,number}, signal}``;
+    older versions expose a plain ``{set, infinite, number}`` wrapper.
+    Returns None when the field is absent or unset.
+    """
+
+    ec = job.get('exit_code')
+    if isinstance(ec, dict):
+        if 'return_code' in ec:
+            return _unwrap(ec.get('return_code'))
+        return _unwrap(ec)
+    return ec
+
+
 def _parse_gpus(gres_str):
     """
     Parse GPU count from a SLURM GRES string.
@@ -200,6 +217,10 @@ class QueueInfoSlurm(QueueInfo):
 
             time_used = int(now - start) if (state == 'RUNNING' and start > 0) else 0
 
+            reason = job.get('state_reason')
+            if reason is None:
+                reason = job.get('reason', '')
+
             result.append({
                 'job_id'     : str(job.get('job_id', '')),
                 'job_name'   : job.get('name', ''),
@@ -215,6 +236,21 @@ class QueueInfoSlurm(QueueInfo):
                 'priority'   : _unwrap(job.get('priority', {}))   or 0,
                 'account'    : job.get('account', ''),
                 'node_list'  : job.get('nodes', ''),
+                # extra detail surfaced for the Explorer (issue #40); all
+                # additive with None/'' defaults so older SLURM still parses
+                'reason'       : reason or '',
+                'qos'          : job.get('qos', ''),
+                'dependency'   : job.get('dependency', ''),
+                'std_out'      : job.get('standard_output', ''),
+                'std_err'      : job.get('standard_error', ''),
+                'work_dir'     : job.get('current_working_directory', ''),
+                'command'      : job.get('command', ''),
+                'exit_code'    : _exit_code(job),
+                'array_job_id' : _unwrap(job.get('array_job_id')),
+                'array_task_id': _unwrap(job.get('array_task_id')),
+                'tres_req'     : job.get('tres_req_str', ''),
+                'tres_alloc'   : job.get('tres_alloc_str', ''),
+                'restart_cnt'  : _unwrap(job.get('restart_cnt')),
             })
         return result
 

--- a/tests/unittests/test_queue_info.py
+++ b/tests/unittests/test_queue_info.py
@@ -365,6 +365,97 @@ class TestCollectJobs:
         assert result['jobs'][0]['job_id'] == '12345'
 
 
+# ---- _parse_squeue_jobs extra-fields tests (issue #40) ----------------------
+
+class TestParseSqueueJobsExtras:
+    """Extra per-job detail surfaced from squeue --json (issue #40)."""
+
+    def test_rich_fields_surfaced(self):
+        jobs = [{
+            'job_id'                   : 200001,
+            'name'                     : 'rich_job',
+            'user_name'                : 'alice',
+            'partition'                : 'gpu',
+            'job_state'                : ['PENDING'],
+            'node_count'               : {'set': True, 'number': 4},
+            'state_reason'             : 'Priority',
+            'qos'                      : 'high',
+            'dependency'               : 'afterok:100000',
+            'standard_output'          : '/home/alice/job.out',
+            'standard_error'           : '/home/alice/job.err',
+            'current_working_directory': '/home/alice/work',
+            'command'                  : '/home/alice/run.sh',
+            'exit_code'                : {'status': ['SUCCESS'],
+                                          'return_code': {'set': True,
+                                                          'number': 0}},
+            'array_job_id'             : {'set': True, 'number': 200001},
+            'array_task_id'            : {'set': True, 'number': 7},
+            'tres_req_str'             : 'cpu=8,mem=32G',
+            'tres_alloc_str'           : 'cpu=8,mem=32G,node=4',
+            'restart_cnt'              : 2,
+        }]
+
+        job = QueueInfoSlurm._parse_squeue_jobs(jobs)[0]
+
+        assert job['reason']        == 'Priority'
+        assert job['qos']           == 'high'
+        assert job['dependency']    == 'afterok:100000'
+        assert job['std_out']       == '/home/alice/job.out'
+        assert job['std_err']       == '/home/alice/job.err'
+        assert job['work_dir']      == '/home/alice/work'
+        assert job['command']       == '/home/alice/run.sh'
+        assert job['exit_code']     == 0
+        assert job['array_job_id']  == 200001
+        assert job['array_task_id'] == 7
+        assert job['tres_req']      == 'cpu=8,mem=32G'
+        assert job['tres_alloc']    == 'cpu=8,mem=32G,node=4'
+        assert job['restart_cnt']   == 2
+
+    def test_absent_fields_default(self):
+        """Older SLURM without the extra keys yields graceful defaults."""
+
+        jobs = [{
+            'job_id'   : 200002,
+            'name'     : 'plain_job',
+            'user_name': 'bob',
+            'partition': 'compute',
+            'job_state': ['RUNNING'],
+        }]
+
+        job = QueueInfoSlurm._parse_squeue_jobs(jobs)[0]
+
+        assert job['reason']        == ''
+        assert job['qos']           == ''
+        assert job['dependency']    == ''
+        assert job['std_out']       == ''
+        assert job['std_err']       == ''
+        assert job['work_dir']      == ''
+        assert job['command']       == ''
+        assert job['exit_code']     is None
+        assert job['array_job_id']  is None
+        assert job['array_task_id'] is None
+        assert job['tres_req']      == ''
+        assert job['tres_alloc']    == ''
+        assert job['restart_cnt']   is None
+
+    def test_exit_code_plain_wrapper(self):
+        """Older squeue JSON: exit_code as a plain {set,number} wrapper."""
+
+        jobs = [{'job_id'   : 3,
+                 'job_state': ['COMPLETED'],
+                 'exit_code': {'set': True, 'infinite': False, 'number': 1}}]
+
+        job = QueueInfoSlurm._parse_squeue_jobs(jobs)[0]
+        assert job['exit_code'] == 1
+
+    def test_reason_key_fallback(self):
+        """When only the legacy 'reason' key is present it is used."""
+
+        jobs = [{'job_id': 4, 'job_state': ['PENDING'], 'reason': 'Resources'}]
+        job  = QueueInfoSlurm._parse_squeue_jobs(jobs)[0]
+        assert job['reason'] == 'Resources'
+
+
 # ---- _collect_allocations tests ---------------------------------------------
 
 class TestCollectAllocations:

--- a/tests/unittests/test_queue_info_pbs.py
+++ b/tests/unittests/test_queue_info_pbs.py
@@ -163,6 +163,56 @@ class TestCollectJobs:
         assert j['time_limit'] == 3600
 
 
+# ---------------------------------------------------------------------------
+# _render_job extra-fields (issue #40)
+# ---------------------------------------------------------------------------
+
+def test_render_job_surfaces_extra_fields():
+    info = {
+        'job_state'             : 'R',
+        'queue'                 : 'compute',
+        'Job_Owner'             : 'alice@login1',
+        'Job_Name'              : 'job1',
+        'Resource_List.nodect'  : '2',
+        'Resource_List.ncpus'   : '128',
+        'Resource_List.walltime': '01:00:00',
+        'Priority'              : '150',
+        'comment'               : 'Job run at some point',
+        'depend'                : 'afterok:99.x',
+        'Output_Path'           : 'login1:/home/alice/job.o1',
+        'Error_Path'            : 'login1:/home/alice/job.e1',
+        'Submit_arguments'      : 'run.sh',
+        'Exit_status'           : '0',
+        'Variable_List'         : 'PBS_O_HOME=/home/alice,'
+                                  'PBS_O_WORKDIR=/home/alice/work',
+        'resources_used.mem'    : '1048576kb',
+    }
+    j = QueueInfoPBSPro._render_job('1.x', info)
+    assert j['owner']      == 'alice@login1'
+    assert j['priority']   == 150
+    assert j['reason']     == 'Job run at some point'
+    assert j['dependency'] == 'afterok:99.x'
+    assert j['std_out']    == 'login1:/home/alice/job.o1'
+    assert j['std_err']    == 'login1:/home/alice/job.e1'
+    assert j['command']    == 'run.sh'
+    assert j['exit_code']  == 0
+    assert j['work_dir']   == '/home/alice/work'
+    assert j['mem_used']   == '1048576kb'
+
+
+def test_render_job_defaults_when_absent():
+    """qstat -f records missing the extra attributes degrade gracefully."""
+    info = {'job_state': 'Q', 'queue': 'compute'}
+    j = QueueInfoPBSPro._render_job('2.x', info)
+    assert j['owner']      == ''
+    assert j['priority']   == 0
+    assert j['reason']     == ''
+    assert j['dependency'] == ''
+    assert j['exit_code']  is None
+    assert j['work_dir']   == ''
+    assert j['mem_used']   == ''
+
+
 def test_collect_allocations_returns_empty_without_sbank():
     """When sbank-list-allocations is unavailable we degrade gracefully."""
     backend = QueueInfoPBSPro()


### PR DESCRIPTION
Closes #40. The queue_info backends already fetched rich per-job data from `squeue --json` / `qstat -f` but returned only a handful of fields, and the Explorer coloured only four job states (everything else grey).

## Backend — surface fields already fetched (no extra subprocess)
- **SLURM** (`_parse_squeue_jobs`): adds `reason`, `qos`, `dependency`, `std_out`/`std_err`, `work_dir`, `command`, `exit_code` (new `_exit_code` helper handling both SLURM JSON shapes), `array_job_id`/`array_task_id`, `tres_req`/`tres_alloc`, `restart_cnt` — all additive, defaulting when absent (older SLURM).
- **PBSPro** (`_render_job`): fills `priority` and adds `owner`, `reason`, `qos`, `dependency`, `std_out`/`std_err`, `work_dir`, `command`, `exit_code`, `mem_used`.

## Explorer (`queue_info.js`)
- One shared `jobStateBadge()` over the full SLURM/PBS state vocabulary (RUNNING/PENDING/COMPLETING/CONFIGURING/SUSPENDED/PREEMPTED/HELD/TIMEOUT/NODE_FAIL/DEADLINE/OUT_OF_MEMORY/CANCELLED/…) **replaces the four duplicated 4-state maps**, so terminal/abnormal states are no longer all grey.
- Job-detail overlays render the new fields conditionally (absent/`None` skipped).
- Removed dead `num_nodes`/`job_state` fallbacks the backend never emits.

## Docs
Refreshed `plugin_queue_info.rst` (was stale): documents `list_all_jobs`, `job_allocation`, `backend`, `cancel_job`, `nodelist`, the new job-detail fields, and adds a Client API section.

## Tests
SLURM parser extras (rich / absent / legacy-shape / plain-wrapper exit_code) + PBS render extras. **873 passed, 2 skipped**, flake8 clean.

Out of scope (left for #14): normalizing raw scheduler `state` strings through `batch_system.STATE_*` — this PR only broadens the badge map to recognise them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)