### PR TITLE
usability: read-only config surface + embedded broker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,24 +47,47 @@ For HTTPS, generate a self-signed cert first:
 openssl req -x509 -newkey rsa:4096 -nodes -keyout key.pem -out cert.pem -days 365 -subj "/CN=localhost"
 ```
 
+### Embedded broker
+
+A consumer client can host the full broker (routing + hosted plugins +
+gateway) inside its own process instead of connecting out:
+`EndpointRuntime(embedded=True)` (implementation: `embedded.py`,
+`EmbeddedBroker`). The embedded broker binds port 8000 (falls back to an
+ephemeral port with a warning when taken), uses the same operator-placed
+cert/key/token as a standalone broker, and never writes under
+`~/.radical/orbit`. Remote endpoints connect to `rt.broker_url` exactly as
+they would to a standalone broker; `submit_tunneled` children inherit that
+URL automatically. `embedded=True` skips URL resolution entirely (an ambient
+`$RADICAL_ORBIT_BROKER_URL` is ignored); combining it with an explicit
+`broker_url` raises. For host/port/auth/plugin control, construct
+`EmbeddedBroker` directly and pass `broker_url=eb.url`. The standalone
+`radical-orbit-broker.py` remains the deployment for shared, multi-client
+brokers.
+
 ### Ingress auth token
 
 The broker gates its HTTP ingress and the endpoint `/register` handshake with a
-**shared bearer token**. On first start it generates one and writes it to
-`~/.radical/orbit/broker.token` (0600); the token value is **never** printed to
-stdout (only its source/path), so it can't leak into captured logs (CWE-532) —
-read it from the file. Resolution
-(client/endpoint side): `--token` > `$RADICAL_ORBIT_BROKER_TOKEN` >
+**shared bearer token**. Like the cert/key pair, the token is operator-placed —
+the software never generates or writes it (`~/.radical/orbit` config is
+read-only for the code; `utils.TOKEN_RECIPE` / `radical-orbit-broker.py --help`
+carry the one-time creation recipe). The token value is **never** printed to
+stdout (only its source/path), so it can't leak into captured logs (CWE-532).
+Resolution (both sides): `--token` > `$RADICAL_ORBIT_BROKER_TOKEN` >
 `~/.radical/orbit/broker.token` — so same-host clients/endpoints pick it up with
-no config; for a remote broker, copy the token or set the env var. The Explorer
-prompts for it and then rides an HttpOnly cookie minted by `POST /auth`. Disable
-the gate for local dev with `--no-auth` (or `RADICAL_ORBIT_BROKER_NO_AUTH=1`).
-Helpers live in `utils.py`
-(`resolve_broker_token`, `ensure_broker_token`, `auth_disabled`, `tokens_match`);
+no config; for a remote broker, copy the token or set the env var. The broker
+refuses to start without a token unless auth is disabled explicitly:
+`auth=False` on the `Broker` ctor / `--no-auth` on the bin (local dev only; no
+env-var escape hatch). The Explorer prompts for the token and then rides an
+HttpOnly cookie minted by `POST /auth`. Helpers live in `utils.py`
+(`resolve_broker_token`, `tokens_match`, `TOKEN_RECIPE`, `TLS_RECIPE`);
 the broker core gates the WS `/register` handshake (`Broker._auth_dispatch`) and
 the gateway gates HTTP ingress (`Gateway._auth_dispatch`, minting the `/auth`
 cookie). This is the interim credential; a future per-participant identity
 (mTLS) generalizes it.
+
+The broker URL similarly has **no file fallback**: clients/endpoints resolve it
+from the API/CLI arg > `$RADICAL_ORBIT_BROKER_URL` only (a stale on-disk URL
+was a recurring source of confusion).
 
 ## Testing
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -52,12 +52,22 @@ start otherwise — and never leaves the broker host.
 ### Ingress token
 
 The broker gates its HTTP ingress *and* the endpoint `/register`
-handshake with a shared bearer token.  On first start it generates one
-and writes it to `~/.radical/orbit/broker.token` (mode `0600`; the
-token itself is never printed, only its path).  Precedence everywhere
-is `--token` > `$RADICAL_ORBIT_BROKER_TOKEN` >
-`~/.radical/orbit/broker.token`.  For local development only,
-`--no-auth` (or `$RADICAL_ORBIT_BROKER_NO_AUTH=1`) disables the gate.
+handshake with a shared bearer token.  Like the cert/key pair, the
+token is created by the operator — the broker never generates or
+writes it (`~/.radical/orbit` config is read-only for the software;
+`radical-orbit-broker.py --help` carries a copy-pasteable recipe):
+
+```sh
+mkdir -p ~/.radical/orbit
+python3 -c "import secrets; print(secrets.token_urlsafe(32))" \
+    > ~/.radical/orbit/broker.token
+chmod 600 ~/.radical/orbit/broker.token
+```
+
+Precedence everywhere is `--token` > `$RADICAL_ORBIT_BROKER_TOKEN` >
+`~/.radical/orbit/broker.token`; the broker refuses to start without a
+token.  For local development only, `--no-auth` (API: `auth=False`)
+disables the gate.
 
 ### Credential staging to endpoint/client hosts
 
@@ -83,8 +93,8 @@ The **token** reaches the endpoint in one of two ways:
   from `$RADICAL_ORBIT_BROKER_TOKEN` or
   `~/.radical/orbit/broker.token`.  Stage whichever matches the
   broker's configuration: when the broker uses its token *file*
-  (the default — generated on first start), copy it, and re-copy it
-  whenever it is regenerated:
+  (the default), copy it, and re-copy it whenever the operator
+  rotates it:
 
   ```sh
   ssh <endpoint-host> "mkdir -p ~/.radical/orbit"
@@ -116,8 +126,8 @@ User=radical
 WorkingDirectory=/opt/orbit
 Environment=RADICAL_ORBIT_BROKER_CERT=/opt/orbit/certs/broker_cert.pem
 Environment=RADICAL_ORBIT_BROKER_KEY=/opt/orbit/certs/broker_key.pem
-# Token: resolved from ~radical/.radical/orbit/broker.token (generated
-# on first start), or pin one explicitly:
+# Token: resolved from ~radical/.radical/orbit/broker.token (operator-
+# placed — see "Ingress token" above), or pin one explicitly:
 # Environment=RADICAL_ORBIT_BROKER_TOKEN=<shared ingress token>
 ExecStart=/opt/orbit/bin/radical-orbit-broker.py
 Restart=on-failure

--- a/bin/radical-orbit-broker.py
+++ b/bin/radical-orbit-broker.py
@@ -14,21 +14,11 @@ import ssl
 import sys
 
 import radical.orbit.logging_config as _lc
+from radical.orbit        import utils
 from radical.orbit.broker import Broker
 
 
-_TLS_RECIPE = '''\
-To create a self-signed cert/key pair at the default location:
-
-  mkdir -p ~/.radical/orbit
-  openssl req -x509 -newkey rsa:4096 -nodes \\
-      -keyout ~/.radical/orbit/broker_key.pem \\
-      -out    ~/.radical/orbit/broker_cert.pem \\
-      -days 365 -subj "/CN=$(hostname -f)"
-  chmod 600 ~/.radical/orbit/broker_key.pem
-'''
-
-_TLS_HOWTO = f'''\
+_SETUP_HOWTO = f'''\
 TLS setup
 ---------
 The broker serves HTTPS/WSS and needs a certificate + private key.
@@ -37,19 +27,31 @@ Resolution order for each:
   cert:  --cert PATH  >  $RADICAL_ORBIT_BROKER_CERT  >  ~/.radical/orbit/broker_cert.pem
   key:   --key  PATH  >  $RADICAL_ORBIT_BROKER_KEY   >  ~/.radical/orbit/broker_key.pem
 
-{_TLS_RECIPE}
+{utils.TLS_RECIPE}
 The key must be mode 0600 or stricter — the broker refuses to start
 otherwise.  Endpoints and clients pin the *cert* (never the key): copy
 broker_cert.pem to ~/.radical/orbit/ on each connecting host, or point
 $RADICAL_ORBIT_BROKER_CERT at it there.  Hostname matching is disabled
 for pinned certs, so the CN does not need to match the broker host.
+
+Ingress token
+-------------
+Auth is on by default and needs an operator-placed shared token
+(never auto-generated; config under ~/.radical/orbit is read-only
+for the software).  Resolution:
+
+  token: --token T    >  $RADICAL_ORBIT_BROKER_TOKEN >  ~/.radical/orbit/broker.token
+
+{utils.TOKEN_RECIPE}
+Copy the token file (or export the env var) on each connecting host.
+--no-auth disables the gate for local dev.
 '''
 
 
 def main():
     parser = argparse.ArgumentParser(
         description='ORBIT Broker',
-        epilog=_TLS_HOWTO,
+        epilog=_SETUP_HOWTO,
         formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--cert', default=None,
                         help='TLS cert path.  CLI > $RADICAL_ORBIT_BROKER_CERT > '
@@ -75,12 +77,12 @@ def main():
     parser.add_argument('--token', default=None,
                         help='Shared ingress auth token.  CLI > '
                              '$RADICAL_ORBIT_BROKER_TOKEN > '
-                             '~/.radical/orbit/broker.token.  If none is set, '
-                             'one is generated and written to that file '
-                             '(mode 0600) at startup.')
+                             '~/.radical/orbit/broker.token.  Required unless '
+                             '--no-auth; never auto-generated (see the recipe '
+                             'below).')
     parser.add_argument('--no-auth', action='store_true',
-                        help='Disable ingress authentication (local dev only). '
-                             'Also via $RADICAL_ORBIT_BROKER_NO_AUTH=1.')
+                        help='Disable ingress authentication (local dev '
+                             'only).')
     parser.add_argument('--no-gateway', action='store_true',
                         help='Run a headless broker: only the token-gated '
                              'WebSocket /register ingress, no HTTP/SSE/Explorer '
@@ -103,13 +105,15 @@ def main():
                         port=args.port,
                         plugins=args.plugins,
                         token=args.token,
-                        no_auth=args.no_auth,
+                        auth=not args.no_auth,
                         gateway=not args.no_gateway)
     except (ValueError, FileNotFoundError, PermissionError, ssl.SSLError) as e:
-        # Cert/key resolution failures (missing, unreadable, malformed,
-        # key too permissive) — short and actionable instead of a
-        # traceback; resolution details live in --help and DEPLOYMENT.md.
-        print(f'\nERROR: {e}\n\n{_TLS_RECIPE}', file=sys.stderr)
+        # Cert/key/token resolution failures (missing, unreadable, malformed,
+        # key too permissive) — short and actionable instead of a traceback;
+        # resolution details live in --help and DEPLOYMENT.md.  The token
+        # error carries its own recipe; append the TLS one otherwise.
+        recipe = '' if 'token' in str(e) else f'\n\n{utils.TLS_RECIPE}'
+        print(f'\nERROR: {e}{recipe}', file=sys.stderr)
         sys.exit(1)
 
     broker.run()

--- a/bin/radical-orbit-endpoint.py
+++ b/bin/radical-orbit-endpoint.py
@@ -27,8 +27,8 @@ def main():
     parser = argparse.ArgumentParser(description="ORBIT Service")
     parser.add_argument("--name",      "-n", nargs="?", help="Endpoint name")
     parser.add_argument("--url",       "-u", nargs="?",
-                        help="Broker URL.  CLI > $RADICAL_ORBIT_BROKER_URL > "
-                             "~/.radical/orbit/broker.url.")
+                        help="Broker URL.  CLI > $RADICAL_ORBIT_BROKER_URL "
+                             "(no file fallback).")
     parser.add_argument("--cert",      "-c", nargs="?",
                         help="Broker TLS cert path.  CLI > "
                              "$RADICAL_ORBIT_BROKER_CERT > "

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -67,6 +67,7 @@ Contents:
    getting_started.md
    module_radical.orbit.rst
    runtime_embedding.rst
+   tutorial_plugin.rst
    plugin_development.rst
    plugin_api.rst
    plugin_globus.rst

--- a/docs/source/tutorial_plugin.rst
+++ b/docs/source/tutorial_plugin.rst
@@ -1,0 +1,421 @@
+
+Plugin Writer's Tutorial
+************************
+
+This tutorial walks you through writing a complete ORBIT plugin from scratch:
+the server-side plugin and session classes, the Python client helper, unit
+tests, and the configuration that controls *where* the plugin loads (broker,
+login node, compute node).  It is a hands-on companion to the
+:doc:`plugin_development` reference — every concept used here is described in
+depth there.
+
+The example is deliberately trivial: a **math** plugin that serves the four
+basic arithmetic operations (``add`` / ``sub`` / ``mul`` / ``div``) and keeps a
+per-session history of the operations it performed.  Because the domain logic
+is one line of arithmetic, every remaining line is ORBIT machinery — which is
+exactly what this tutorial is about.
+
+The finished plugin ships with ORBIT as ``src/radical/orbit/plugin_math.py``,
+so you can run every step of this tutorial verbatim.  All code shown below is
+included from that file — it cannot drift from what you install.
+
+Prerequisites: a working local setup as described in
+:doc:`getting_started` — a broker and an endpoint you can start in two
+terminals.
+
+
+What you will build
+===================
+
+Three classes, one file:
+
+===================  =====================  ==========================================
+Class                Runs on                Role
+===================  =====================  ==========================================
+``MathSession``      serving participant    per-client state + the actual work
+``PluginMath``       serving participant    routes, validation, session dispatch
+``MathClient``       consuming application  friendly Python API over the wire calls
+===================  =====================  ==========================================
+
+At runtime the pieces connect like this::
+
+    application                     broker                endpoint
+    -----------                     ------                --------
+    MathClient.add(3, 4)
+      -> POST /math/add/{sid}  -->  routes by dst  -->  PluginMath.op_add()
+                                                          -> _forward(sid, ...)
+                                                            -> MathSession.compute()
+      <- {"result": 7.0}       <--  correlates     <--  response
+                                    by corr_id
+
+The consuming application never opens a connection to the endpoint — both
+sides dial the broker, which routes ``request`` / ``response`` frames between
+them (see the architecture overview in the project README / ``CLAUDE.md``).
+
+
+Step 1 — the session
+====================
+
+A **session** holds per-client state on the serving side.  For ``psij`` that
+is the submitted jobs; for ``rhapsody`` the running tasks; for our tutorial
+plugin it is simply the list of operations performed.  Sessions inherit from
+:class:`~radical.orbit.plugin_session_base.PluginSession`:
+
+.. literalinclude:: ../../src/radical/orbit/plugin_math.py
+   :pyobject: MathSession
+
+Things to note:
+
+* ``super().__init__(sid)`` initializes the base bookkeeping (session id,
+  active flag, notification path).
+* Session methods are **async** and start with ``self._check_active()`` so a
+  call on a closed session fails cleanly with a ``RuntimeError``.
+* ``self.notify(topic, data)`` pushes a real-time **notification** to
+  subscribed consumers.  It is safe from sync/async contexts and background
+  threads, and it is a no-op when the session has no parent plugin (e.g. when
+  you instantiate it directly in a unit test).
+* ``close()`` releases per-session resources, then calls ``super().close()``
+  which marks the session inactive.  Real plugins cancel background pollers
+  and close backend connections here.
+
+Session *lifetime* (when an abandoned session is reclaimed) is a policy the
+caller selects at registration time — you do not implement anything for it.
+See the *Lifetime policies* section in :doc:`plugin_development`.
+
+
+Step 2 — the plugin
+===================
+
+The **plugin** class owns the URL namespace, registers routes, validates
+input, and dispatches to sessions.  It inherits from
+:class:`~radical.orbit.plugin_base.Plugin`:
+
+.. literalinclude:: ../../src/radical/orbit/plugin_math.py
+   :pyobject: PluginMath
+
+Walking through it:
+
+Class attributes
+----------------
+
+* ``plugin_name = 'math'`` — the registry key **and** the default URL
+  namespace.  Defining it auto-registers the class in the global plugin
+  registry the moment the module is imported; that is all "installation"
+  means on the code level.
+* ``session_class = MathSession`` — what ``register_session`` instantiates.
+* ``client_class = MathClient`` — what consumers get from
+  ``runtime.get_plugin(endpoint, 'math')`` (Step 3).
+* ``ui_config`` — a minimal descriptor so the plugin shows up in the broker's
+  Explorer UI with an icon and description.  Forms and monitors can be added
+  later; see :doc:`plugin_development`.
+
+Routes
+------
+
+``add_route_post`` / ``add_route_get`` register a handler under the plugin
+namespace, so ``'add/{sid}'`` becomes ``POST /math/add/{sid}``.  Every plugin
+additionally gets the built-in routes for free — ``register_session``,
+``unregister_session/{sid}``, ``version``, ``list_sessions``, ``health``, and
+``ui_config``.
+
+Handlers are plain ``async`` callables that take a ``Request`` and return a
+dict.  The registration is **dual**: the same handler serves broker-routed
+``request`` frames on the endpoint's work loop *and* plain HTTP (used by the
+gateway proxy and by ``TestClient`` in unit tests) — you never think about
+the transport.
+
+Input validation and errors
+---------------------------
+
+``_compute`` shows the error convention.  ORBIT uses one canonical error
+envelope on the wire — ``{"error": true, "status_code": <int>, "detail":
+"<str>"}`` — and ``radical.orbit.errors`` maps stdlib exception types to HTTP
+statuses (``ValueError`` → 400, ``FileNotFoundError`` → 404,
+``PermissionError`` → 403, …).  Raising ``http_exception(ValueError("division
+by zero"))`` in the handler therefore produces a clean HTTP 400 with that
+detail string.
+
+Do this mapping **at the handler boundary**: an exception that escapes a
+session method is caught by ``_forward`` and surfaces as a generic 500.
+
+Session dispatch
+----------------
+
+``self._forward(sid, MathSession.compute, op=op, a=a, b=b)`` looks up the
+session for ``sid``, checks it has not expired, bumps its last-access time,
+and awaits the method.  Unknown session ids become 404, expired ones 410 —
+you write none of that.
+
+Blocking work
+-------------
+
+Our arithmetic is instant, but the rule matters for real plugins: handlers
+and session methods run on the participant's **work loop**, so anything
+blocking (subprocess calls, file I/O, third-party network requests) must be
+offloaded::
+
+    result = await asyncio.to_thread(subprocess.check_output, ['sinfo'])
+
+A blocked work loop cannot break liveness (the transport thread owns the
+keepalive), but it stalls every other plugin request on this participant.
+
+
+Step 3 — the client
+===================
+
+The client helper is what application code sees.  It inherits from
+:class:`~radical.orbit.client.PluginClient` and turns Python calls into the
+wire requests defined in Step 2:
+
+.. literalinclude:: ../../src/radical/orbit/plugin_math.py
+   :pyobject: MathClient
+
+The base class provides the whole transport:
+
+* ``self._request(method, url, **kwargs)`` — the single transport seam.  The
+  endpoint runtime injects a WebSocket-backed shim here, so the same helper
+  code works over the broker star and, in tests, over plain HTTP.
+* ``self._url(path)`` — prefixes the plugin namespace.
+* ``self._raise(resp, context)`` — raises a ``RuntimeError`` carrying the
+  HTTP status and the server's ``detail`` on any non-2xx response.  This is
+  how the server-side 400 from ``div(1, 0)`` reaches the application.
+* ``self.sid`` / ``self._require_session()`` — session bookkeeping;
+  ``register_session()`` is called for you by ``runtime.get_plugin``.
+
+Consuming the plugin then looks like this:
+
+.. code-block:: python
+
+    from radical.orbit import EndpointRuntime
+
+    rt   = EndpointRuntime()          # join the star as a consumer
+    rt.start(wait=True)
+
+    math = rt.get_plugin('endpoint_1', 'math')   # MathClient, session ready
+    print(math.add(3, 4))                        # -> 7.0
+
+``get_plugin`` discovers the namespace from the live topology, instantiates
+the ``client_class``, and registers a session — one call, ready to use.
+
+
+Step 4 — registering the plugin
+===============================
+
+Auto-registration happens at **import time** (the ``plugin_name`` attribute
+triggers it), so "registering" a plugin means making sure its module gets
+imported.  There are two ways:
+
+In-tree plugin
+--------------
+
+The tutorial plugin lives in the ORBIT source tree, so it is imported from
+``src/radical/orbit/__init__.py`` alongside its siblings::
+
+    from .plugin_staging import PluginStaging  # noqa: F401
+    from .plugin_math    import PluginMath     # noqa: F401
+
+Out-of-tree plugin (recommended for your own work)
+--------------------------------------------------
+
+You do not need to patch ORBIT.  Package your plugin as its own distribution
+and declare a ``radical.orbit.plugins`` entry point; the plugin host discovers
+and imports it at startup:
+
+.. code-block:: toml
+
+    # pyproject.toml of your plugin package
+    [project]
+    name = "orbit-plugin-math"
+    version = "0.1.0"
+    dependencies = ["radical.orbit"]
+
+    [project.entry-points."radical.orbit.plugins"]
+    math = "orbit_plugin_math.plugin_math"
+
+The entry-point *value* is the module to import (importing it runs the
+auto-registration); the *name* is informational.  After ``pip install`` of
+your package, ``--plugins math`` works exactly as for a built-in plugin.
+
+
+Step 5 — controlling where the plugin loads
+===========================================
+
+Two independent mechanisms decide whether a plugin is active on a given
+participant: the operator-facing **plugin filter** and the code-facing
+**is_enabled** gate.  A plugin loads only if it passes both.
+
+The ``--plugins`` filter
+------------------------
+
+Both ``radical-orbit-endpoint.py`` and ``radical-orbit-broker.py`` accept
+``--plugins`` (default: ``default``), a comma-separated list of tokens:
+
+* exact names — ``--plugins math,sysinfo``
+* fnmatch wildcards — ``--plugins 'iri*'``
+* ``all`` — every registered plugin
+* ``default`` — the **role-specific** default set
+
+The ``default`` token expands against the host's detected role — ``broker``,
+``login`` (a scheduler is present, not inside an allocation), ``compute``
+(inside an allocation), or ``standalone`` (no scheduler) — using
+``DEFAULT_PLUGINS_BY_ROLE`` in ``plugin_host_base.py``.  That is why a login
+node gets ``psij`` by default while a compute node gets ``rhapsody``.
+
+The math plugin is intentionally **not** in any default set; load it
+explicitly on top of the defaults::
+
+    ./bin/radical-orbit-endpoint-wrapper.sh --plugins default,math
+
+The ``is_enabled`` gate
+-----------------------
+
+The filter is operator policy; ``is_enabled`` is *plugin* policy — a
+classmethod checked **before** instantiation (no routes get registered when
+it returns ``False``).  Use it when the plugin only makes sense in a specific
+environment.  Real examples: ``globus`` disables itself on the broker,
+``queue_info`` disables itself when no scheduler is detected.
+
+The role machinery is available to your gate via
+``radical.orbit.utils.host_role``.  To load a plugin **only on compute
+nodes** (i.e. inside a batch allocation):
+
+.. code-block:: python
+
+    from radical.orbit.utils import host_role
+
+    class PluginMyService(Plugin):
+        plugin_name = 'myservice'
+        ...
+
+        @classmethod
+        def is_enabled(cls, app: FastAPI) -> bool:
+            """Load only inside a batch allocation (compute nodes)."""
+            return host_role(app)['role'] == 'compute'
+
+``host_role(app)`` returns ``role`` (``broker`` / ``login`` / ``compute`` /
+``standalone``), the detected ``scheduler``, and — on compute nodes — the
+current allocation's ``job_id``.  Other common gates:
+
+.. code-block:: python
+
+    # broker-only (e.g. plugins that orchestrate other participants):
+    return bool(getattr(app.state, 'is_broker', False))
+
+    # endpoint-only (never host on the broker):
+    return not getattr(app.state, 'is_broker', False)
+
+    # gate on an optional dependency:
+    return HAS_GLOBUS_SDK
+
+A skipped plugin is logged at INFO (``Skipping plugin (not applicable
+here)``), so a "why is my plugin not loading?" question is answered by the
+participant's log.
+
+The tutorial plugin defines no ``is_enabled`` and therefore loads anywhere it
+is asked for — handy for a tutorial, and the right default for most plugins.
+
+
+Step 6 — trying it out
+======================
+
+Three terminals, as in :doc:`getting_started`:
+
+.. code-block:: sh
+
+    # Terminal 1 — broker
+    ./bin/radical-orbit-broker.py
+
+    # Terminal 2 — endpoint, defaults plus the math plugin
+    ./bin/radical-orbit-endpoint-wrapper.sh --plugins default,math
+
+    # Terminal 3 — consumer
+    python examples/example_math.py
+
+The consumer script exercises everything built above — the four operations,
+the error path, the history, and the notifications:
+
+.. literalinclude:: ../../examples/example_math.py
+   :language: python
+
+Expected output (endpoint name will differ)::
+
+    add(3, 4): 7.0
+      notification: endpoint_1/math result: add(3.0, 4.0) = 7.0
+    sub(3, 4): -1.0
+    ...
+    div(1, 0) failed as expected: HTTP 400 — [endpoint_1/math] div(1, 0) —
+    division by zero
+    4 operations recorded in this session
+
+You can also poke the plugin from a browser or ``curl`` through the broker's
+gateway, which proxies HTTP onto the same routes
+(``/{endpoint_name}/math/...``), and see it as a tile in the Explorer UI at
+the broker's root URL.
+
+
+Step 7 — notifications, closing the loop
+========================================
+
+Step 1 planted ``self.notify("result", {...})`` in the session; Step 6's
+consumer receives it.  The full path is:
+
+**Session → Plugin → participant runtime → Broker → subscribed consumers**
+(and the gateway's SSE ``/events`` stream for browsers).
+
+On the consumer side, subscription is one call on the client helper::
+
+    math.register_notification_callback(on_result, topic='result')
+
+with a callback signature of ``(endpoint, plugin, topic, data)``.  Callbacks
+fire on the runtime's dedicated dispatcher thread — a slow callback never
+affects the connection's liveness, but do not block in it needlessly.
+
+Two rules of thumb:
+
+* Notifications are **fire-and-forget** state broadcasts (job finished, task
+  running); anything the caller must not miss belongs in a response.
+* Pick stable topic names and payload keys — they are your plugin's public
+  API just as much as the routes are (see the notification topics documented
+  per-plugin in the project ``CLAUDE.md``).
+
+
+Step 8 — unit tests
+===================
+
+Because route registration is dual (direct dispatch **and** ASGI), the whole
+plugin can be tested over HTTP with Starlette's ``TestClient`` — no broker,
+no endpoint, no sockets.  The tutorial plugin's tests live in
+``tests/unittests/test_plugin_math.py``; the core round trip:
+
+.. literalinclude:: ../../tests/unittests/test_plugin_math.py
+   :pyobject: test_math_http_roundtrip
+
+Session logic that does not need HTTP is tested even more directly — sessions
+are plain objects:
+
+.. literalinclude:: ../../tests/unittests/test_plugin_math.py
+   :pyobject: test_math_session_notifies
+
+Run them with::
+
+    pytest tests/unittests/test_plugin_math.py -v
+
+Test the error paths too — the typed statuses (400/404/410) are part of your
+plugin's contract, and the client helper's exception behaviour depends on
+them.
+
+
+Where to go next
+================
+
+* :doc:`plugin_development` — the full reference: session lifetime policies,
+  owner binding, topology callbacks, plugin shutdown, Explorer ``ui_config``
+  forms, and the JS module API for custom Explorer pages.
+* ``src/radical/orbit/plugin_staging.py`` — a small real plugin (adds path
+  validation and richer error mapping).
+* ``src/radical/orbit/plugin_psij.py`` / ``plugin_rhapsody.py`` — large
+  plugins with background pollers, notification batching, and single-sourced
+  ``ROUTE_*`` constants shared between routes and client helpers (a pattern
+  worth copying once your route table grows).
+* ``src/radical/orbit/plugin_queue_info.py`` — a worked ``is_enabled`` gate
+  plus a backend-selection factory.

--- a/examples/example_math.py
+++ b/examples/example_math.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+'''Consume the tutorial `math` plugin (see docs/source/tutorial_plugin.rst).
+
+Start a broker and an endpoint that serves the plugin first:
+
+    # Terminal 1
+    ./bin/radical-orbit-broker.py
+
+    # Terminal 2
+    ./bin/radical-orbit-endpoint-wrapper.sh --plugins default,math
+
+    # Terminal 3
+    python examples/example_math.py
+'''
+
+import time
+
+from radical.orbit import EndpointRuntime
+
+
+def on_result(endpoint, plugin, topic, data):
+    print(f"  notification: {endpoint}/{plugin} {topic}: "
+          f"{data['op']}({data['a']}, {data['b']}) = {data['result']}")
+
+
+def main():
+
+    rt = EndpointRuntime()
+    rt.start(wait=True)
+
+    # Find an endpoint that serves the math plugin
+    eids = [e_name for e_name, e_info in rt.topology().items()
+            if e_info and 'math' in (e_info.get('plugins') or {})]
+    if not eids:
+        print("no endpoint serves the 'math' plugin - start one with "
+              "'--plugins default,math'")
+        rt.stop()
+        return
+
+    math = rt.get_plugin(eids[0], 'math')   # also registers a session
+    math.register_notification_callback(on_result, topic='result')
+
+    print(f"add(3, 4): {math.add(3, 4)}")
+    print(f"sub(3, 4): {math.sub(3, 4)}")
+    print(f"mul(3, 4): {math.mul(3, 4)}")
+    print(f"div(3, 4): {math.div(3, 4)}")
+
+    try:
+        math.div(1, 0)
+    except RuntimeError as e:
+        print(f"div(1, 0) failed as expected: {e}")
+
+    hist = math.history()
+    print(f"{hist['count']} operations recorded in this session")
+
+    time.sleep(1)   # let the last notification arrive
+    math.close()
+    rt.stop()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/radical/orbit/__init__.py
+++ b/src/radical/orbit/__init__.py
@@ -30,6 +30,7 @@ from .plugin_sfapi_connect import PluginSFAPIConnect  # noqa: F401
 from .plugin_queue_info    import PluginQueueInfo     # noqa: F401
 from .plugin_sysinfo    import PluginSysInfo  # noqa: F401
 from .plugin_staging    import PluginStaging  # noqa: F401
+from .plugin_math       import PluginMath     # noqa: F401
 from .plugin_task_dispatcher import PluginTaskDispatcher  # noqa: F401
 from .plugin_replay      import PluginReplay  # noqa: F401
 

--- a/src/radical/orbit/broker.py
+++ b/src/radical/orbit/broker.py
@@ -209,7 +209,7 @@ class Broker:
     """The active broker — lean routing loop + own-thread plugin host.
 
     The constructor takes the handful of things an operator sets — ``app``,
-    ``cert``/``key``, ``host``/``port``, ``plugins``, ``token``/``no_auth`` and
+    ``cert``/``key``, ``host``/``port``, ``plugins``, ``token``/``auth`` and
     ``gateway``.  The liveness/backpressure knobs are grouped in an optional
     :class:`BrokerTuning` object (unit tests pass one with tiny timeouts, or
     mutate the resulting ``self._*`` attributes, so no test sleeps for real).
@@ -223,7 +223,7 @@ class Broker:
                  port:     int = 8000,
                  plugins:  str = '',
                  token:    Optional[str]     = None,
-                 no_auth:  bool              = False,
+                 auth:     bool              = True,
                  gateway:  bool              = True,
                  tuning:   Optional[BrokerTuning] = None):
 
@@ -234,11 +234,22 @@ class Broker:
         self._key : str = str(key_path)
 
         # ── Ingress auth token ────────────────────────────────────────
-        self._auth_enabled: bool          = not utils.auth_disabled(no_auth)
+        # Auth is on by default and requires an operator-placed token;
+        # nothing is ever generated or written (``~/.radical/orbit`` config
+        # is read-only for the software).  ``auth=False`` (``--no-auth``)
+        # is the explicit local-dev escape hatch.
+        self._auth_enabled: bool          = auth
         self._token:        Optional[str] = None
         self._token_source: str           = 'disabled'
         if self._auth_enabled:
-            self._token, self._token_source = utils.ensure_broker_token(cli=token)
+            self._token, self._token_source = \
+                                        utils.resolve_broker_token(cli=token)
+            if not self._token:
+                raise ValueError(
+                    f'ingress auth token required (no --token, '
+                    f'${utils.ENV_TOKEN} unset, no file at '
+                    f'{utils.TOKEN_FILE}).  Pass auth=False (--no-auth) '
+                    f'for local dev, or create one:\n\n{utils.TOKEN_RECIPE}')
 
         # ── Advertised URL ───────────────────────────────────────────
         self._host = host
@@ -557,9 +568,8 @@ class Broker:
         if not auth_enabled:
             lines.append('[Broker] WARNING: ingress authentication DISABLED '
                          '(--no-auth)')
-        elif token_source in ('generated', 'file'):
-            verb = 'creating' if token_source == 'generated' else 'using'
-            lines.append(f'[Broker] {verb:<10}{"token":<6}at '
+        elif token_source == 'file':
+            lines.append(f'[Broker] {"using":<10}{"token":<6}at '
                          f'{Broker._tilde(utils.TOKEN_FILE)}')
         else:  # 'cli' / 'env' — configured, but not at the default file path
             src = '--token' if token_source == 'cli' else f'${utils.ENV_TOKEN}'
@@ -593,7 +603,7 @@ class Broker:
 
         if not auth_enabled:
             lines += ['', '  On Client and Endpoint:', export_url, cp_cert]
-        elif token_source in ('generated', 'file'):
+        elif token_source == 'file':
             lines += ['', '  On Client:',   export_url, cp_both,
                       '', '  On Endpoint:', export_url, cp_cert]
         else:  # cli / env — the client needs the token via env, not a file
@@ -603,6 +613,21 @@ class Broker:
                       '', '  On Endpoint:', export_url, cp_cert]
         lines.append('')
         return '\n'.join(lines)
+
+    def _uvicorn_kwargs(self) -> dict:
+        """Server kwargs shared by ``run()`` and the embedded-broker server."""
+        return dict(reload=False,
+                    ssl_certfile=self._cert,
+                    ssl_keyfile=self._key,
+                    log_level="info",
+                    # Transport enforces the frame cap on inbound frames.
+                    ws_max_size=self._frame_cap,
+                    ws_per_message_deflate=True,
+                    # Server-wide WS keepalive disconnects a silent client at
+                    # ping_interval + ping_timeout.
+                    ws_ping_interval=self._ping_interval,
+                    ws_ping_timeout=self._ping_timeout,
+                    timeout_graceful_shutdown=3)
 
     def run(self) -> None:
         """Start uvicorn.  Blocks until shutdown."""
@@ -615,23 +640,13 @@ class Broker:
                                    self._token_source, self._auth_enabled),
               flush=True)
         if not self._auth_enabled:
-            log.warning("[Broker] ingress authentication DISABLED (--no-auth)")
+            log.warning("[Broker] ingress authentication DISABLED "
+                        "(auth=False / --no-auth)")
 
         uvicorn.run(self._app,
                     host=self._host,
                     port=self._port,
-                    reload=False,
-                    ssl_certfile=self._cert,
-                    ssl_keyfile=self._key,
-                    log_level="info",
-                    # Transport enforces the frame cap on inbound frames.
-                    ws_max_size=self._frame_cap,
-                    ws_per_message_deflate=True,
-                    # Server-wide WS keepalive disconnects a silent client at
-                    # ping_interval + ping_timeout.
-                    ws_ping_interval=self._ping_interval,
-                    ws_ping_timeout=self._ping_timeout,
-                    timeout_graceful_shutdown=3)
+                    **self._uvicorn_kwargs())
 
     @asynccontextmanager
     async def _lifespan(self, app: FastAPI):

--- a/src/radical/orbit/embedded.py
+++ b/src/radical/orbit/embedded.py
@@ -1,0 +1,171 @@
+"""In-process ORBIT broker for consumer clients.
+
+``EmbeddedBroker`` runs the full :class:`~radical.orbit.broker.Broker`
+(routing loop, hosted plugins, gateway) on a daemon thread inside the
+client process, so a single-client setup needs no standalone broker
+deployment.  Endpoints connect to the advertised URL exactly as they
+would to a standalone broker.
+
+The embedded broker is a *regular* broker: the operator-placed
+cert / key / token under ``~/.radical/orbit`` (or their env-var
+redirects) are required, auth is on by default, and nothing is ever
+written to the config directory.
+
+The listen socket is bound *before* the ``Broker`` is constructed:
+uvicorn runs the FastAPI lifespan — which hands the broker's advertised
+URL to hosted plugins — before it would bind sockets itself, so the
+port must be final at construction time.  The pre-bound socket is then
+handed to ``uvicorn.Server.run(sockets=[...])``.
+"""
+
+import errno
+import logging
+import socket
+import threading
+import time
+
+from typing import Optional
+
+from .broker import Broker, BrokerTuning
+
+log = logging.getLogger("radical.orbit.embedded")
+
+
+class EmbeddedBroker:
+    """A full ORBIT broker served on a daemon thread inside this process."""
+
+    _DEFAULT_PORT = 8000     # parity with the standalone broker; tests redirect
+
+    def __init__(self,
+                 cert:    Optional[str] = None,
+                 key:     Optional[str] = None,
+                 token:   Optional[str] = None,
+                 host:    str           = '0.0.0.0',
+                 port:    Optional[int] = None,
+                 plugins: str           = '',
+                 auth:    bool          = True,
+                 gateway: bool          = True,
+                 tuning:  Optional[BrokerTuning] = None):
+        self._cert    = cert
+        self._key     = key
+        self._token   = token
+        self._host    = host
+        self._port    = port
+        self._plugins = plugins
+        self._auth    = auth
+        self._gateway = gateway
+        self._tuning  = tuning
+
+        self._broker:  Optional[Broker]           = None
+        self._server                              = None   # uvicorn.Server
+        self._thread:  Optional[threading.Thread] = None
+        self._sock:    Optional[socket.socket]    = None
+        self._stopped: bool                       = False
+
+    # ── public API ─────────────────────────────────────────────────────
+
+    @property
+    def broker(self) -> Optional[Broker]:
+        return self._broker
+
+    @property
+    def url(self) -> Optional[str]:
+        return self._broker.url if self._broker else None
+
+    def start(self, timeout: float = 15.0) -> str:
+        """Bind, construct the broker, serve on a daemon thread.
+
+        Returns the advertised broker URL once the server accepts
+        connections.  On any failure the pre-bound socket and the server
+        thread are cleaned up before the exception propagates.
+        """
+        import uvicorn
+
+        self._sock = self._bind()
+        port       = self._sock.getsockname()[1]
+
+        try:
+            self._broker = Broker(cert=self._cert, key=self._key,
+                                  host=self._host, port=port,
+                                  plugins=self._plugins, token=self._token,
+                                  auth=self._auth, gateway=self._gateway,
+                                  tuning=self._tuning)
+        except Exception:
+            self._sock.close()
+            self._sock = None
+            raise
+
+        # Quieter than run(): an embedded broker must not spam the client's
+        # output (and the startup banner is skipped — run() is never called).
+        config = uvicorn.Config(self._broker.app,
+                                host=self._host, port=port,
+                                **{**self._broker._uvicorn_kwargs(),
+                                   'log_level': 'warning'})
+        self._server = uvicorn.Server(config)
+        self._thread = threading.Thread(target=self._server.run,
+                                        kwargs={'sockets': [self._sock]},
+                                        name='orbit-embedded-broker',
+                                        daemon=True)
+        self._thread.start()
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self._server.started:
+                log.info("[Embedded] broker serving at %s", self._broker.url)
+                return self._broker.url
+            if not self._thread.is_alive():
+                break                      # serve() returned — startup failed
+            time.sleep(0.02)
+
+        # Timeout or early thread death: tear down, nothing may leak.
+        self._server.should_exit = True
+        self._thread.join(5.0)
+        self._sock.close()
+        self._sock = None
+        raise RuntimeError(
+            f"embedded broker failed to start on {self._host}:{port} "
+            f"within {timeout}s — see the radical.orbit log for the "
+            f"uvicorn/broker error")
+
+    def stop(self, timeout: float = 10.0) -> None:
+        """Shut the server down and join its thread.  Idempotent."""
+        if self._stopped:
+            return
+        self._stopped = True
+        if self._server is not None:
+            self._server.should_exit = True
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout)
+            if self._thread.is_alive():
+                log.warning("[Embedded] broker thread did not stop within "
+                            "%.1fs; abandoning (daemon)", timeout)
+
+    # ── internals ──────────────────────────────────────────────────────
+
+    def _bind(self) -> socket.socket:
+        """Pre-bind the listen socket (no ``listen()`` — uvicorn's job).
+
+        An explicit ``port`` binds exactly (``OSError`` propagates); the
+        default tries ``_DEFAULT_PORT`` and falls back to an ephemeral
+        port with a warning when it is taken.
+        """
+        def _try(port: int) -> socket.socket:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind((self._host, port))
+            except OSError:
+                sock.close()
+                raise
+            return sock
+
+        if self._port is not None:
+            return _try(self._port)
+        try:
+            return _try(self._DEFAULT_PORT)
+        except OSError as e:
+            if e.errno != errno.EADDRINUSE:
+                raise
+            log.warning("[Embedded] port %d in use; falling back to an "
+                        "ephemeral port", self._DEFAULT_PORT)
+            return _try(0)

--- a/src/radical/orbit/embedded.py
+++ b/src/radical/orbit/embedded.py
@@ -90,23 +90,24 @@ class EmbeddedBroker:
                                   plugins=self._plugins, token=self._token,
                                   auth=self._auth, gateway=self._gateway,
                                   tuning=self._tuning)
+
+            # Quieter than run(): an embedded broker must not spam the
+            # client's output (and the startup banner is skipped — run() is
+            # never called).
+            config = uvicorn.Config(self._broker.app,
+                                    host=self._host, port=port,
+                                    **{**self._broker._uvicorn_kwargs(),
+                                       'log_level': 'warning'})
+            self._server = uvicorn.Server(config)
+            self._thread = threading.Thread(target=self._server.run,
+                                            kwargs={'sockets': [self._sock]},
+                                            name='orbit-embedded-broker',
+                                            daemon=True)
+            self._thread.start()
         except Exception:
             self._sock.close()
             self._sock = None
             raise
-
-        # Quieter than run(): an embedded broker must not spam the client's
-        # output (and the startup banner is skipped — run() is never called).
-        config = uvicorn.Config(self._broker.app,
-                                host=self._host, port=port,
-                                **{**self._broker._uvicorn_kwargs(),
-                                   'log_level': 'warning'})
-        self._server = uvicorn.Server(config)
-        self._thread = threading.Thread(target=self._server.run,
-                                        kwargs={'sockets': [self._sock]},
-                                        name='orbit-embedded-broker',
-                                        daemon=True)
-        self._thread.start()
 
         deadline = time.time() + timeout
         while time.time() < deadline:
@@ -150,7 +151,9 @@ class EmbeddedBroker:
         port with a warning when it is taken.
         """
         def _try(port: int) -> socket.socket:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            # IPv6 literals ('::', '::1', …) need AF_INET6.
+            family = socket.AF_INET6 if ':' in self._host else socket.AF_INET
+            sock = socket.socket(family, socket.SOCK_STREAM)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             try:
                 sock.bind((self._host, port))

--- a/src/radical/orbit/plugin_math.py
+++ b/src/radical/orbit/plugin_math.py
@@ -1,0 +1,219 @@
+"""Tutorial plugin: a four-function calculator.
+
+This module is the worked example for the Plugin Writer's Tutorial
+(``docs/source/tutorial_plugin.rst``).  It is intentionally small: the
+arithmetic is trivial so that every line of ORBIT machinery — session,
+routes, error mapping, notifications, client helper — stays in focus.
+
+The plugin is not part of any default plugin set; load it explicitly::
+
+    ./bin/radical-orbit-endpoint-wrapper.sh --plugins default,math
+"""
+
+__author__    = 'Radical Development Team'
+__email__     = 'radical@radical-project.org'
+__copyright__ = 'Copyright 2026, RADICAL@Rutgers'
+__license__   = 'MIT'
+
+
+import logging
+
+from fastapi import FastAPI
+from starlette.requests import Request
+
+from .plugin_base import Plugin
+from .plugin_session_base import PluginSession
+from .client import PluginClient
+from .errors import http_exception
+
+log = logging.getLogger("radical.orbit")
+
+
+# ------------------------------------------------------------------------
+#
+class MathSession(PluginSession):
+    """
+    Math session (service side).
+
+    Holds the per-session operation history — the tutorial's stand-in for
+    real per-client state (jobs, tasks, backend connections).
+    """
+
+    def __init__(self, sid: str):
+        super().__init__(sid)
+        self._history = []      # [{"op", "a", "b", "result"}, ...]
+
+    async def compute(self, op: str, a: float, b: float) -> dict:
+        """
+        Apply one arithmetic operation and record it.
+
+        Args:
+            op: One of ``'add'`` / ``'sub'`` / ``'mul'`` / ``'div'``.
+            a:  Left operand.
+            b:  Right operand.
+
+        Returns:
+            {"op": str, "a": float, "b": float, "result": float}
+        """
+        self._check_active()
+
+        if   op == 'add': result = a + b
+        elif op == 'sub': result = a - b
+        elif op == 'mul': result = a * b
+        elif op == 'div': result = a / b
+        else:
+            raise ValueError(f"unknown operation: {op}")
+
+        entry = {"op": op, "a": a, "b": b, "result": result}
+        self._history.append(entry)
+        log.info("[math] %s(%s, %s) = %s", op, a, b, result)
+
+        # Real-time notification to subscribed consumers (Python callbacks
+        # over the WebSocket, browsers over the gateway's SSE `/events`).
+        self.notify("result", dict(entry, count=len(self._history)))
+
+        return entry
+
+    async def history(self) -> dict:
+        """
+        Return the operations recorded in this session.
+
+        Returns:
+            {"count": int, "ops": [{"op", "a", "b", "result"}, ...]}
+        """
+        self._check_active()
+        return {"count": len(self._history), "ops": list(self._history)}
+
+    async def close(self) -> dict:
+        """Release per-session state."""
+        self._history = []
+        return await super().close()
+
+
+# ------------------------------------------------------------------------
+#
+class MathClient(PluginClient):
+    """
+    Client-side interface for the Math plugin.
+
+    Obtained via ``runtime.get_plugin(endpoint_name, 'math')``, which also
+    registers a session.
+    """
+
+    def add(self, a: float, b: float) -> float:
+        """Return ``a + b``, computed on the serving participant."""
+        return self._compute('add', a, b)
+
+    def sub(self, a: float, b: float) -> float:
+        """Return ``a - b``, computed on the serving participant."""
+        return self._compute('sub', a, b)
+
+    def mul(self, a: float, b: float) -> float:
+        """Return ``a * b``, computed on the serving participant."""
+        return self._compute('mul', a, b)
+
+    def div(self, a: float, b: float) -> float:
+        """Return ``a / b``, computed on the serving participant.
+
+        Raises:
+            RuntimeError: On division by zero (HTTP 400 from the plugin).
+        """
+        return self._compute('div', a, b)
+
+    def history(self) -> dict:
+        """Return ``{"count": int, "ops": [...]}`` for this session."""
+        self._require_session()
+        resp = self._request('GET', self._url(f'history/{self.sid}'))
+        self._raise(resp, 'history')
+        return resp.json()
+
+    def _compute(self, op: str, a: float, b: float) -> float:
+        """Single seam for the four operation calls."""
+        self._require_session()
+        resp = self._request('POST', self._url(f'{op}/{self.sid}'),
+                             json={"a": a, "b": b})
+        self._raise(resp, f'{op}({a}, {b})')
+        return resp.json()['result']
+
+
+# ------------------------------------------------------------------------
+#
+class PluginMath(Plugin):
+    """
+    Math plugin for ORBIT — the Plugin Writer's Tutorial example.
+
+    Serves the four basic arithmetic operations plus a per-session
+    operation history.
+    """
+
+    plugin_name   = 'math'
+    session_class = MathSession
+    client_class  = MathClient
+    version       = '0.1.0'
+
+    ui_config = {
+        "icon"       : "🧮",
+        "title"      : "Math",
+        "description": "Four-function calculator (tutorial plugin)."
+    }
+
+    def __init__(self, app: FastAPI, instance_name: str = 'math'):
+        """
+        Initialize the Math plugin.
+        """
+        super().__init__(app, instance_name)
+
+        self.add_route_post('add/{sid}',     self.op_add)
+        self.add_route_post('sub/{sid}',     self.op_sub)
+        self.add_route_post('mul/{sid}',     self.op_mul)
+        self.add_route_post('div/{sid}',     self.op_div)
+        self.add_route_get ('history/{sid}', self.history)
+
+    async def op_add(self, request: Request) -> dict:
+        """Route handler for ``POST /math/add/{sid}``."""
+        return await self._compute(request, 'add')
+
+    async def op_sub(self, request: Request) -> dict:
+        """Route handler for ``POST /math/sub/{sid}``."""
+        return await self._compute(request, 'sub')
+
+    async def op_mul(self, request: Request) -> dict:
+        """Route handler for ``POST /math/mul/{sid}``."""
+        return await self._compute(request, 'mul')
+
+    async def op_div(self, request: Request) -> dict:
+        """Route handler for ``POST /math/div/{sid}``."""
+        return await self._compute(request, 'div')
+
+    async def history(self, request: Request) -> dict:
+        """Route handler for ``GET /math/history/{sid}``."""
+        sid = request.path_params['sid']
+        return await self._forward(sid, MathSession.history)
+
+    async def _compute(self, request: Request, op: str) -> dict:
+        """Validate the request body, then forward to the session.
+
+        Request body:
+            {"a": number, "b": number}
+
+        Returns:
+            {"op": str, "a": float, "b": float, "result": float}
+        """
+        sid  = request.path_params['sid']
+        body = await request.json()
+
+        try:
+            a = float(body['a'])
+            b = float(body['b'])
+        except (KeyError, TypeError, ValueError) as e:
+            raise http_exception(
+                ValueError("body must carry numeric fields 'a' and 'b'")) \
+                from e
+
+        # Domain errors get their typed HTTP status at this boundary
+        # (errors.EXC_STATUS maps ValueError -> 400); an exception escaping
+        # the session method would surface as a generic 500 instead.
+        if op == 'div' and b == 0.0:
+            raise http_exception(ValueError("division by zero"))
+
+        return await self._forward(sid, MathSession.compute, op=op, a=a, b=b)

--- a/src/radical/orbit/runtime.py
+++ b/src/radical/orbit/runtime.py
@@ -106,8 +106,16 @@ class EndpointRuntime(PluginHostBase):
     """A participant: serve and/or consume over one outbound WS to the broker.
 
     Args:
-        broker_url:  Broker URL.  CLI > env (``RADICAL_ORBIT_BROKER_URL``) >
-                     file — resolved via :func:`utils.resolve_broker_url`.
+        broker_url:  Broker URL.  CLI > env (``RADICAL_ORBIT_BROKER_URL``) —
+                     resolved via :func:`utils.resolve_broker_url`.  Mutually
+                     exclusive with ``embedded=True``.
+        embedded:    ``True`` runs a full broker inside this process (see
+                     :class:`~radical.orbit.embedded.EmbeddedBroker`: port
+                     8000 with ephemeral fallback, operator-placed
+                     cert/key/token, auth + gateway on) and connects to it;
+                     URL resolution — including an ambient env URL — is
+                     skipped.  Default ``False``: connect out to
+                     ``broker_url``.
         cert:        Broker TLS cert (only for ``https``/``wss``).
         name:        Stable participant name.  ``None`` → ``consumer.<uuid8>``
                      (auto-named consumers cannot recover sessions on restart).
@@ -136,6 +144,7 @@ class EndpointRuntime(PluginHostBase):
                  tunnel_via:  Optional[str]  = None,
                  token:       Optional[str]  = None,
                  resume_key:  Optional[str]  = None,
+                 embedded:    bool           = False,
                  app:         Optional[FastAPI] = None,
                  ping_interval:       float = _PING_INTERVAL,
                  ping_timeout:        float = _PING_TIMEOUT,
@@ -151,17 +160,33 @@ class EndpointRuntime(PluginHostBase):
                             % ', '.join(sorted(bad)))
 
         # ── URL / TLS / token resolution ──────────────────────────────
-        resolved_url, _ = utils.resolve_broker_url(cli=broker_url)
-        self._broker_url: str = resolved_url
-        scheme = urlparse(self._broker_url).scheme
-        if scheme in ('https', 'wss'):
-            resolved_cert, _ = utils.resolve_broker_cert(cli=cert)
-            self._cert: Optional[str] = str(resolved_cert)
+        # embedded=True hosts the broker in this process — URL resolution
+        # (including an ambient env URL) is skipped; the code is explicit.
+        self._embedded = None                    # EmbeddedBroker | None
+        if embedded:
+            if broker_url:
+                raise ValueError(
+                    "broker_url and embedded=True are mutually exclusive "
+                    "— the embedded broker provides the URL")
+            resolved_url = self._start_embedded(cert=cert, token=token)
         else:
-            self._cert = None
-        # Keep the token's source ('cli' / 'env' / 'file' / '') so a
-        # credential rejection can name the exact place to fix.
-        self._token, self._token_source = utils.resolve_broker_token(cli=token)
+            resolved_url, _ = utils.resolve_broker_url(cli=broker_url)
+        self._broker_url: str = resolved_url
+        try:
+            scheme = urlparse(self._broker_url).scheme
+            if scheme in ('https', 'wss'):
+                resolved_cert, _ = utils.resolve_broker_cert(cli=cert)
+                self._cert: Optional[str] = str(resolved_cert)
+            else:
+                self._cert = None
+            # Keep the token's source ('cli' / 'env' / 'file' / '') so a
+            # credential rejection can name the exact place to fix.
+            self._token, self._token_source = \
+                                          utils.resolve_broker_token(cli=token)
+        except Exception:
+            if self._embedded is not None:
+                self._embedded.stop()
+            raise
 
         # ── Identity / role ───────────────────────────────────────────
         self._name: str = name or ('consumer.%s' % uuid.uuid4().hex[:8])
@@ -266,6 +291,18 @@ class EndpointRuntime(PluginHostBase):
     @property
     def broker_url(self) -> str:
         return self._broker_url
+
+    @property
+    def embedded_broker(self):
+        """The in-process :class:`Broker` when ``embedded=True``, else None."""
+        return self._embedded.broker if self._embedded else None
+
+    def _start_embedded(self, cert: Optional[str],
+                        token: Optional[str]) -> str:
+        # Lazy import: uvicorn is only pulled in when embedding is requested.
+        from .embedded import EmbeddedBroker
+        self._embedded = EmbeddedBroker(cert=cert, token=token)
+        return self._embedded.start()
 
     @property
     def fatal(self) -> bool:
@@ -427,6 +464,11 @@ class EndpointRuntime(PluginHostBase):
             _tunnel.cleanup_tunnel(self._tunnel_proc, self._name)
             self._tunnel_proc = None
         self._prof.close()
+        # The embedded broker (if any) goes down last: the runtime above
+        # disconnected first, so the broker sees a clean close.
+        if self._embedded is not None:
+            embedded, self._embedded = self._embedded, None
+            embedded.stop()
 
     async def _graceful_close(self) -> None:
         self._stopping = True

--- a/src/radical/orbit/utils.py
+++ b/src/radical/orbit/utils.py
@@ -7,12 +7,10 @@ belongs in its own module.
 
 import hmac
 import os
-import secrets
 import socket
 import ssl
 import stat
 import sys
-import tempfile
 
 from pathlib import Path
 from typing  import Any, Dict, List, Optional, Tuple
@@ -27,21 +25,22 @@ from typing  import Any, Dict, List, Optional, Tuple
 #                          clients verify against it)
 #    RADICAL_ORBIT_BROKER_KEY  — TLS key path (broker only)
 #
-#  Fallback files (placed by the operator; never auto-written from env):
-#    ~/.radical/orbit/broker.url
+#  Fallback files (placed by the operator — the ``~/.radical/orbit`` config
+#  is read-only for the software; nothing below is ever auto-written):
 #    ~/.radical/orbit/broker_cert.pem
 #    ~/.radical/orbit/broker_key.pem
+#    ~/.radical/orbit/broker.token
 #
-#  Precedence (consumer side): CLI arg > env var > file > error.
+#  Precedence (cert / key / token): CLI arg > env var > file > error.
+#  The URL has *no* file fallback — it always comes explicitly, via API /
+#  CLI arg or $RADICAL_ORBIT_BROKER_URL (a stale on-disk URL was a recurring
+#  source of confusion; certs and tokens are stable material, URLs are not).
 #
 #  The broker process itself does NOT consume a URL — it derives its
-#  advertised URL from its own (host, port).  ``broker.url`` is a write-
-#  side artefact only: broker writes; endpoints / clients read.
-#  Cert / key files are never written by code — operator places them.
+#  advertised URL from its own (host, port).
 # ─────────────────────────────────────────────────────────────────────────────
 
 DEFAULT_DIR  = Path.home() / '.radical' / 'orbit'
-URL_FILE     = DEFAULT_DIR / 'broker.url'
 CERT_FILE    = DEFAULT_DIR / 'broker_cert.pem'
 KEY_FILE     = DEFAULT_DIR / 'broker_key.pem'
 TOKEN_FILE   = DEFAULT_DIR / 'broker.token'
@@ -50,7 +49,6 @@ ENV_URL      = 'RADICAL_ORBIT_BROKER_URL'
 ENV_CERT     = 'RADICAL_ORBIT_BROKER_CERT'
 ENV_KEY      = 'RADICAL_ORBIT_BROKER_KEY'
 ENV_TOKEN    = 'RADICAL_ORBIT_BROKER_TOKEN'
-ENV_NO_AUTH  = 'RADICAL_ORBIT_BROKER_NO_AUTH'
 
 
 def _env(name: str) -> str:
@@ -62,44 +60,6 @@ def _env(name: str) -> str:
 # token never lives in a query string, only this HttpOnly cookie or a
 # request header.
 AUTH_COOKIE  = 'orbit_broker_token'
-
-
-def _read_url_file(path: Optional[Path] = None) -> Optional[str]:
-    """Read a URL file, stripped of surrounding whitespace/newlines.
-
-    Resolves ``path`` from the module-level ``URL_FILE`` at call time
-    (not at def time) so tests that monkeypatch ``URL_FILE`` see the
-    redirected location.
-    """
-    if path is None:
-        path = URL_FILE
-    try:
-        text = path.read_text().strip()
-    except FileNotFoundError:
-        return None
-    return text or None
-
-
-def write_broker_url_file(url: str, path: Optional[Path] = None) -> None:
-    """Write *url* to *path* atomically (tmp + os.replace).
-
-    Creates parent directories as needed.  Mode 0644.  This is the only
-    auto-write of any of the three broker config files; cert and key are
-    always operator-placed.
-    """
-    if path is None:
-        path = URL_FILE
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(prefix='.broker.url.', dir=str(path.parent))
-    try:
-        with os.fdopen(fd, 'w') as f:
-            f.write(url.rstrip() + '\n')
-        os.chmod(tmp, 0o644)
-        os.replace(tmp, path)
-    except Exception:
-        try:    os.unlink(tmp)
-        except FileNotFoundError: pass
-        raise
 
 
 def _outbound_ipv4() -> Optional[str]:
@@ -164,11 +124,12 @@ def public_url_forms(host: str, port: int, *,
 def resolve_broker_url(cli: Optional[str] = None) -> Tuple[str, str]:
     """Resolve the broker URL for a *consumer* (endpoint / client).
 
-    Precedence: CLI arg > ``$RADICAL_ORBIT_BROKER_URL`` > ``~/.radical/orbit/broker.url``.
+    Precedence: CLI arg > ``$RADICAL_ORBIT_BROKER_URL``.  There is
+    deliberately no file fallback — a URL is volatile (hosts and ports
+    change) and always passed explicitly.
 
-    Returns ``(url, source)`` with source one of
-    ``'cli'`` / ``'env'`` / ``'file'``.  Raises ``ValueError`` if no
-    source resolves.
+    Returns ``(url, source)`` with source one of ``'cli'`` / ``'env'``.
+    Raises ``ValueError`` if no source resolves.
 
     The broker process itself does *not* call this — it derives its
     advertised URL from its own ``(host, port)``.
@@ -178,11 +139,7 @@ def resolve_broker_url(cli: Optional[str] = None) -> Tuple[str, str]:
     env_url = _env(ENV_URL)
     if env_url:
         return env_url.rstrip('/'), 'env'
-    file_url = _read_url_file()
-    if file_url:
-        return file_url.rstrip('/'), 'file'
-    raise ValueError(f"Broker URL required (no CLI arg, ${ENV_URL} unset, "
-                     f"no file at {URL_FILE})")
+    raise ValueError(f"Broker URL required (no CLI arg, ${ENV_URL} unset)")
 
 
 def _resolve_path_value(cli: Optional[str], env_var: str,
@@ -200,6 +157,18 @@ def _resolve_path_value(cli: Optional[str], env_var: str,
     if file_path.exists():
         return file_path, 'file'
     return None, ''
+
+
+TLS_RECIPE = '''\
+To create a self-signed cert/key pair at the default location:
+
+  mkdir -p ~/.radical/orbit
+  openssl req -x509 -newkey rsa:4096 -nodes \\
+      -keyout ~/.radical/orbit/broker_key.pem \\
+      -out    ~/.radical/orbit/broker_cert.pem \\
+      -days 365 -subj "/CN=$(hostname -f)"
+  chmod 600 ~/.radical/orbit/broker_key.pem
+'''
 
 
 def resolve_broker_cert(cli: Optional[str] = None) -> Tuple[Path, str]:
@@ -274,22 +243,31 @@ def resolve_broker_key(cli: Optional[str] = None, *,
 #  model as the cert): clients/endpoints present it, the broker verifies it.
 #
 #    Env var:  RADICAL_ORBIT_BROKER_TOKEN
-#    File:     ~/.radical/orbit/broker.token   (mode 0600)
-#    Disable:  RADICAL_ORBIT_BROKER_NO_AUTH=1  (escape hatch for local dev)
+#    File:     ~/.radical/orbit/broker.token   (mode 0600, operator-placed)
 #
-#  Consumer precedence (endpoint / client): CLI > env > file.  A missing token
-#  is *not* an error on the consumer side — the broker may run with auth off.
-#  The broker itself uses ``ensure_broker_token``, which generates and writes a
-#  token when none is configured.
+#  Precedence (both sides): CLI > env > file.  A missing token is *not* an
+#  error on the consumer side — the broker may run with auth off.  The broker
+#  *requires* a token when auth is enabled (``auth=False`` / ``--no-auth`` is
+#  the explicit local-dev escape hatch); nothing is ever generated or written
+#  by code — ``TOKEN_RECIPE`` below is the one-time operator step.
 # ─────────────────────────────────────────────────────────────────────────────
+
+TOKEN_RECIPE = '''\
+To create a shared ingress token at the default location:
+
+  mkdir -p ~/.radical/orbit
+  python3 -c "import secrets; print(secrets.token_urlsafe(32))" \\
+      > ~/.radical/orbit/broker.token
+  chmod 600 ~/.radical/orbit/broker.token
+'''
+
 
 def _read_token_file(path: Optional[Path] = None) -> Optional[str]:
     """Read the token file, stripped.  ``None`` if absent/empty.
 
-    Only ``FileNotFoundError`` is swallowed (consistent with ``_read_url_file``):
-    a present-but-unreadable file (e.g. ``PermissionError``) is a real
-    misconfiguration that should surface loudly rather than be masked as
-    "no token" — which would otherwise trigger a regenerate-then-crash-on-write.
+    Only ``FileNotFoundError`` is swallowed: a present-but-unreadable file
+    (e.g. ``PermissionError``) is a real misconfiguration that should
+    surface loudly rather than be masked as "no token".
     """
     if path is None:
         path = TOKEN_FILE
@@ -298,23 +276,6 @@ def _read_token_file(path: Optional[Path] = None) -> Optional[str]:
     except FileNotFoundError:
         return None
     return text or None
-
-
-def write_broker_token_file(token: str, path: Optional[Path] = None) -> None:
-    """Write *token* to *path* atomically, mode 0600 (private — like the key)."""
-    if path is None:
-        path = TOKEN_FILE
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(prefix='.broker.token.', dir=str(path.parent))
-    try:
-        with os.fdopen(fd, 'w') as f:
-            f.write(token.rstrip() + '\n')
-        os.chmod(tmp, 0o600)
-        os.replace(tmp, path)
-    except Exception:
-        try:    os.unlink(tmp)
-        except FileNotFoundError: pass
-        raise
 
 
 def resolve_broker_token(cli: Optional[str] = None) -> Tuple[Optional[str], str]:
@@ -334,33 +295,6 @@ def resolve_broker_token(cli: Optional[str] = None) -> Tuple[Optional[str], str]
     if file_tok:
         return file_tok, 'file'
     return None, ''
-
-
-def auth_disabled(cli_no_auth: bool = False) -> bool:
-    """Whether broker ingress auth is disabled (the ``--no-auth`` escape hatch).
-
-    True when *cli_no_auth* is set or ``$RADICAL_ORBIT_BROKER_NO_AUTH`` is a
-    truthy value (``1`` / ``true`` / ``yes``).
-    """
-    if cli_no_auth:
-        return True
-    return _env(ENV_NO_AUTH).lower() in ('1', 'true', 'yes')
-
-
-def ensure_broker_token(cli: Optional[str] = None) -> Tuple[str, str]:
-    """Resolve the broker token for the *broker* itself, generating if absent.
-
-    Precedence: CLI > env > file; if none resolves, generate a fresh
-    URL-safe token, write it to ``~/.radical/orbit/broker.token`` (mode 0600),
-    and return it.  Returns ``(token, source)`` with source one of
-    ``'cli'`` / ``'env'`` / ``'file'`` / ``'generated'``.
-    """
-    token, source = resolve_broker_token(cli)
-    if token:
-        return token, source
-    token = secrets.token_urlsafe(32)
-    write_broker_token_file(token)
-    return token, 'generated'
 
 
 def tokens_match(provided: Any, expected: Any) -> bool:

--- a/tests/unittests/test_broker.py
+++ b/tests/unittests/test_broker.py
@@ -63,7 +63,6 @@ def make_broker(self_signed, tmp_path, monkeypatch):
     they own the loop; TestClient tests let the app lifespan do it.
     """
     from radical.orbit import utils
-    monkeypatch.setattr(utils, 'URL_FILE',   tmp_path / 'broker.url')
     monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'broker.token')
 
     cert, key = self_signed
@@ -78,7 +77,7 @@ def make_broker(self_signed, tmp_path, monkeypatch):
         for _k in list(kwargs):
             if _k in _TUNING_KEYS:
                 setattr(tuning, _k, kwargs.pop(_k))
-        defaults = dict(cert=str(cert), key=str(key), no_auth=True, tuning=tuning)
+        defaults = dict(cert=str(cert), key=str(key), auth=False, tuning=tuning)
         defaults.update(kwargs)
         return Broker(**defaults)
 
@@ -166,7 +165,7 @@ def test_first_frame_not_register_is_rejected(make_broker):
 
 @pytest.mark.asyncio
 async def test_token_gate_rejects_bad_and_missing(make_broker):
-    broker = make_broker(no_auth=False, token='sekret')
+    broker = make_broker(auth=True, token='sekret')
     await broker.startup()
     try:
         ws_bad = FakeWS()
@@ -188,7 +187,7 @@ async def test_token_gate_rejects_bad_and_missing(make_broker):
 
 @pytest.mark.asyncio
 async def test_auth_disabled_accepts_no_credential(make_broker):
-    broker = make_broker(no_auth=True)
+    broker = make_broker(auth=False)
     await broker.startup()
     try:
         ws = FakeWS()
@@ -818,7 +817,7 @@ async def test_gateway_seam_surface(make_broker):
         snap = broker.topology_snapshot()
         assert 'e1' in snap and 'broker' in snap
         assert snap['e1']['liveness'] == 'present'
-        assert broker.auth_enabled is False              # no_auth=True
+        assert broker.auth_enabled is False              # auth=False
     finally:
         await broker.shutdown()
 
@@ -982,17 +981,15 @@ def test_broker_startup_banner_token_file():
     assert 'scp host.example.org:' in text
 
 
-def test_broker_startup_banner_generated_vs_loaded():
-    from radical.orbit        import utils
-    from radical.orbit.broker import Broker
-    forms = ['https://h:8000']
-    gen   = Broker._startup_banner(forms, str(utils.CERT_FILE),
-                                   'generated', True)
-    lod   = Broker._startup_banner(forms, str(utils.CERT_FILE),
-                                   'file', True)
-    assert 'creating' in gen and 'creating' not in lod
-    # both bootstrap blocks are identical — the token is on disk either way
-    assert gen.split('\n\n', 1)[1] == lod.split('\n\n', 1)[1]
+def test_broker_ctor_requires_token_when_auth_on(make_broker, monkeypatch):
+    # Auth on + no token anywhere → refuse to start with the recipe in the
+    # message; nothing is ever generated or written (read-only config dir).
+    from radical.orbit import utils
+    monkeypatch.delenv(utils.ENV_TOKEN, raising=False)
+    with pytest.raises(ValueError, match='ingress auth token required') as ei:
+        make_broker(auth=True)
+    assert 'token_urlsafe' in str(ei.value)          # carries TOKEN_RECIPE
+    assert not utils.TOKEN_FILE.exists()             # no write-on-start
 
 
 def test_broker_startup_banner_no_auth():

--- a/tests/unittests/test_embedded.py
+++ b/tests/unittests/test_embedded.py
@@ -1,0 +1,235 @@
+# pylint: disable=protected-access
+"""Unit tests for the embedded broker (``radical.orbit.embedded``) and the
+``EndpointRuntime(embedded=True)`` wiring.
+
+The embedded broker is a regular broker: operator-placed cert/key/token
+(redirected into ``tmp_path`` here), auth on, nothing ever written under
+the config dir.  The end-to-end test drives a real uvicorn server on a
+daemon thread and registers the hosting runtime against it — the same
+pattern as ``test_runtime.py``'s ``_RunningBroker`` harness, but through
+the production code path.
+"""
+
+import os
+import socket
+import subprocess
+import threading
+
+import pytest
+
+from radical.orbit import utils
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _have_openssl() -> bool:
+    try:
+        subprocess.run(['openssl', 'version'], check=True, capture_output=True)
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+@pytest.fixture
+def self_signed(tmp_path):
+    """Throw-away self-signed cert+key in *tmp_path* (skip w/o openssl)."""
+    if not _have_openssl():
+        pytest.skip("openssl not available")
+    cert = tmp_path / 'cert.pem'
+    key  = tmp_path / 'key.pem'
+    subprocess.run(
+        ['openssl', 'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+         '-keyout', str(key), '-out', str(cert),
+         '-days', '1', '-subj', '/CN=localhost'],
+        check=True, capture_output=True,
+    )
+    os.chmod(key, 0o600)
+    return cert, key
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch, self_signed):
+    """Operator-placed cert/key/token in a tmp config dir; env cleared.
+
+    Yields the tmp config dir.  Mirrors the read-only-config contract:
+    the files exist before any broker starts, and tests assert nothing
+    new appears.
+    """
+    cert, key = self_signed
+    cfg = tmp_path / 'orbit'
+    cfg.mkdir()
+    (cfg / 'broker_cert.pem').write_bytes(cert.read_bytes())
+    (cfg / 'broker_key.pem').write_bytes(key.read_bytes())
+    os.chmod(cfg / 'broker_key.pem', 0o600)
+    (cfg / 'broker.token').write_text('sekret-token\n')
+    os.chmod(cfg / 'broker.token', 0o600)
+
+    monkeypatch.setattr(utils, 'DEFAULT_DIR', cfg)
+    monkeypatch.setattr(utils, 'CERT_FILE',  cfg / 'broker_cert.pem')
+    monkeypatch.setattr(utils, 'KEY_FILE',   cfg / 'broker_key.pem')
+    monkeypatch.setattr(utils, 'TOKEN_FILE', cfg / 'broker.token')
+    for var in (utils.ENV_URL, utils.ENV_CERT, utils.ENV_KEY, utils.ENV_TOKEN):
+        monkeypatch.delenv(var, raising=False)
+    return cfg
+
+
+@pytest.fixture
+def local_embedded(monkeypatch):
+    """Redirect the runtime's EmbeddedBroker to loopback + ephemeral port.
+
+    Keeps the end-to-end tests hermetic (no fqdn DNS, no port-8000
+    contention); the production default (0.0.0.0:8000) is covered by the
+    port-selection unit tests.
+    """
+    import radical.orbit.embedded as emb
+
+    class _LocalEB(emb.EmbeddedBroker):
+        def __init__(self, **kw):
+            kw.setdefault('host', '127.0.0.1')
+            kw.setdefault('port', 0)
+            super().__init__(**kw)
+
+    monkeypatch.setattr(emb, 'EmbeddedBroker', _LocalEB)
+    return _LocalEB
+
+
+def _embedded_threads():
+    return [t for t in threading.enumerate()
+            if t.name == 'orbit-embedded-broker' and t.is_alive()]
+
+
+# ---------------------------------------------------------------------------
+# EmbeddedBroker
+# ---------------------------------------------------------------------------
+
+def test_embedded_start_stop(isolated):
+    from radical.orbit.embedded import EmbeddedBroker
+    eb  = EmbeddedBroker(host='127.0.0.1', port=0)
+    url = eb.start()
+    try:
+        assert url == eb.url
+        assert url.startswith('https://127.0.0.1:')
+        assert not url.endswith(':0')                 # real bound port
+        assert eb._server.started
+        assert _embedded_threads()
+    finally:
+        eb.stop()
+    assert not _embedded_threads()
+    eb.stop()                                         # idempotent no-op
+
+
+def test_embedded_default_port_fallback(isolated, monkeypatch, caplog):
+    from radical.orbit.embedded import EmbeddedBroker
+
+    # Occupy a port of our own choosing and make it the "default".
+    blocker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    blocker.bind(('127.0.0.1', 0))
+    blocker.listen(1)
+    taken = blocker.getsockname()[1]
+    monkeypatch.setattr(EmbeddedBroker, '_DEFAULT_PORT', taken)
+
+    try:
+        eb = EmbeddedBroker(host='127.0.0.1')          # port=None → fallback
+        with caplog.at_level('WARNING', logger='radical.orbit.embedded'):
+            url = eb.start()
+        try:
+            assert not url.endswith(f':{taken}')       # landed elsewhere
+            assert 'in use' in caplog.text
+        finally:
+            eb.stop()
+
+        # An *explicit* busy port must fail, not fall back.
+        with pytest.raises(OSError):
+            EmbeddedBroker(host='127.0.0.1', port=taken).start()
+    finally:
+        blocker.close()
+
+
+def test_embedded_missing_token_fails_closed(isolated, monkeypatch):
+    from radical.orbit.embedded import EmbeddedBroker
+    (isolated / 'broker.token').unlink()
+
+    eb = EmbeddedBroker(host='127.0.0.1', port=0)
+    with pytest.raises(ValueError, match='ingress auth token required') as ei:
+        eb.start()
+    assert 'token_urlsafe' in str(ei.value)            # carries TOKEN_RECIPE
+    assert not _embedded_threads()                     # nothing leaked
+    assert not (isolated / 'broker.token').exists()    # nothing written
+
+
+def test_embedded_missing_cert_fails_closed(isolated):
+    from radical.orbit.embedded import EmbeddedBroker
+    (isolated / 'broker_cert.pem').unlink()
+
+    eb = EmbeddedBroker(host='127.0.0.1', port=0)
+    with pytest.raises(ValueError, match='TLS cert required'):
+        eb.start()
+    assert not _embedded_threads()
+
+
+# ---------------------------------------------------------------------------
+# EndpointRuntime(embedded=True)
+# ---------------------------------------------------------------------------
+
+def test_runtime_embedded_end_to_end(isolated, local_embedded):
+    from radical.orbit.runtime import EndpointRuntime
+
+    before = sorted(os.listdir(isolated))
+    rt = EndpointRuntime(embedded=True, name='embed-e2e')
+    try:
+        assert rt.broker_url.startswith('https://127.0.0.1:')
+        assert rt.embedded_broker is not None
+        assert rt._app.state.broker_url == rt.broker_url
+
+        rt.start(wait=True, timeout=15.0)
+        assert rt.wait_registered(timeout=15.0)
+        assert 'embed-e2e' in rt.topology()            # self-registered
+    finally:
+        rt.stop()
+
+    assert not _embedded_threads()                     # broker torn down
+    assert sorted(os.listdir(isolated)) == before      # config dir untouched
+
+
+def test_runtime_embedded_excludes_broker_url(isolated, local_embedded):
+    from radical.orbit.runtime import EndpointRuntime
+    with pytest.raises(ValueError, match='mutually exclusive'):
+        EndpointRuntime(broker_url='wss://x:1', embedded=True)
+    assert not _embedded_threads()
+
+
+def test_runtime_embedded_ignores_env_url(isolated, local_embedded,
+                                          monkeypatch):
+    from radical.orbit.runtime import EndpointRuntime
+    monkeypatch.setenv(utils.ENV_URL, 'https://ambient-env-host:9999')
+    rt = EndpointRuntime(embedded=True)
+    try:
+        assert 'ambient-env-host' not in rt.broker_url
+    finally:
+        rt.stop()
+    assert not _embedded_threads()
+
+
+def test_runtime_embedded_init_failure_stops_broker(isolated, local_embedded,
+                                                    monkeypatch):
+    # A failure in the init tail *after* the embed must stop the embedded
+    # server before the ctor exception propagates.  The first cert
+    # resolution happens inside the Broker ctor; fail the second (the
+    # runtime's own).
+    from radical.orbit.runtime import EndpointRuntime
+
+    real  = utils.resolve_broker_cert
+    calls = {'n': 0}
+
+    def _flaky(cli=None):
+        calls['n'] += 1
+        if calls['n'] >= 2:
+            raise ValueError('injected post-embed failure')
+        return real(cli=cli)
+
+    monkeypatch.setattr(utils, 'resolve_broker_cert', _flaky)
+    with pytest.raises(ValueError, match='injected post-embed failure'):
+        EndpointRuntime(embedded=True)
+    assert not _embedded_threads()

--- a/tests/unittests/test_embedded.py
+++ b/tests/unittests/test_embedded.py
@@ -159,6 +159,42 @@ def test_embedded_missing_token_fails_closed(isolated, monkeypatch):
     assert not (isolated / 'broker.token').exists()    # nothing written
 
 
+def test_embedded_server_setup_failure_closes_socket(isolated, monkeypatch):
+    # A failure *after* the Broker ctor (uvicorn Config/Server/thread setup)
+    # must also release the pre-bound socket, not just Broker-ctor failures.
+    import uvicorn
+    from radical.orbit.embedded import EmbeddedBroker
+
+    def _boom(*a, **kw):
+        raise RuntimeError('injected uvicorn setup failure')
+
+    monkeypatch.setattr(uvicorn, 'Config', _boom)
+    eb = EmbeddedBroker(host='127.0.0.1', port=0)
+    with pytest.raises(RuntimeError, match='injected uvicorn setup failure'):
+        eb.start()
+    assert eb._sock is None                            # socket released
+    assert not _embedded_threads()
+
+
+def test_embedded_binds_ipv6_literal(isolated):
+    from radical.orbit.embedded import EmbeddedBroker
+    probe = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    try:
+        probe.bind(('::1', 0))
+    except OSError:
+        pytest.skip("no IPv6 loopback available")
+    finally:
+        probe.close()
+
+    eb = EmbeddedBroker(host='::1', port=0)
+    sock = eb._bind()                                  # AF_INET6, no OSError
+    try:
+        assert sock.family == socket.AF_INET6
+        assert sock.getsockname()[1] > 0
+    finally:
+        sock.close()
+
+
 def test_embedded_missing_cert_fails_closed(isolated):
     from radical.orbit.embedded import EmbeddedBroker
     (isolated / 'broker_cert.pem').unlink()

--- a/tests/unittests/test_flip.py
+++ b/tests/unittests/test_flip.py
@@ -61,7 +61,7 @@ def test_broker_entrypoint_constructs_broker(monkeypatch, tmp_path):
                          '--port', '9123', '--plugins', 'sysinfo'])
     mod.main()
 
-    assert captured['no_auth'] is True
+    assert captured['auth']    is False          # --no-auth -> auth=False
     assert captured['gateway'] is False          # --no-gateway -> gateway=False
     assert captured['port']    == 9123
     assert captured['plugins'] == 'sysinfo'
@@ -119,7 +119,6 @@ def broker_client(tmp_path, monkeypatch):
     from radical.orbit import utils
     from radical.orbit.broker import Broker, BrokerTuning
 
-    monkeypatch.setattr(utils, 'URL_FILE',   tmp_path / 'broker.url')
     monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'broker.token')
 
     cert = tmp_path / 'cert.pem'
@@ -130,7 +129,7 @@ def broker_client(tmp_path, monkeypatch):
          '-days', '1', '-subj', '/CN=localhost'],
         check=True, capture_output=True)
 
-    broker = Broker(cert=str(cert), key=str(key), no_auth=True,
+    broker = Broker(cert=str(cert), key=str(key), auth=False,
                     tuning=BrokerTuning(grace=0.05, ping_timeout=0.05))
     return broker
 
@@ -177,7 +176,6 @@ async def test_gateway_auth_dispatch_normalizes_traversal(tmp_path, monkeypatch)
     from radical.orbit import utils
     from radical.orbit.broker import Broker
 
-    monkeypatch.setattr(utils, 'URL_FILE',   tmp_path / 'broker.url')
     monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'broker.token')
     cert = tmp_path / 'cert.pem'
     key  = tmp_path / 'key.pem'
@@ -187,7 +185,7 @@ async def test_gateway_auth_dispatch_normalizes_traversal(tmp_path, monkeypatch)
          '-days', '1', '-subj', '/CN=localhost'],
         check=True, capture_output=True)
 
-    broker = Broker(cert=str(cert), key=str(key), token='s3cret', no_auth=False)
+    broker = Broker(cert=str(cert), key=str(key), token='s3cret', auth=True)
     gateway = broker._gateway
 
     async def _passed(_req):

--- a/tests/unittests/test_gateway.py
+++ b/tests/unittests/test_gateway.py
@@ -131,7 +131,6 @@ class _RunningBroker:
 def harness(self_signed, tmp_path, monkeypatch):
     """Factory yielding (make_broker, make_runtime); tears everything down."""
     from radical.orbit import utils
-    monkeypatch.setattr(utils, 'URL_FILE',   tmp_path / 'broker.url')
     monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'broker.token')
     monkeypatch.delenv('RADICAL_ORBIT_BROKER_TOKEN', raising=False)
     monkeypatch.delenv('RADICAL_ORBIT_BROKER_URL',   raising=False)
@@ -146,7 +145,7 @@ def harness(self_signed, tmp_path, monkeypatch):
         for _k in list(kw):
             if hasattr(tuning, _k):
                 setattr(tuning, _k, kw.pop(_k))
-        defaults = dict(cert=str(cert), key=str(key), no_auth=True, tuning=tuning)
+        defaults = dict(cert=str(cert), key=str(key), auth=False, tuning=tuning)
         defaults.update(kw)
         broker = Broker(**defaults)
         srv = _RunningBroker(broker).start()
@@ -232,7 +231,7 @@ class _SSEReader:
 
 def test_auth_gate_401_without_token_and_cookie_flow(harness):
     make_broker, _ = harness
-    srv = make_broker(no_auth=False, token='sekret')
+    srv = make_broker(auth=True, token='sekret')
 
     # No token -> 401 on a capability route.
     r = httpx.post(srv.url + '/endpoint/list')
@@ -258,7 +257,7 @@ def test_auth_gate_401_without_token_and_cookie_flow(harness):
 
 def test_auth_exempt_paths(harness):
     make_broker, _ = harness
-    srv = make_broker(no_auth=False, token='sekret')
+    srv = make_broker(auth=True, token='sekret')
 
     # UI shell + static plugin JS load without a token (Explorer must prompt).
     assert httpx.get(srv.url + '/').status_code in (200, 404)  # served or absent
@@ -269,7 +268,7 @@ def test_auth_exempt_paths(harness):
 
 def test_auth_disabled_passthrough(harness):
     make_broker, _ = harness
-    srv = make_broker(no_auth=True)
+    srv = make_broker(auth=False)
     r = httpx.post(srv.url + '/endpoint/list')
     assert r.status_code == 200
 

--- a/tests/unittests/test_plugin_math.py
+++ b/tests/unittests/test_plugin_math.py
@@ -1,0 +1,128 @@
+
+# pylint: disable=protected-access,unused-variable
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from radical.orbit.plugin_math import PluginMath, MathSession
+
+
+def _mk():
+    app    = FastAPI()
+    plugin = PluginMath(app)
+    return app, plugin, TestClient(app)
+
+
+# ── plugin construction ─────────────────────────────────────────────────────
+
+def test_plugin_math_init():
+    """Test plugin initialization and route registration."""
+    app, plugin, _ = _mk()
+
+    assert plugin.instance_name == 'math'
+    assert plugin.namespace     == '/math'
+
+    route_pats = [p.pattern for _, p, _, _ in app.state.direct_routes]
+    for op in ('add', 'sub', 'mul', 'div', 'history'):
+        assert any(f'math/{op}/' in p for p in route_pats), op
+
+
+# ── session behaviour (no HTTP involved) ────────────────────────────────────
+
+def test_math_session_compute_and_history():
+    """Compute records every operation in the session history."""
+    session = MathSession('sid.test')
+
+    r = asyncio.run(session.compute('add', 3.0, 4.0))
+    assert r['result'] == 7.0
+
+    r = asyncio.run(session.compute('div', 1.0, 4.0))
+    assert r['result'] == 0.25
+
+    h = asyncio.run(session.history())
+    assert h['count'] == 2
+    assert h['ops'][0]['op'] == 'add'
+    assert h['ops'][1]['op'] == 'div'
+
+
+def test_math_session_notifies():
+    """Every compute emits a 'result' notification via the parent plugin."""
+    session = MathSession('sid.test')
+    sent    = []
+
+    class _FakePlugin:
+        def _dispatch_notify(self, topic, data):
+            sent.append((topic, data))
+
+    session._plugin = _FakePlugin()
+    asyncio.run(session.compute('mul', 6.0, 7.0))
+
+    assert sent == [('result', {'op': 'mul', 'a': 6.0, 'b': 7.0,
+                                'result': 42.0, 'count': 1})]
+
+
+def test_math_session_unknown_op_raises():
+    session = MathSession('sid.test')
+    with pytest.raises(ValueError):
+        asyncio.run(session.compute('pow', 2.0, 3.0))
+
+
+def test_math_session_closed_raises():
+    session = MathSession('sid.test')
+    asyncio.run(session.close())
+    with pytest.raises(RuntimeError):
+        asyncio.run(session.compute('add', 1.0, 2.0))
+
+
+# ── HTTP round trips (TestClient over the ASGI routes) ──────────────────────
+
+def test_math_http_roundtrip():
+    """Register a session, compute, read history, unregister."""
+    _, plugin, client = _mk()
+
+    resp = client.post('/math/register_session')
+    assert resp.status_code == 200
+    sid = resp.json()['sid']
+
+    resp = client.post(f'/math/add/{sid}', json={'a': 3, 'b': 4})
+    assert resp.status_code == 200
+    assert resp.json()['result'] == 7.0
+
+    resp = client.post(f'/math/div/{sid}', json={'a': 1, 'b': 4})
+    assert resp.status_code == 200
+    assert resp.json()['result'] == 0.25
+
+    resp = client.get(f'/math/history/{sid}')
+    assert resp.status_code == 200
+    assert resp.json()['count'] == 2
+
+    resp = client.post(f'/math/unregister_session/{sid}')
+    assert resp.status_code == 200
+
+
+def test_math_http_div_by_zero_is_400():
+    _, plugin, client = _mk()
+    sid  = client.post('/math/register_session').json()['sid']
+
+    resp = client.post(f'/math/div/{sid}', json={'a': 1, 'b': 0})
+    assert resp.status_code == 400
+    assert 'division by zero' in resp.json()['detail']
+
+
+def test_math_http_bad_body_is_400():
+    _, plugin, client = _mk()
+    sid  = client.post('/math/register_session').json()['sid']
+
+    for body in ({}, {'a': 1}, {'a': 'x', 'b': 2}, {'a': None, 'b': 2}):
+        resp = client.post(f'/math/add/{sid}', json=body)
+        assert resp.status_code == 400, body
+
+
+def test_math_http_unknown_session_is_404():
+    _, plugin, client = _mk()
+
+    resp = client.post('/math/add/no-such-sid', json={'a': 1, 'b': 2})
+    assert resp.status_code == 404

--- a/tests/unittests/test_plugin_replay.py
+++ b/tests/unittests/test_plugin_replay.py
@@ -458,7 +458,6 @@ def harness(tmp_path, monkeypatch):
         pytest.skip("openssl not available")
     import os
     from radical.orbit import utils
-    monkeypatch.setattr(utils, 'URL_FILE',   tmp_path / 'broker.url')
     monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'broker.token')
     monkeypatch.delenv('RADICAL_ORBIT_BROKER_TOKEN', raising=False)
     cert = tmp_path / 'cert.pem'
@@ -478,7 +477,7 @@ def harness(tmp_path, monkeypatch):
         for _k in list(kw):
             if hasattr(tuning, _k):
                 setattr(tuning, _k, kw.pop(_k))
-        defaults = dict(cert=str(cert), key=str(key), no_auth=True, tuning=tuning)
+        defaults = dict(cert=str(cert), key=str(key), auth=False, tuning=tuning)
         defaults.update(kw)
         srv = _RunningBroker(Broker(**defaults)).start()
         servers.append(srv)

--- a/tests/unittests/test_resolve_broker.py
+++ b/tests/unittests/test_resolve_broker.py
@@ -28,7 +28,6 @@ def isolated_dir(tmp_path, monkeypatch):
     Yields the tmp directory so tests can drop files into it directly.
     """
     monkeypatch.setattr(utils, 'DEFAULT_DIR', tmp_path)
-    monkeypatch.setattr(utils, 'URL_FILE',  tmp_path / 'broker.url')
     monkeypatch.setattr(utils, 'CERT_FILE', tmp_path / 'broker_cert.pem')
     monkeypatch.setattr(utils, 'KEY_FILE',  tmp_path / 'broker_key.pem')
     for v in (utils.ENV_URL, utils.ENV_CERT, utils.ENV_KEY):
@@ -70,30 +69,27 @@ def _have_openssl() -> bool:
 # URL resolution
 # ---------------------------------------------------------------------------
 
-def test_url_cli_wins_over_env_and_file(isolated_dir, monkeypatch):
-    """CLI > env > file when all three are set."""
+def test_url_cli_wins_over_env(isolated_dir, monkeypatch):
+    """CLI > env when both are set."""
     monkeypatch.setenv(utils.ENV_URL, 'https://from-env:8000')
-    (isolated_dir / 'broker.url').write_text('https://from-file:8000\n')
     url, src = utils.resolve_broker_url(cli='https://from-cli:8000')
     assert url == 'https://from-cli:8000'
     assert src == 'cli'
 
 
-def test_url_env_wins_over_file(isolated_dir, monkeypatch):
-    """Env > file when CLI is absent."""
+def test_url_env_used_when_no_cli(isolated_dir, monkeypatch):
+    """Env is the lowest-precedence successful source (no file leg)."""
     monkeypatch.setenv(utils.ENV_URL, 'https://from-env:8000')
-    (isolated_dir / 'broker.url').write_text('https://from-file:8000\n')
     url, src = utils.resolve_broker_url()
     assert url == 'https://from-env:8000'
     assert src == 'env'
 
 
-def test_url_file_used_when_no_cli_no_env(isolated_dir):
-    """File is the lowest precedence successful source."""
+def test_url_has_no_file_fallback(isolated_dir):
+    """An on-disk broker.url is deliberately ignored — URL is API/env only."""
     (isolated_dir / 'broker.url').write_text('https://from-file:8000\n')
-    url, src = utils.resolve_broker_url()
-    assert url == 'https://from-file:8000'
-    assert src == 'file'
+    with pytest.raises(ValueError, match='Broker URL required'):
+        utils.resolve_broker_url()
 
 
 def test_url_trailing_slash_stripped(isolated_dir, monkeypatch):
@@ -107,26 +103,6 @@ def test_url_errors_when_unconfigured(isolated_dir):
     """Nothing set anywhere → ValueError."""
     with pytest.raises(ValueError, match='Broker URL required'):
         utils.resolve_broker_url()
-
-
-# ---------------------------------------------------------------------------
-# URL file write (atomic)
-# ---------------------------------------------------------------------------
-
-def test_write_broker_url_file_creates_parents(tmp_path):
-    """``write_broker_url_file`` mkdirs parent dirs and writes the file."""
-    target = tmp_path / 'fresh' / 'broker.url'
-    utils.write_broker_url_file('https://here:8000', path=target)
-    assert target.read_text().strip() == 'https://here:8000'
-    assert target.parent.is_dir()
-
-
-def test_write_broker_url_file_overwrites(tmp_path):
-    """Subsequent writes replace the file content (atomic via os.replace)."""
-    target = tmp_path / 'broker.url'
-    utils.write_broker_url_file('https://first:8000', path=target)
-    utils.write_broker_url_file('https://second:8000', path=target)
-    assert target.read_text().strip() == 'https://second:8000'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittests/test_runtime.py
+++ b/tests/unittests/test_runtime.py
@@ -168,7 +168,6 @@ class _RunningBroker:
 def harness(self_signed, tmp_path, monkeypatch):
     """Factory yielding (make_broker, make_runtime); tears everything down."""
     from radical.orbit import utils
-    monkeypatch.setattr(utils, 'URL_FILE',   tmp_path / 'broker.url')
     monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'broker.token')
     monkeypatch.delenv('RADICAL_ORBIT_BROKER_TOKEN', raising=False)
     monkeypatch.delenv('RADICAL_ORBIT_BROKER_URL',   raising=False)
@@ -183,7 +182,7 @@ def harness(self_signed, tmp_path, monkeypatch):
         for _k in list(kw):
             if hasattr(tuning, _k):
                 setattr(tuning, _k, kw.pop(_k))
-        defaults = dict(cert=str(cert), key=str(key), no_auth=True, tuning=tuning)
+        defaults = dict(cert=str(cert), key=str(key), auth=False, tuning=tuning)
         defaults.update(kw)
         broker = Broker(**defaults)
         srv = _RunningBroker(broker, ws_ping_interval, ws_ping_timeout).start()
@@ -791,7 +790,7 @@ def test_runtime_response_headers_case_insensitive():
 
 def test_invalid_credential_is_fatal_and_actionable(harness):
     make_broker, make_runtime = harness
-    srv = make_broker(no_auth=False, token='sekret-token')
+    srv = make_broker(auth=True, token='sekret-token')
 
     # wait=False: the fatal flag + actionable reason are observable
     rt = make_runtime(srv.url, token='wrong-token', wait=False)

--- a/tests/unittests/test_task_dispatcher_broker.py
+++ b/tests/unittests/test_task_dispatcher_broker.py
@@ -130,7 +130,6 @@ class _RunningBroker:
 @pytest.fixture
 def harness(self_signed, tmp_path, monkeypatch):
     from radical.orbit import utils
-    monkeypatch.setattr(utils, 'URL_FILE',   tmp_path / 'broker.url')
     monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'broker.token')
     monkeypatch.delenv('RADICAL_ORBIT_BROKER_TOKEN', raising=False)
     # Keep the dispatcher's durable store off $HOME.
@@ -150,7 +149,7 @@ def harness(self_signed, tmp_path, monkeypatch):
         for _k in list(kw):
             if hasattr(tuning, _k):
                 setattr(tuning, _k, kw.pop(_k))
-        defaults = dict(cert=str(cert), key=str(key), no_auth=True, tuning=tuning)
+        defaults = dict(cert=str(cert), key=str(key), auth=False, tuning=tuning)
         defaults.update(kw)
         srv = _RunningBroker(Broker(**defaults)).start()
         servers.append(srv)

--- a/tests/unittests/test_utils_token.py
+++ b/tests/unittests/test_utils_token.py
@@ -9,8 +9,7 @@ from radical.orbit import utils
 def _isolate_token(tmp_path, monkeypatch):
     """Redirect the token file and clear the env so tests are hermetic."""
     monkeypatch.setattr(utils, 'TOKEN_FILE', tmp_path / 'broker.token')
-    monkeypatch.delenv(utils.ENV_TOKEN,   raising=False)
-    monkeypatch.delenv(utils.ENV_NO_AUTH, raising=False)
+    monkeypatch.delenv(utils.ENV_TOKEN, raising=False)
     return tmp_path
 
 
@@ -18,8 +17,8 @@ def test_resolve_precedence(monkeypatch):
     # nothing configured
     assert utils.resolve_broker_token() == (None, '')
 
-    # file
-    utils.write_broker_token_file('filetok')
+    # file (operator-placed — code never writes it)
+    utils.TOKEN_FILE.write_text('filetok\n')
     assert utils.resolve_broker_token() == ('filetok', 'file')
 
     # env beats file
@@ -28,33 +27,6 @@ def test_resolve_precedence(monkeypatch):
 
     # cli beats env
     assert utils.resolve_broker_token(cli='clitok') == ('clitok', 'cli')
-
-
-def test_write_token_file_is_0600(_isolate_token):
-    utils.write_broker_token_file('x')
-    mode = utils.TOKEN_FILE.stat().st_mode & 0o777
-    assert mode == 0o600
-
-
-def test_ensure_generates_then_reads(_isolate_token):
-    tok, src = utils.ensure_broker_token()
-    assert src == 'generated'
-    assert tok
-    assert utils.TOKEN_FILE.read_text().strip() == tok
-
-    # second call picks the written file up
-    tok2, src2 = utils.ensure_broker_token()
-    assert tok2 == tok
-    assert src2 == 'file'
-
-
-def test_auth_disabled(monkeypatch):
-    assert utils.auth_disabled() is False
-    assert utils.auth_disabled(cli_no_auth=True) is True
-    monkeypatch.setenv(utils.ENV_NO_AUTH, '1')
-    assert utils.auth_disabled() is True
-    monkeypatch.setenv(utils.ENV_NO_AUTH, 'no')
-    assert utils.auth_disabled() is False
 
 
 def test_tokens_match():


### PR DESCRIPTION
## Summary

Two usability changes aimed at the "broker deployment is a no-go for end users" adoption risk, converged in design discussion:

**1. Config surface cleanup** — `~/.radical/orbit` *config* is now strictly operator-managed; the software only reads it (logs and tunnel rendezvous files still write there — runtime state, not config):

- Broker token write-on-start removed: auth is on by default via the new `Broker(auth=True)` ctor flag (replaces `no_auth`), and with auth on the broker refuses to start without an operator-placed token — the error carries the new `utils.TOKEN_RECIPE`. The `$RADICAL_ORBIT_BROKER_NO_AUTH` env escape hatch is gone; disabling auth takes explicit code (`auth=False`) or the explicit `--no-auth` flag.
- The `~/.radical/orbit/broker.url` file leg is dropped: the broker URL resolves from the API/CLI arg or `$RADICAL_ORBIT_BROKER_URL` only. A stale on-disk URL was a recurring source of confusion; certs/tokens are stable material, URLs are not.
- `utils`: `write_broker_url_file` / `write_broker_token_file` / `ensure_broker_token` / `auth_disabled` deleted; `TLS_RECIPE` moved in from the bin, `TOKEN_RECIPE` added.

**2. Embedded broker** — `EndpointRuntime(embedded=True)` hosts the full broker (routing, hosted plugins, gateway) inside the client process; endpoints connect to `rt.broker_url` exactly as to a standalone broker, and `submit_tunneled` children inherit that URL as before:

- New `embedded.py` / `EmbeddedBroker`: pre-binds the listen socket (port 8000, ephemeral fallback with warning; explicit port fails hard), constructs a regular `Broker` with the final port (uvicorn runs the lifespan — which hands the advertised URL to hosted plugins — before it would bind), then serves via `uvicorn.Server.run(sockets=[...])` on a daemon thread. All failure paths clean up socket + thread; `stop()` is idempotent; nothing is ever written under `~/.radical/orbit`.
- `embedded=True` skips URL resolution entirely (ambient env URL ignored — the code is explicit) and is mutually exclusive with `broker_url`. Default `False` keeps today's behavior; no bin changes.
- Advanced control (host/port/auth/plugins): construct `EmbeddedBroker` directly and pass `broker_url=eb.url`.

Related: #105 tracks moving the plugin-scoped env vars to per-plugin options (split out of this change).

## Breaking changes

- Fresh hosts need the two one-time recipes (cert/key + token) before a broker starts; existing deployments with files in place are unaffected.
- External `Broker()` callers: `no_auth=` → `auth=`.
- Hand-created `broker.url` files are no longer consulted (clear error names the env var).

## Testing

- 970 unit tests green (8 new in `test_embedded.py`: start/stop + idempotency, port fallback + explicit-port failure, missing cert/token failing closed with recipes and no leaked thread/socket, end-to-end self-registration, mutual-exclusion and env-ignored contracts, post-embed init failure stopping the server).
- flake8 clean on all touched files.
- Manual smoke in an isolated `$HOME`: fresh config → TLS recipe; cert-but-no-token → token recipe with nothing written; after the recipes a standalone broker serves (Explorer 200); `EndpointRuntime(embedded=True)` self-registers (`topology: ['broker', 'smoke-client']`), Explorer answers 200 through the embedded gateway, clean shutdown with no lingering non-daemon threads, config dir untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)