### PR TITLE
psij: allow loading the plugin on a broker

### DIFF
--- a/src/radical/orbit/plugin_psij.py
+++ b/src/radical/orbit/plugin_psij.py
@@ -681,8 +681,9 @@ class PluginPSIJ(Plugin):
 
     @classmethod
     def is_enabled(cls, app: FastAPI) -> bool:
-        """PsiJ loads on endpoint nodes (login or compute) — not on the broker."""
-        return not getattr(app.state, 'is_broker', False)
+        """PsiJ loads on any host, including a broker embedded on a login
+        node — batch system access matters, not the participant role."""
+        return True
 
     def __init__(self, app: FastAPI, instance_name: str = "psij"):
         super().__init__(app, instance_name)

--- a/tests/unittests/test_plugin_psij.py
+++ b/tests/unittests/test_plugin_psij.py
@@ -31,6 +31,13 @@ def mock_psij():
         yield mock
 
 
+def test_plugin_psij_enabled_on_broker():
+    # psij must load on a broker too (embedded broker on a login node)
+    app = FastAPI()
+    app.state.is_broker = True
+    assert PluginPSIJ.is_enabled(app)
+
+
 def test_plugin_psij_init():
     app = FastAPI()
     plugin = PluginPSIJ(app)


### PR DESCRIPTION
## Intent

An embedded broker running on a login node needs local batch submission via psij. The plugin was hard-gated off brokers by `PluginPSIJ.is_enabled` (`not app.state.is_broker`) — but the relevant capability is batch system access, not the participant role. `BrokerPluginHost` already satisfies everything psij needs (`send_notification`, `app.state.broker_url` for the tunneled child-endpoint flow, batch system detection).

## Changes

- `plugin_psij.py`: `is_enabled` now returns `True` unconditionally; docstring documents that a broker embedded on a login node is a supported home.
- `test_plugin_psij.py`: new `test_plugin_psij_enabled_on_broker` pins the behavior for `is_broker=True`.

Note: the broker **default** plugin set is unchanged — a broker still opts in explicitly (e.g. `--plugins default,psij`). Side effect: `--plugins all` on a broker now also loads psij.

## Verification

- `pytest tests/unittests/`: 968 passed, 3 skipped (pre-existing missing-dependency skips).
- `flake8` on both touched files: no new findings (test-file warnings are pre-existing, verified by before/after comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)