### PR TITLE
Fix #97: add EndpointRuntime.wait_for_listener()

### DIFF
--- a/src/radical/orbit/runtime.py
+++ b/src/radical/orbit/runtime.py
@@ -332,6 +332,16 @@ class EndpointRuntime(PluginHostBase):
         """Block until the first ``register_ack`` arrives; ``True`` on success."""
         return self._registered.wait(timeout=timeout)
 
+    def wait_for_listener(self, timeout: float = 30.0) -> bool:
+        """Block until event delivery is live; ``True`` on success.
+
+        Events flow over the registered WS, so "listener connected" is
+        registration.  Plugin clients call this on their ``broker_client``
+        before a POST whose response they must not race (e.g.
+        ``register_session`` waiting on a ``session_status`` notification).
+        """
+        return self.wait_registered(timeout=timeout)
+
     def stop(self) -> None:
         """Clean-close the WS (broker treats a clean close as immediate
         removal) and tear down loops + threads."""

--- a/tests/unittests/test_runtime.py
+++ b/tests/unittests/test_runtime.py
@@ -246,6 +246,10 @@ def test_register_ack_and_auto_named_consumer(harness):
     assert rt.resume_key                            # minted, non-empty
     assert rt._role() == 'consumer'
     assert _wait(lambda: rt.name in srv.broker.registry)
+    # plugin clients gate event-raced POSTs on their broker_client's
+    # wait_for_listener (e.g. RhapsodyClient.register_session); on the
+    # runtime that is registration
+    assert rt.wait_for_listener(timeout=5.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #97.

## Problem

`RhapsodyClient.register_session()` gates its POST on `broker_client.wait_for_listener()` so it cannot miss a fast `session_status` notification. Through the Python SDK the `broker_client` is the `EndpointRuntime` itself (passed by `get_plugin(..., broker_client=runtime)`), which lacked that method:

```
AttributeError: 'EndpointRuntime' object has no attribute 'wait_for_listener'
```

Uncovered by the rhapsody `OrbitExecutionBackend` update.

## Fix

Add `EndpointRuntime.wait_for_listener()` delegating to `wait_registered()`. For a WS participant, event delivery is live once registration completes: notification callbacks and the plugin POST ride the same ordered WebSocket, so there is no subscribe/event race.

## Testing

- `tests/unittests/`: 903 passed, 3 skipped (radical.pilot not installed locally)
- `flake8 src/ bin/`: no findings on changed files
- New assertion in `test_register_ack_and_auto_named_consumer` covers the SDK path

🤖 Generated with [Claude Code](https://claude.com/claude-code)