### PR TITLE
Fix #31: print a copy-paste broker-URL help line at startup

### DIFF
--- a/src/radical/orbit/broker.py
+++ b/src/radical/orbit/broker.py
@@ -515,12 +515,25 @@ class Broker:
 
     # ── run (uvicorn) ─────────────────────────────────────────────────
 
+    @staticmethod
+    def _url_announce_lines(url_forms: List[str], env_var: str) -> List[str]:
+        """Startup URL banner + a copy-paste help line.
+
+        Each advertised URL is the canonical FQDN/IP form and carries no
+        ``/register`` (the endpoint appends that); the help line exports the
+        env var endpoints and clients resolve the broker URL from.
+        """
+        lines = [f'[Broker] URL: {form}' for form in url_forms]
+        lines.append('[Broker] to connect an endpoint or client, run first:\n'
+                     f'    export {env_var}={url_forms[0]}')
+        return lines
+
     def run(self) -> None:
         """Start uvicorn.  Blocks until shutdown."""
         import uvicorn
 
-        for form in self._url_forms:
-            print(f'[Broker] URL: {form}', flush=True)
+        for line in self._url_announce_lines(self._url_forms, utils.ENV_URL):
+            print(line, flush=True)
         # Lifespan (startup/shutdown) is attached at FastAPI construction.
         # Never echo the token (CWE-532); report only its source/path.
         if not self._auth_enabled:

--- a/src/radical/orbit/broker.py
+++ b/src/radical/orbit/broker.py
@@ -524,8 +524,9 @@ class Broker:
         env var endpoints and clients resolve the broker URL from.
         """
         lines = [f'[Broker] URL: {form}' for form in url_forms]
-        lines.append('[Broker] to connect an endpoint or client, run first:\n'
-                     f'    export {env_var}={url_forms[0]}')
+        if url_forms:
+            lines.append('[Broker] to connect an endpoint or client, run first:')
+            lines.append(f'    export {env_var}={url_forms[0]}')
         return lines
 
     def run(self) -> None:

--- a/tests/unittests/test_broker.py
+++ b/tests/unittests/test_broker.py
@@ -972,3 +972,9 @@ def test_broker_url_announce_has_export_help_and_no_register():
     # every advertised form is printed
     assert 'https://host.example.org:8000' in text
     assert 'https://10.0.0.5:8000'         in text
+
+
+def test_broker_url_announce_empty_forms_no_crash():
+    # Guard: an empty url_forms must not IndexError on url_forms[0].
+    from radical.orbit.broker import Broker
+    assert Broker._url_announce_lines([], 'RADICAL_ORBIT_BROKER_URL') == []

--- a/tests/unittests/test_broker.py
+++ b/tests/unittests/test_broker.py
@@ -958,3 +958,17 @@ async def test_disconnect_sends_terminate_control(make_broker):
         assert broker.registry.get('e1') is None          # removed from routing
     finally:
         await broker.shutdown()
+
+
+def test_broker_url_announce_has_export_help_and_no_register():
+    from radical.orbit.broker import Broker
+    forms = ['https://host.example.org:8000', 'https://10.0.0.5:8000']
+    lines = Broker._url_announce_lines(forms, 'RADICAL_ORBIT_BROKER_URL')
+    text  = '\n'.join(lines)
+    # copy-paste help exports the env var with the canonical (first) form
+    assert 'export RADICAL_ORBIT_BROKER_URL=https://host.example.org:8000' in text
+    # advertised URLs carry no /register (the endpoint appends it itself)
+    assert '/register' not in text
+    # every advertised form is printed
+    assert 'https://host.example.org:8000' in text
+    assert 'https://10.0.0.5:8000'         in text


### PR DESCRIPTION
Closes #31. The broker already advertises its URL form(s) at startup — the **canonical FQDN/IP** form, **without** `/register` (the endpoint appends that) — via `utils.public_url_forms`. The gap was that it printed no guidance on using them.

Adds a copy-paste help line at startup:
```
[Broker] URL: https://<fqdn>:8000
[Broker] URL: https://<ipv4>:8000
[Broker] to connect an endpoint or client, run first:
    export RADICAL_ORBIT_BROKER_URL=https://<fqdn>:8000
```
The advertise + help lines are factored into a testable `Broker._url_announce_lines()`; the test asserts the export line uses `RADICAL_ORBIT_BROKER_URL` with the canonical form and that no advertised URL contains `/register`. (All three of the issue's points — env-var help line, no `/register`, IP/FQDN not localhost — hold.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)