### PR TITLE
Eliminate the 'bridge' legacy: 'edge'→'endpoint' terminology + remove backward-compat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,10 +59,7 @@ read it from the file. Resolution
 no config; for a remote broker, copy the token or set the env var. The Explorer
 prompts for it and then rides an HttpOnly cookie minted by `POST /auth`. Disable
 the gate for local dev with `--no-auth` (or `RADICAL_ORBIT_BROKER_NO_AUTH=1`).
-The `BROKER`-named env var and the `broker.token` file each fall back to their
-pre-rename `RADICAL_ORBIT_BRIDGE_TOKEN` / `bridge.token` predecessor when the
-`BROKER` name is unset/absent, so tokens configured before the rename keep
-authenticating; only `broker.token` is ever written. Helpers live in `utils.py`
+Helpers live in `utils.py`
 (`resolve_broker_token`, `ensure_broker_token`, `auth_disabled`, `tokens_match`);
 the broker core gates the WS `/register` handshake (`Broker._auth_dispatch`) and
 the gateway gates HTTP ingress (`Gateway._auth_dispatch`, minting the `/auth`

--- a/docs/source/machine_guide.rst
+++ b/docs/source/machine_guide.rst
@@ -69,7 +69,10 @@ No endpoint is required — the broker talks to the facility's IRI service direc
 2. Connect and use the per-endpoint instance client (see
    :ref:`Plugin: iri <plugin_iri>` for the full API)::
 
-      iri   = broker.get_plugin("iri_connect")
+      from radical.orbit import EndpointRuntime
+
+      rt    = EndpointRuntime(broker_url="https://my-broker:8000").start()
+      iri   = rt.get_plugin("broker", "iri_connect")
       nersc = iri.connect("nersc", token="<token>")
       print(nersc.list_resources("compute"))
 

--- a/docs/source/machine_guide.rst
+++ b/docs/source/machine_guide.rst
@@ -16,12 +16,12 @@ each provided by a plugin.  A given workflow may use one or several:
      - What it does
      - Plugin
    * - **PsiJ**
-     - Submit and monitor *batch jobs* on the machine, through an ORBIT edge
+     - Submit and monitor *batch jobs* on the machine, through an ORBIT endpoint
        running on that machine's login/compute node.
      - :ref:`psij <rest_api>`
    * - **IRI**
      - Drive the facility's *IRI REST API* (resources, jobs, incidents,
-       allocations) — no edge on the machine required.
+       allocations) — no endpoint on the machine required.
      - :ref:`iri <plugin_iri>`
    * - **Globus**
      - Move *data* between facility collections, out of band.
@@ -30,25 +30,25 @@ each provided by a plugin.  A given workflow may use one or several:
 This guide shows how to set each one up, then gives per-facility notes.
 
 
-PsiJ — batch jobs via an edge
-=============================
+PsiJ — batch jobs via an endpoint
+=================================
 
-1. Start the bridge somewhere reachable from the machine (see the
+1. Start the broker somewhere reachable from the machine (see the
    *Getting Started* guide), and copy its URL (and, for HTTPS, its
    certificate and auth token) to the machine.
-2. On the machine's login node, start an edge::
+2. On the machine's login node, start an endpoint::
 
-      radical-orbit-endpoint --url https://<bridge-host>:8000 \
-                             --cert bridge_cert.pem
+      radical-orbit-endpoint --url https://<broker-host>:8000 \
+                             --cert broker_cert.pem
 
-   The edge auto-detects the batch system (SLURM ``squeue`` / PBSPro
+   The endpoint auto-detects the batch system (SLURM ``squeue`` / PBSPro
    ``qstat``) and loads the ``psij`` and ``queue_info`` plugins.
 3. Submit jobs through the ``psij`` client
    (``submit_job`` / ``get_job_status`` / ``cancel_job``).
 
-**Firewalled compute nodes.**  When the edge must run on a compute node that
-cannot open a direct socket to the bridge, ``submit_tunneled`` launches a child
-edge with an SSH tunnel.  Pick the mode that matches the site's SSH policy:
+**Firewalled compute nodes.**  When the endpoint must run on a compute node that
+cannot open a direct socket to the broker, ``submit_tunneled`` launches a child
+endpoint with an SSH tunnel.  Pick the mode that matches the site's SSH policy:
 
 * ``forward`` — the child opens ``ssh -L`` from compute to the login host.
   Use where **compute → login SSH is allowed** and login → compute is blocked
@@ -62,18 +62,18 @@ edge with an SSH tunnel.  Pick the mode that matches the site's SSH policy:
 IRI — facility REST API
 =======================
 
-No edge is required — the bridge talks to the facility's IRI service directly.
+No endpoint is required — the broker talks to the facility's IRI service directly.
 
 1. Obtain a facility access token (NERSC uses Globus, OLCF uses S3M — see the
    per-facility notes below).
 2. Connect and use the per-endpoint instance client (see
    :ref:`Plugin: iri <plugin_iri>` for the full API)::
 
-      iri   = bridge.get_plugin("iri_connect")
+      iri   = broker.get_plugin("iri_connect")
       nersc = iri.connect("nersc", token="<token>")
       print(nersc.list_resources("compute"))
 
-The token lives only in bridge process memory and is dropped on
+The token lives only in broker process memory and is dropped on
 ``disconnect``.
 
 

--- a/docs/source/plugin_iri.rst
+++ b/docs/source/plugin_iri.rst
@@ -14,7 +14,7 @@ plugin/client model as every other ORBIT plugin.
 It comes in two cooperating parts:
 
 ``iri_connect``
-   A **bridge-side** configurator.  It lists the known IRI facility endpoints
+   A **broker-side** configurator.  It lists the known IRI facility endpoints
    and, on ``connect()``, dynamically registers a per-endpoint instance
    plugin named ``iri.<endpoint>`` (e.g. ``iri.nersc``) that then appears as a
    first-class node in the Explorer tree.
@@ -53,7 +53,7 @@ Authentication
 ==============
 
 A facility access token is supplied at ``connect`` time.  The token is held in
-**bridge process memory** (inside the instance's HTTP client) for the lifetime
+**broker process memory** (inside the instance's HTTP client) for the lifetime
 of the ``iri.<endpoint>`` instance and is **never written to disk**.
 Disconnecting removes the instance and drops the token.
 
@@ -122,11 +122,10 @@ Usage
 
 .. code-block:: python
 
-   from radical.orbit.client import BridgeClient
+   from radical.orbit import EndpointRuntime
 
-   client = BridgeClient(url="https://my-bridge:8000")
-   bridge = client.get_endpoint_client("bridge")   # iri_connect is bridge-hosted
-   iri    = bridge.get_plugin("iri_connect")
+   rt  = EndpointRuntime(broker_url="https://my-broker:8000")
+   iri = rt.get_plugin("broker", "iri_connect")   # iri_connect is broker-hosted
 
    # discover facilities, then connect (token from your facility login flow)
    print(iri.list_endpoints())

--- a/docs/source/plugin_iri.rst
+++ b/docs/source/plugin_iri.rst
@@ -124,7 +124,7 @@ Usage
 
    from radical.orbit import EndpointRuntime
 
-   rt  = EndpointRuntime(broker_url="https://my-broker:8000")
+   rt  = EndpointRuntime(broker_url="https://my-broker:8000").start()
    iri = rt.get_plugin("broker", "iri_connect")   # iri_connect is broker-hosted
 
    # discover facilities, then connect (token from your facility login flow)

--- a/src/radical/orbit/runtime.py
+++ b/src/radical/orbit/runtime.py
@@ -796,7 +796,8 @@ class EndpointRuntime(PluginHostBase):
                           with_meta: bool = False) -> None:
         """Register an event callback and auto-``subscribe`` for its pattern.
 
-        Tuple semantics: ``None`` is a wildcard; filtering happens at the edge.
+        Tuple semantics: ``None`` is a wildcard; filtering happens at the
+        boundary.
 
         By default the callback is invoked as
         ``callback(endpoint, plugin, topic, data)``.  With *with_meta* it is

--- a/src/radical/orbit/utils.py
+++ b/src/radical/orbit/utils.py
@@ -32,10 +32,7 @@ from typing  import Any, Dict, List, Optional, Tuple
 #    ~/.radical/orbit/broker_cert.pem
 #    ~/.radical/orbit/broker_key.pem
 #
-#  Precedence (consumer side): CLI arg > env var > file > error.  Each env var
-#  and file also silently falls back to its ``BRIDGE`` predecessor when the
-#  ``BROKER`` name is unset/absent, so deployments configured before the rename
-#  keep working; only the ``BROKER`` names are ever written.
+#  Precedence (consumer side): CLI arg > env var > file > error.
 #
 #  The broker process itself does NOT consume a URL — it derives its
 #  advertised URL from its own (host, port).  ``broker.url`` is a write-
@@ -49,31 +46,16 @@ CERT_FILE    = DEFAULT_DIR / 'broker_cert.pem'
 KEY_FILE     = DEFAULT_DIR / 'broker_key.pem'
 TOKEN_FILE   = DEFAULT_DIR / 'broker.token'
 
-# Predecessor file names — read as a fallback when the broker-named file is
-# absent, so deployments configured before the rename keep working.
-URL_FILE_LEGACY   = DEFAULT_DIR / 'bridge.url'
-CERT_FILE_LEGACY  = DEFAULT_DIR / 'bridge_cert.pem'
-KEY_FILE_LEGACY   = DEFAULT_DIR / 'bridge_key.pem'
-TOKEN_FILE_LEGACY = DEFAULT_DIR / 'bridge.token'
-
 ENV_URL      = 'RADICAL_ORBIT_BROKER_URL'
 ENV_CERT     = 'RADICAL_ORBIT_BROKER_CERT'
 ENV_KEY      = 'RADICAL_ORBIT_BROKER_KEY'
 ENV_TOKEN    = 'RADICAL_ORBIT_BROKER_TOKEN'
 ENV_NO_AUTH  = 'RADICAL_ORBIT_BROKER_NO_AUTH'
 
-# Predecessor env vars — read as a silent fallback when the broker-named var
-# is unset.
-ENV_URL_LEGACY     = 'RADICAL_ORBIT_BRIDGE_URL'
-ENV_CERT_LEGACY    = 'RADICAL_ORBIT_BRIDGE_CERT'
-ENV_KEY_LEGACY     = 'RADICAL_ORBIT_BRIDGE_KEY'
-ENV_TOKEN_LEGACY   = 'RADICAL_ORBIT_BRIDGE_TOKEN'
-ENV_NO_AUTH_LEGACY = 'RADICAL_ORBIT_BRIDGE_NO_AUTH'
 
-
-def _env(new: str, legacy: str) -> str:
-    """Read env var *new*, falling back silently to its *legacy* predecessor."""
-    return (os.environ.get(new, '') or os.environ.get(legacy, '')).strip()
+def _env(name: str) -> str:
+    """Read env var *name*, stripped of surrounding whitespace."""
+    return os.environ.get(name, '').strip()
 
 
 # Cookie the browser/SSE path carries (set by the broker's POST /auth).  The
@@ -94,13 +76,7 @@ def _read_url_file(path: Optional[Path] = None) -> Optional[str]:
     try:
         text = path.read_text().strip()
     except FileNotFoundError:
-        if path == URL_FILE and URL_FILE_LEGACY.exists():
-            try:
-                text = URL_FILE_LEGACY.read_text().strip()
-            except FileNotFoundError:
-                return None
-        else:
-            return None
+        return None
     return text or None
 
 
@@ -199,7 +175,7 @@ def resolve_broker_url(cli: Optional[str] = None) -> Tuple[str, str]:
     """
     if cli:
         return cli.strip().rstrip('/'), 'cli'
-    env_url = _env(ENV_URL, ENV_URL_LEGACY)
+    env_url = _env(ENV_URL)
     if env_url:
         return env_url.rstrip('/'), 'env'
     file_url = _read_url_file()
@@ -210,28 +186,19 @@ def resolve_broker_url(cli: Optional[str] = None) -> Tuple[str, str]:
 
 
 def _resolve_path_value(cli: Optional[str], env_var: str,
-                        file_path: Path, *,
-                        env_legacy: Optional[str]  = None,
-                        file_legacy: Optional[Path] = None
-                        ) -> Tuple[Optional[Path], str]:
+                        file_path: Path) -> Tuple[Optional[Path], str]:
     """CLI > env > file precedence for a filesystem path.
 
     ``~`` is expanded: the shell does not expand it after ``--cert=`` /
-    ``--key=`` or inside env vars, so the tool must.  *env_legacy* /
-    *file_legacy* are the pre-rename predecessor names, consulted as a
-    silent fallback when the primary is unset/absent.
+    ``--key=`` or inside env vars, so the tool must.
     """
     if cli:
         return Path(cli).expanduser(), 'cli'
     env_val = os.environ.get(env_var, '').strip()
-    if not env_val and env_legacy:
-        env_val = os.environ.get(env_legacy, '').strip()
     if env_val:
         return Path(env_val).expanduser(), 'env'
     if file_path.exists():
         return file_path, 'file'
-    if file_legacy is not None and file_legacy.exists():
-        return file_legacy, 'file'
     return None, ''
 
 
@@ -251,12 +218,10 @@ def resolve_broker_cert(cli: Optional[str] = None) -> Tuple[Path, str]:
     yields a path, ``FileNotFoundError`` if the path does not exist,
     ``ssl.SSLError`` if the file is not a valid cert.
     """
-    path, source = _resolve_path_value(cli, ENV_CERT, CERT_FILE,
-                                       env_legacy=ENV_CERT_LEGACY,
-                                       file_legacy=CERT_FILE_LEGACY)
+    path, source = _resolve_path_value(cli, ENV_CERT, CERT_FILE)
     if path is None:
         raise ValueError(f"TLS cert required (no CLI arg, ${ENV_CERT} unset, "
-                         f"no file at {CERT_FILE} or {CERT_FILE_LEGACY})")
+                         f"no file at {CERT_FILE})")
     if not path.exists():
         raise FileNotFoundError(f"TLS cert not found: {path}")
     ctx = ssl.create_default_context()
@@ -277,13 +242,11 @@ def resolve_broker_key(cli: Optional[str] = None, *,
 
     Returns ``(path, source)``.
     """
-    path, source = _resolve_path_value(cli, ENV_KEY, KEY_FILE,
-                                       env_legacy=ENV_KEY_LEGACY,
-                                       file_legacy=KEY_FILE_LEGACY)
+    path, source = _resolve_path_value(cli, ENV_KEY, KEY_FILE)
     if path is None:
         raise ValueError(
             f"TLS key required for role='broker' (no CLI arg, "
-            f"${ENV_KEY} unset, no file at {KEY_FILE} or {KEY_FILE_LEGACY})")
+            f"${ENV_KEY} unset, no file at {KEY_FILE})")
     if not path.exists():
         raise FileNotFoundError(f"TLS key not found: {path}")
 
@@ -317,10 +280,7 @@ def resolve_broker_key(cli: Optional[str] = None, *,
 #  Consumer precedence (endpoint / client): CLI > env > file.  A missing token
 #  is *not* an error on the consumer side — the broker may run with auth off.
 #  The broker itself uses ``ensure_broker_token``, which generates and writes a
-#  token when none is configured.  Both the env var and the file fall back to
-#  their pre-rename ``BRIDGE`` predecessors when the ``BROKER`` name is
-#  unset/absent, so an existing token keeps authenticating; only the
-#  ``broker.token`` file is ever written.
+#  token when none is configured.
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _read_token_file(path: Optional[Path] = None) -> Optional[str]:
@@ -336,13 +296,7 @@ def _read_token_file(path: Optional[Path] = None) -> Optional[str]:
     try:
         text = path.read_text().strip()
     except FileNotFoundError:
-        if path == TOKEN_FILE and TOKEN_FILE_LEGACY.exists():
-            try:
-                text = TOKEN_FILE_LEGACY.read_text().strip()
-            except FileNotFoundError:
-                return None
-        else:
-            return None
+        return None
     return text or None
 
 
@@ -373,7 +327,7 @@ def resolve_broker_token(cli: Optional[str] = None) -> Tuple[Optional[str], str]
     """
     if cli:
         return cli.strip(), 'cli'
-    env_tok = _env(ENV_TOKEN, ENV_TOKEN_LEGACY)
+    env_tok = _env(ENV_TOKEN)
     if env_tok:
         return env_tok, 'env'
     file_tok = _read_token_file()
@@ -390,7 +344,7 @@ def auth_disabled(cli_no_auth: bool = False) -> bool:
     """
     if cli_no_auth:
         return True
-    return _env(ENV_NO_AUTH, ENV_NO_AUTH_LEGACY).lower() in ('1', 'true', 'yes')
+    return _env(ENV_NO_AUTH).lower() in ('1', 'true', 'yes')
 
 
 def ensure_broker_token(cli: Optional[str] = None) -> Tuple[str, str]:

--- a/tests/unittests/test_resolve_broker.py
+++ b/tests/unittests/test_resolve_broker.py
@@ -31,13 +31,7 @@ def isolated_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(utils, 'URL_FILE',  tmp_path / 'broker.url')
     monkeypatch.setattr(utils, 'CERT_FILE', tmp_path / 'broker_cert.pem')
     monkeypatch.setattr(utils, 'KEY_FILE',  tmp_path / 'broker_key.pem')
-    # Neutralize the pre-rename predecessor files so a developer's real
-    # ``~/.radical/orbit/bridge.*`` cannot leak in via the fallback path.
-    monkeypatch.setattr(utils, 'URL_FILE_LEGACY',  tmp_path / 'bridge.url')
-    monkeypatch.setattr(utils, 'CERT_FILE_LEGACY', tmp_path / 'bridge_cert.pem')
-    monkeypatch.setattr(utils, 'KEY_FILE_LEGACY',  tmp_path / 'bridge_key.pem')
-    for v in (utils.ENV_URL, utils.ENV_CERT, utils.ENV_KEY,
-              utils.ENV_URL_LEGACY, utils.ENV_CERT_LEGACY, utils.ENV_KEY_LEGACY):
+    for v in (utils.ENV_URL, utils.ENV_CERT, utils.ENV_KEY):
         monkeypatch.delenv(v, raising=False)
     yield tmp_path
 
@@ -113,26 +107,6 @@ def test_url_errors_when_unconfigured(isolated_dir):
     """Nothing set anywhere → ValueError."""
     with pytest.raises(ValueError, match='Broker URL required'):
         utils.resolve_broker_url()
-
-
-def test_url_legacy_env_fallback(isolated_dir, monkeypatch):
-    """The pre-rename ``BRIDGE`` env var resolves when the ``BROKER`` one is unset."""
-    monkeypatch.setenv(utils.ENV_URL_LEGACY, 'https://from-legacy:8000')
-    url, src = utils.resolve_broker_url()
-    assert url == 'https://from-legacy:8000'
-    assert src == 'env'
-    # The broker-named var wins when both are set.
-    monkeypatch.setenv(utils.ENV_URL, 'https://from-new:8000')
-    url, _ = utils.resolve_broker_url()
-    assert url == 'https://from-new:8000'
-
-
-def test_url_legacy_file_fallback(isolated_dir):
-    """The pre-rename ``bridge.url`` file is read when ``broker.url`` is absent."""
-    (isolated_dir / 'bridge.url').write_text('https://from-legacy-file:8000\n')
-    url, src = utils.resolve_broker_url()
-    assert url == 'https://from-legacy-file:8000'
-    assert src == 'file'
 
 
 # ---------------------------------------------------------------------------
@@ -232,29 +206,17 @@ def test_cert_file_fallback(isolated_dir, self_signed):
     assert src == 'file'
 
 
-def test_cert_legacy_file_fallback(isolated_dir, self_signed):
-    """The pre-rename ``bridge_cert.pem`` is read when ``broker_cert.pem`` is absent."""
-    cert, _ = self_signed
-    (isolated_dir / 'bridge_cert.pem').write_bytes(cert.read_bytes())
-
-    path, src = utils.resolve_broker_cert()
-    assert path == isolated_dir / 'bridge_cert.pem'
-    assert src == 'file'
-
-
 def test_cert_missing_everywhere_raises(isolated_dir):
     """Nothing configured → ValueError."""
     with pytest.raises(ValueError, match='TLS cert required'):
         utils.resolve_broker_cert()
 
 
-def test_cert_missing_error_names_both_checked_paths(isolated_dir):
-    """The TLS-cert error names BOTH the broker file and the legacy fallback."""
+def test_cert_missing_error_names_broker_file(isolated_dir):
+    """The TLS-cert error names the broker cert file."""
     with pytest.raises(ValueError) as ei:
         utils.resolve_broker_cert()
-    msg = str(ei.value)
-    assert str(utils.CERT_FILE)        in msg
-    assert str(utils.CERT_FILE_LEGACY) in msg
+    assert str(utils.CERT_FILE) in str(ei.value)
 
 
 def test_cert_path_set_but_file_missing(isolated_dir, monkeypatch):
@@ -294,13 +256,11 @@ def test_key_with_cert_validates_pair(isolated_dir, self_signed, monkeypatch):
     assert path == key
 
 
-def test_key_missing_error_names_both_checked_paths(isolated_dir):
-    """The TLS-key error names BOTH the broker file and the legacy fallback."""
+def test_key_missing_error_names_broker_file(isolated_dir):
+    """The TLS-key error names the broker key file."""
     with pytest.raises(ValueError) as ei:
         utils.resolve_broker_key()
-    msg = str(ei.value)
-    assert str(utils.KEY_FILE)        in msg
-    assert str(utils.KEY_FILE_LEGACY) in msg
+    assert str(utils.KEY_FILE) in str(ei.value)
 
 
 def test_key_refuses_world_readable(isolated_dir, self_signed, monkeypatch):

--- a/tests/unittests/test_utils_token.py
+++ b/tests/unittests/test_utils_token.py
@@ -9,13 +9,8 @@ from radical.orbit import utils
 def _isolate_token(tmp_path, monkeypatch):
     """Redirect the token file and clear the env so tests are hermetic."""
     monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'broker.token')
-    # Redirect the pre-rename predecessor file into the tmp dir too so a
-    # developer's real ``~/.radical/orbit/bridge.token`` cannot leak in.
-    monkeypatch.setattr(utils, 'TOKEN_FILE_LEGACY', tmp_path / 'bridge.token')
-    monkeypatch.delenv(utils.ENV_TOKEN,          raising=False)
-    monkeypatch.delenv(utils.ENV_NO_AUTH,        raising=False)
-    monkeypatch.delenv(utils.ENV_TOKEN_LEGACY,   raising=False)
-    monkeypatch.delenv(utils.ENV_NO_AUTH_LEGACY, raising=False)
+    monkeypatch.delenv(utils.ENV_TOKEN,   raising=False)
+    monkeypatch.delenv(utils.ENV_NO_AUTH, raising=False)
     return tmp_path
 
 
@@ -73,28 +68,3 @@ def test_tokens_match():
     assert utils.tokens_match(123,   'abc') is False
     assert utils.tokens_match('abc', 123)   is False
     assert utils.tokens_match(True,  'abc') is False
-
-
-def test_legacy_env_fallback(_isolate_token, monkeypatch):
-    # The broker-named var is unset; the pre-rename predecessor still resolves.
-    monkeypatch.setenv(utils.ENV_TOKEN_LEGACY, 'legacytok')
-    assert utils.resolve_broker_token() == ('legacytok', 'env')
-    # The broker-named var takes precedence when both are set.
-    monkeypatch.setenv(utils.ENV_TOKEN, 'newtok')
-    assert utils.resolve_broker_token() == ('newtok', 'env')
-
-
-def test_legacy_file_fallback(_isolate_token):
-    # Only the predecessor file exists — it is read as a fallback.
-    utils.write_broker_token_file('legacyfiletok', path=utils.TOKEN_FILE_LEGACY)
-    assert utils.resolve_broker_token() == ('legacyfiletok', 'file')
-    # ``ensure`` picks up the predecessor file rather than regenerating, and
-    # never writes a bridge-named file.
-    tok, src = utils.ensure_broker_token()
-    assert (tok, src) == ('legacyfiletok', 'file')
-    assert not utils.TOKEN_FILE.exists()
-
-
-def test_legacy_no_auth_fallback(_isolate_token, monkeypatch):
-    monkeypatch.setenv(utils.ENV_NO_AUTH_LEGACY, '1')
-    assert utils.auth_disabled() is True


### PR DESCRIPTION
Eliminates the pre-rename **`bridge`** legacy entirely and finishes the `edge`→`endpoint` terminology pass.

## `edge` → `endpoint`
`machine_guide.rst` ("an ORBIT edge" / "start an edge" …) and the `runtime.py` "at the edge" idiom → `endpoint`/`boundary`. **Zero** `edge` occurrences remain in live surfaces.

## `bridge` removed — terminology **and** backward-compat
- **Docs:** `machine_guide.rst` and `plugin_iri.rst` `bridge`→`broker`; the `plugin_iri.rst` Usage example was **broken** (non-existent `BridgeClient`/`get_endpoint_client`) and is rewritten against the real `EndpointRuntime` API.
- **Code (no backward compat):** `utils.py` no longer consults the pre-rename `bridge`-named env vars/files — removed the `*_FILE_LEGACY`/`ENV_*_LEGACY` constants, the `_env()` legacy fallback, the URL/token legacy-file branches, and the `_resolve_path_value` legacy params. Only the `broker`-named names remain. Corresponding legacy-fallback tests trimmed; the CLAUDE.md note removed.

## Review fixes (gemini)
Both IRI examples now `EndpointRuntime(broker_url=...).start()` (topology populated) + `rt.get_plugin("broker", "iri_connect")` (two args).

**Left as-is:** the `plans/` historical design ledgers (period record of the old `src/radical/edge/` layout).

Suite **907 passed / 2 skipped**, flake8 clean; `grep bridge src/ bin/` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)