### PR TITLE
Fix #14: one canonical error envelope across runtime, broker, gateway, plugins

### DIFF
--- a/docs/source/rest_api.rst
+++ b/docs/source/rest_api.rst
@@ -393,14 +393,45 @@ All plugin endpoints return standard HTTP status codes:
 
 - ``200`` — Success
 - ``400`` — Bad request (missing/invalid parameters)
+- ``401`` — Missing or invalid broker token (ingress auth)
 - ``403`` — Session owned by another participant (cross-owner reattach)
 - ``404`` — Session, resource, or endpoint not found
 - ``409`` — Conflict (e.g. incoherent/conflicting session lifetime policy)
 - ``410`` — Session expired (TTL exceeded)
 - ``500`` — Internal server error
-- ``503`` — Broker at concurrency cap (too many in-flight calls)
+- ``502`` — Bad gateway (upstream participant returned an invalid response)
+- ``503`` — Broker/endpoint at concurrency cap (too many in-flight calls)
 - ``504`` — Upstream (participant) timeout
 
-Error body format::
+Error body format
+-----------------
 
-    {"detail": "human-readable error message"}
+Every synthesized error carries one canonical envelope::
+
+    {"error": true, "status_code": <int>, "detail": "human-readable message"}
+
+This is a superset of the older ``{"detail": ...}`` body: ``detail`` is always
+present (so existing consumers keep working), and ``error`` + ``status_code``
+are additive.  ``status_code`` mirrors the HTTP status on the wire, which is
+useful for clients that read the body without the transport status (e.g. the
+endpoint runtime tunnels an HTTP response over the WebSocket).
+
+The one exception is request-validation (``422``): FastAPI's structured
+validation body is preserved as-is and is *not* rewrapped in this envelope.
+
+Error status matrix
+-------------------
+
+===========  ===========================================================
+Status       Meaning
+===========  ===========================================================
+``400``      Bad request — missing or invalid parameters
+``401``      Missing or invalid broker token (ingress auth gate)
+``403``      Forbidden — permission denied / cross-owner session reattach
+``404``      Not found — session, resource, route, or endpoint
+``409``      Conflict — e.g. target already exists, incoherent lifetime
+``500``      Internal server error — unhandled handler exception
+``502``      Bad gateway — upstream participant returned an invalid response
+``503``      At concurrency cap — too many in-flight calls (with ``Retry-After``)
+``504``      Upstream timeout — participant handler exceeded the call deadline
+===========  ===========================================================

--- a/src/radical/orbit/broker.py
+++ b/src/radical/orbit/broker.py
@@ -44,7 +44,6 @@ re-registration is first-come after a restart.
 import asyncio
 import concurrent.futures
 import itertools
-import json
 import logging
 import os
 import signal
@@ -68,6 +67,7 @@ from . import utils
 
 from .broker_plugin_host import BrokerPluginHost
 from .broker_events      import EventRouter
+from .errors             import error_body, error_dict
 
 
 log = logging.getLogger("radical.orbit.broker")
@@ -584,8 +584,7 @@ class Broker:
         if not utils.tokens_match(token, self._token):
             return JSONResponse(
                 status_code=401,
-                content={"error": True, "status_code": 401,
-                         "detail": "missing or invalid broker token"})
+                content=error_dict(401, "missing or invalid broker token"))
         return await call_next(request)
 
     # ── /register ─────────────────────────────────────────────────────
@@ -841,8 +840,7 @@ class Broker:
         shape :meth:`_dispatch_to_host` wraps into a wire ``response``."""
         if self._plugin_host is None:
             return {'status': 503, 'headers': {},
-                    'body': json.dumps({"error": True,
-                                        "detail": "no broker host"}).encode()}
+                    'body': error_body(503, "no broker host")}
         query = ''
         if '?' in path:
             path, query = path.split('?', 1)
@@ -862,14 +860,12 @@ class Broker:
         except HTTPException as e:
             return {'status': e.status_code,
                     'headers': {'content-type': 'application/json'},
-                    'body': json.dumps({"error": True,
-                                        "detail": e.detail}).encode()}
+                    'body': error_body(e.status_code, e.detail)}
         except Exception as e:
             log.exception("[Broker] host dispatch failed: %s", e)
             return {'status': 500,
                     'headers': {'content-type': 'application/json'},
-                    'body': json.dumps({"error": True,
-                                        "detail": str(e)}).encode()}
+                    'body': error_body(500, str(e))}
 
     async def _host_broadcast(self, topic: str, data: dict) -> None:
         """``broadcast_fn`` handed to :class:`BrokerPluginHost`.
@@ -1132,8 +1128,7 @@ class Broker:
         out = protocol.Response(
             src=BROKER_NAME, dst=req_raw.get('src'), status=status,
             headers={'content-type': 'application/json'},
-            body=json.dumps({"error": True, "status_code": status,
-                             "detail": detail}).encode(),
+            body=error_body(status, detail),
             corr_id=req_raw.get('corr_id'))
         return protocol.pack_message(out, cap=self._frame_cap)
 

--- a/src/radical/orbit/client.py
+++ b/src/radical/orbit/client.py
@@ -39,7 +39,12 @@ def _raise(resp, context: str = '') -> None:
         parts = [f"HTTP {resp.status_code}"]
         if context: parts.append(context)
         if detail:  parts.append(detail)
-        raise RuntimeError(' — '.join(parts))
+        exc = RuntimeError(' — '.join(parts))
+        # Expose the HTTP status so callers can branch on it (the canonical
+        # error envelope carries it as ``status_code``; the wire status is the
+        # authoritative source here).
+        exc.status_code = resp.status_code
+        raise exc
 
 
 class PluginClient:

--- a/src/radical/orbit/data/orbit_explorer.html
+++ b/src/radical/orbit/data/orbit_explorer.html
@@ -1834,7 +1834,14 @@
             if (ok) return await apiFetch(path, { ...opts, _retried: true });
           }
           const t = await res.text();
-          const errMsg = `HTTP ${res.status}: ${t}`;
+          // Canonical error envelope is {"error":true,"status_code":N,"detail":".."}
+          // — surface the human message (`detail`), not the whole JSON blob.
+          // Fall back to the raw text if the body is not JSON or has no detail.
+          // `t` itself stays untouched for the stale-session heal path below.
+          let msg = t;
+          try { const j = JSON.parse(t); if (j && j.detail) msg = j.detail; }
+          catch (e) { /* not JSON — keep raw text */ }
+          const errMsg = `HTTP ${res.status}: ${msg}`;
 
           // Stale-session auto-recovery: a 410 (expired) or a 404 whose detail
           // is specifically "unknown session id" means the sid is dead — not

--- a/src/radical/orbit/errors.py
+++ b/src/radical/orbit/errors.py
@@ -1,0 +1,65 @@
+"""Canonical error envelope + exception-to-status mapping for ORBIT.
+
+Every boundary error-producer (endpoint runtime, broker, gateway, plugins)
+synthesizes its error bodies through the helpers here so they all carry one
+shape on the wire::
+
+    {"error": true, "status_code": <int>, "detail": "<str>"}
+
+This is a strict superset of the older ``{"detail": ...}`` body — ``detail``
+stays present at every site, so existing consumers (``client.py`` and external
+HTTP callers) keep working; ``error`` and ``status_code`` are additive.
+"""
+
+import json
+
+from typing import Dict, Optional
+
+
+# ── exception → HTTP status ────────────────────────────────────────────────
+# Boundary handlers translate a raised stdlib exception into an HTTP status via
+# this map (walking the type's MRO); anything unmapped is a 500.  Keep the
+# staging client's status→exception reversal in mind: FileExistsError→409,
+# FileNotFoundError→404, PermissionError→403, ValueError/NotADirectoryError→400
+# must stay exactly as below.
+EXC_STATUS: Dict[type, int] = {
+    FileNotFoundError:  404,
+    FileExistsError:    409,
+    PermissionError:    403,
+    NotADirectoryError: 400,
+    IsADirectoryError:  400,
+    ValueError:         400,
+    TimeoutError:       504,
+}
+
+
+def status_for(exc: BaseException) -> int:
+    """Return the HTTP status for *exc*, walking its MRO against ``EXC_STATUS``.
+
+    Falls back to 500 for any exception type not covered by the map.
+    """
+    for cls in type(exc).__mro__:
+        status = EXC_STATUS.get(cls)
+        if status is not None:
+            return status
+    return 500
+
+
+def error_dict(status: int, detail: str) -> dict:
+    """Return the canonical error envelope as a dict."""
+    return {"error": True, "status_code": status, "detail": detail}
+
+
+def error_body(status: int, detail: str) -> bytes:
+    """Return the canonical error envelope as JSON-encoded bytes."""
+    return json.dumps(error_dict(status, detail)).encode()
+
+
+def http_exception(exc: BaseException, status: Optional[int] = None):
+    """Wrap *exc* in a ``fastapi.HTTPException`` with a mapped status.
+
+    Convenience for plugin handlers: uses *status* when given, else
+    :func:`status_for`; the detail is ``str(exc)``.
+    """
+    from fastapi import HTTPException
+    return HTTPException(status or status_for(exc), str(exc))

--- a/src/radical/orbit/gateway.py
+++ b/src/radical/orbit/gateway.py
@@ -72,9 +72,11 @@ from fastapi.responses          import JSONResponse, FileResponse
 from fastapi.middleware.cors    import CORSMiddleware
 from starlette.middleware.base  import BaseHTTPMiddleware
 from starlette.responses        import StreamingResponse
+from starlette.exceptions       import HTTPException as StarletteHTTPException
 
 from . import utils
 from . import protocol
+from .errors        import error_dict
 from .queues        import BoundedDropOldestQueue
 from .runtime_client import unpack_response_dict
 
@@ -231,8 +233,7 @@ class Gateway:
         if not utils.tokens_match(self._request_token(request), self._token):
             return JSONResponse(
                 status_code=401,
-                content={"error": True, "status_code": 401,
-                         "detail": "missing or invalid broker token"})
+                content=error_dict(401, "missing or invalid broker token"))
         return await call_next(request)
 
     # ── event subscriptions (SSE fan-out) ─────────────────────────────
@@ -410,6 +411,22 @@ class Gateway:
             "/{endpoint_name}/{path:path}", self._route_proxy,
             methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
             tags=["Proxy"], summary="Proxy requests to endpoint plugins")
+        # Render the gateway's OWN raised HTTPExceptions in the canonical error
+        # envelope (FastAPI defaults to a bare ``{"detail": ...}``).  FastAPI's
+        # HTTPException subclasses the Starlette one, so this covers both.  Note:
+        # we deliberately do NOT handle RequestValidationError — that would
+        # flatten the structured 422 body — and proxied plugin responses are
+        # returned as ``Response`` objects (never raised), so they bypass this.
+        app.add_exception_handler(StarletteHTTPException,
+                                  self._http_exception_handler)
+
+    @staticmethod
+    async def _http_exception_handler(request: Request,
+                                      exc: StarletteHTTPException):
+        """Render a raised HTTPException as the canonical error envelope."""
+        return JSONResponse(error_dict(exc.status_code, exc.detail),
+                            status_code=exc.status_code,
+                            headers=getattr(exc, 'headers', None))
 
     # ── route handlers ────────────────────────────────────────────────
 

--- a/src/radical/orbit/plugin_staging.py
+++ b/src/radical/orbit/plugin_staging.py
@@ -16,6 +16,7 @@ from starlette.requests import Request
 from .plugin_base import Plugin
 from .plugin_session_base import PluginSession
 from .client import PluginClient
+from .errors import http_exception
 
 log = logging.getLogger("radical.orbit")
 
@@ -406,12 +407,11 @@ class PluginStaging(Plugin):
         try:
             result = await session.put_file(filename, content_b64, overwrite=overwrite)
             return result
-        except FileExistsError as e:
-            raise HTTPException(status_code=409, detail=str(e)) from e
-        except PermissionError as e:
-            raise HTTPException(status_code=403, detail=str(e)) from e
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
+        except (FileExistsError, PermissionError, ValueError) as e:
+            # status_for maps: FileExistsError→409, PermissionError→403,
+            # ValueError→400 (identical to the former hand-rolled ladder; the
+            # staging client reverses these codes).
+            raise http_exception(e) from e
 
     async def get_endpoint(self, request: Request) -> dict:
         """
@@ -438,12 +438,9 @@ class PluginStaging(Plugin):
         try:
             result = await session.get_file(filename)
             return result
-        except FileNotFoundError as e:
-            raise HTTPException(status_code=404, detail=str(e)) from e
-        except PermissionError as e:
-            raise HTTPException(status_code=403, detail=str(e)) from e
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
+        except (FileNotFoundError, PermissionError, ValueError) as e:
+            # FileNotFoundError→404, PermissionError→403, ValueError→400.
+            raise http_exception(e) from e
 
     async def list_endpoint(self, request: Request) -> dict:
         """
@@ -470,11 +467,8 @@ class PluginStaging(Plugin):
         try:
             result = await session.list_dir(path)
             return result
-        except FileNotFoundError as e:
-            raise HTTPException(status_code=404, detail=str(e)) from e
-        except NotADirectoryError as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
-        except PermissionError as e:
-            raise HTTPException(status_code=403, detail=str(e)) from e
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
+        except (FileNotFoundError, NotADirectoryError,
+                PermissionError, ValueError) as e:
+            # FileNotFoundError→404, NotADirectoryError→400, PermissionError→403,
+            # ValueError→400.
+            raise http_exception(e) from e

--- a/src/radical/orbit/runtime.py
+++ b/src/radical/orbit/runtime.py
@@ -64,6 +64,7 @@ from . import utils
 
 from .client            import PluginClient
 from .dispatch          import RequestShim, match_route
+from .errors            import error_body
 from .plugin_base       import Plugin
 from .plugin_host_base  import PluginHostBase
 from .runtime_client    import RuntimeResponse, _RuntimeHTTP
@@ -644,9 +645,7 @@ class EndpointRuntime(PluginHostBase):
                 req, 503,
                 headers={'content-type': 'application/json',
                          'retry-after': str(self._retry_after)},
-                body=_json.dumps({"error": True, "status_code": 503,
-                                  "detail": "endpoint at concurrency cap"
-                                  }).encode()))
+                body=error_body(503, "endpoint at concurrency cap")))
             return
         self._req_inflight += 1
         self._work_loop.create_task(self._serve_request(req))
@@ -663,15 +662,13 @@ class EndpointRuntime(PluginHostBase):
             self._emit(protocol.make_response(
                 req, 504,
                 headers={'content-type': 'application/json'},
-                body=_json.dumps({"error": True, "status_code": 504,
-                                  "detail": "handler timed out"
-                                  }).encode()))
+                body=error_body(504, "handler timed out")))
         except Exception as e:                             # pragma: no cover
             log.exception("[Runtime] request handling error: %s", e)
             self._emit(protocol.make_response(
                 req, 500,
                 headers={'content-type': 'application/json'},
-                body=_json.dumps({"error": True, "detail": str(e)}).encode()))
+                body=error_body(500, str(e))))
         finally:
             self._req_inflight -= 1
 
@@ -687,8 +684,7 @@ class EndpointRuntime(PluginHostBase):
         handler, path_params = match_route(self._direct_routes, req.method, path)
         if handler is None:
             return (404, {'content-type': 'application/json'},
-                    _json.dumps({"detail": f"No route: {req.method} {path}"
-                                 }).encode())
+                    error_body(404, f"No route: {req.method} {path}"))
         # Case-insensitive content-type lookup: a client may send
         # ``Content-Type`` and a plain dict ``.get('content-type')`` would miss.
         lower_headers = {k.lower(): v for k, v in (req.headers or {}).items()}
@@ -707,12 +703,11 @@ class EndpointRuntime(PluginHostBase):
             result = await handler(shim)
         except HTTPException as e:
             return (e.status_code, {'content-type': 'application/json'},
-                    _json.dumps({"detail": e.detail}).encode())
+                    error_body(e.status_code, e.detail))
         except Exception as e:
             log.exception("[Runtime] handler error: %s %s", req.method, path)
             return (500, {'content-type': 'application/json'},
-                    _json.dumps({"error": "endpoint-invoke-failed",
-                                 "detail": str(e)}).encode())
+                    error_body(500, str(e)))
         if hasattr(result, 'status_code'):
             return (result.status_code, dict(result.headers), bytes(result.body))
         return (200, {'content-type': 'application/json'},

--- a/tests/unittests/test_broker.py
+++ b/tests/unittests/test_broker.py
@@ -922,3 +922,18 @@ async def test_restart_sender_delivers_buffered_events(make_broker):
     finally:
         broker.registry.pop('e1', None)
         await broker.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# canonical error envelope (issue #14): _error_response carries the rich shape
+# ---------------------------------------------------------------------------
+
+def test_error_response_carries_rich_envelope(make_broker):
+    import json as _json
+    broker = make_broker()
+    packed = broker._error_response({'src': 'epX', 'corr_id': 'c1'},
+                                    404, 'no such route')
+    msg = protocol.parse_message(packed)
+    assert msg.status == 404
+    assert _json.loads(msg.body) == {"error": True, "status_code": 404,
+                                     "detail": "no such route"}

--- a/tests/unittests/test_errors.py
+++ b/tests/unittests/test_errors.py
@@ -1,0 +1,69 @@
+"""Tests for :mod:`radical.orbit.errors` — the canonical error envelope."""
+
+import json
+
+import pytest
+
+from radical.orbit import errors
+
+
+# ---------------------------------------------------------------------------
+# status_for: direct map, MRO lookup, default
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("exc, status", [
+    (FileNotFoundError('x'),  404),
+    (FileExistsError('x'),    409),
+    (PermissionError('x'),    403),
+    (NotADirectoryError('x'), 400),
+    (IsADirectoryError('x'),  400),
+    (ValueError('x'),         400),
+    (TimeoutError('x'),       504),
+])
+def test_status_for_direct_map(exc, status):
+    assert errors.status_for(exc) == status
+
+
+def test_status_for_subclass_mro_lookup():
+    # A subclass not itself in the map resolves via its MRO to the mapped base.
+    class MyValueError(ValueError):
+        pass
+
+    assert errors.status_for(MyValueError('boom')) == 400
+
+
+def test_status_for_default_is_500():
+    assert errors.status_for(RuntimeError('unmapped')) == 500
+    assert errors.status_for(KeyError('unmapped'))     == 500
+
+
+# ---------------------------------------------------------------------------
+# builders
+# ---------------------------------------------------------------------------
+
+def test_error_dict_shape():
+    d = errors.error_dict(404, 'not here')
+    assert d == {"error": True, "status_code": 404, "detail": "not here"}
+
+
+def test_error_body_is_json_bytes():
+    body = errors.error_body(503, 'at cap')
+    assert isinstance(body, bytes)
+    assert json.loads(body) == {"error": True, "status_code": 503,
+                                "detail": "at cap"}
+
+
+# ---------------------------------------------------------------------------
+# http_exception convenience
+# ---------------------------------------------------------------------------
+
+def test_http_exception_maps_status_and_detail():
+    exc = errors.http_exception(FileExistsError('dup'))
+    assert exc.status_code == 409
+    assert exc.detail      == 'dup'
+
+
+def test_http_exception_explicit_status_overrides_map():
+    exc = errors.http_exception(ValueError('bad'), status=422)
+    assert exc.status_code == 422
+    assert exc.detail      == 'bad'

--- a/tests/unittests/test_gateway.py
+++ b/tests/unittests/test_gateway.py
@@ -379,6 +379,19 @@ def test_proxy_unknown_endpoint_is_404(harness):
     assert r.status_code == 404
 
 
+def test_gateway_raised_httpexception_uses_rich_envelope(harness):
+    # A gateway-raised HTTPException (disconnecting the broker host is a 400)
+    # renders the canonical envelope, not FastAPI's bare {"detail": ...}.
+    make_broker, _ = harness
+    srv = make_broker()
+    r = httpx.post(srv.url + '/endpoint/disconnect/broker')
+    assert r.status_code == 400
+    body = r.json()
+    assert body['error']       is True
+    assert body['status_code'] == 400
+    assert 'broker' in body['detail'].lower()
+
+
 # ---------------------------------------------------------------------------
 # Long 504 deadline carried over (config value; not waited on)
 # ---------------------------------------------------------------------------

--- a/tests/unittests/test_runtime.py
+++ b/tests/unittests/test_runtime.py
@@ -313,6 +313,15 @@ def test_serve_and_call_plugin_end_to_end(harness):
     assert resp.status_code == 200
     assert resp.json() == {'pong': True}
 
+    # A served-request error carries the canonical rich envelope: an unknown
+    # route on the served plugin 404s with {"error", "status_code", "detail"}.
+    miss = b.call('epA', 'GET', '/echo_rt/does_not_exist')
+    assert miss.status_code == 404
+    body = miss.json()
+    assert body['error']       is True
+    assert body['status_code'] == 404
+    assert 'No route' in body['detail']
+
 
 # ---------------------------------------------------------------------------
 # pending-table timeout (and no leak: a later call still works)


### PR DESCRIPTION
Closes #14. Errors were synthesized in several competing shapes — bare `{"detail": …}`, `{"error": true, …}` with and without `status_code`, and `{"error": "<str>", …}`. This unifies on one canonical envelope everywhere.

## The canonical envelope (a strict superset)
```json
{"error": true, "status_code": <int>, "detail": "<human message>"}
```
`detail` is **always present**, so `client.py` and any external consumer keep working — `error` + `status_code` are purely additive (low breakage risk).

## Changes
- **`errors.py`** (new): `error_dict`/`error_body` builders, an exception→status map (`status_for`, MRO-walked, default 500), and an `http_exception()` helper.
- **`runtime.py`**: all six served-request error sites route through `error_body` (503/504 deduped; the no-route 404, bare-exception, HTTPException, and invoke-failed bodies now all carry `error` + `status_code`).
- **`broker.py`**: auth 401, the three `call_host` paths, and `_error_response` via the helpers (the `call_host` bodies that lacked `status_code` now have it).
- **`gateway.py`**: auth 401 via the helper, **plus** an `HTTPException` handler so the gateway's *own* raised errors render the canonical envelope instead of FastAPI's `{"detail"}`. `RequestValidationError` (422) is deliberately left structured; proxied plugin responses (returned, not raised) bypass the handler; SSE is unaffected.
- **`client.py`**: `_raise` attaches `.status_code` to the raised error. **Explorer `apiFetch`**: surfaces `.detail` (not the raw JSON blob) in toasts, while leaving the 404/410 stale-session heal path intact.
- **`plugin_staging.py`**: the three hand-rolled `except → HTTPException` ladders collapse onto `http_exception()`; the status codes are **provably identical** (409/404/403/400), so the staging client's status→exception reversal is unbroken.
- **`docs/rest_api.rst`**: canonical envelope + full error-status matrix (+ the 422 note).

## Scope
Status-**vocabulary** normalization (`batch_system.STATE_*` / raw scheduler states) is intentionally **out of scope** (per discussion).

## Tests
`test_errors.py` (map incl. MRO + default-500, both builders, `http_exception`); per-layer shape assertions in `test_runtime.py` / `test_broker.py` / `test_gateway.py`; staging tests unchanged (same codes). **913 passed, 2 skipped**, flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)